### PR TITLE
fix(skills): include runtime script in setup guidance

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,4 +1,4 @@
-You are an expert in C#, Blazor, and scalable web application development. You write functional, maintainable, performant, and accessible code following .NET and Blazor best practices. You are currently immersed in the latest .NET and Blazor, adopting modern C# features, component-based architecture with clean separation of concerns, and modern Blazor patterns for reactive UI and dependencygit pull injection.
+You are an expert in C#, Blazor, and scalable web application development. You write functional, maintainable, performant, and accessible code following .NET and Blazor best practices. You are currently immersed in the latest .NET and Blazor, adopting modern C# features, component-based architecture with clean separation of concerns, and modern Blazor patterns for reactive UI and dependency injection.
 
 ## Coding Standards
 
@@ -57,9 +57,10 @@ You are an expert in C#, Blazor, and scalable web application development. You w
 
 ## UI Components
 
-- Use `IgniteUI.Blazor.Lite`, `IgniteUI.Blazor.GridLite` for general purpose components and light-weight grid, and `IgniteUI.Blazor` (trial version available publicly as `IgniteUI.Blazor.Trial`) for specialized feature-rich grids and charts.
+- Use `IgniteUI.Blazor.Lite`, `IgniteUI.Blazor.GridLite` for general purpose components and light-weight grid, and `IgniteUI.Blazor` (trial version available publicly as `IgniteUI.Blazor.Trial`) for specialized feature-rich grids and charts. If the project already references full `IgniteUI.Blazor`, do not add `IgniteUI.Blazor.Lite` or `IgniteUI.Blazor.GridLite` unless the user explicitly chooses to switch package strategy.
 - Components use the `Igb` prefix (e.g., `IgbGrid`, `IgbCombo`, `IgbDatePicker`).
 - Every component requires module registration in `Program.cs`: `builder.Services.AddIgniteUIBlazor(typeof(IgbGridModule))`.
 - Add `@using IgniteUI.Blazor.Controls` to `_Imports.razor`.
 - Link a theme stylesheet in the host page (e.g., `_content/IgniteUI.Blazor/themes/light/bootstrap.css`).
-- If the `IgniteUI.Blazor.Lite`, `IgniteUI.Blazor.GridLite` NuGet packages are not present in the project file, add it first.
+- Add the Ignite UI runtime script before the Blazor framework script in the host page: `<script src="_content/IgniteUI.Blazor/app.bundle.js"></script>`.
+- If no Ignite UI package is present, add the package that matches the chosen package strategy.

--- a/skills/igniteui-blazor-components/SKILL.md
+++ b/skills/igniteui-blazor-components/SKILL.md
@@ -12,7 +12,7 @@ user-invocable: true
 - The correct NuGet package installed: `IgniteUI.Blazor.Lite` (NuGet.org, MIT) for general purpose UI components; `IgniteUI.Blazor.GridLite` (NuGet.org, MIT) for the lightweight grid; `IgniteUI.Blazor` (Infragistics private feed, licensed) for the full suite including charts, maps, gauges, and enterprise grids; or `IgniteUI.Blazor.Trial` (NuGet.org) for evaluation of the full suite
 - `builder.Services.AddIgniteUIBlazor(...)` called in `Program.cs`
 - `@using IgniteUI.Blazor.Controls` added to `_Imports.razor`
-- A theme CSS file linked in the host page (see [`references/setup.md`](./references/setup.md))
+- A theme CSS file and `_content/IgniteUI.Blazor/app.bundle.js` runtime script linked in the host page (see [`references/setup.md`](./references/setup.md))
 - The **Ignite UI CLI MCP server** (`igniteui-cli`) is available as a tool provider
 
 > **AGENT INSTRUCTION - MCP Server Setup (REQUIRED)**
@@ -78,7 +78,7 @@ Base your code and explanation exclusively on what you read. If the reference fi
 | `IgniteUI.Blazor` | Infragistics private NuGet feed (`https://packages.infragistics.com/nuget/licensed/`) | Licensed / enterprise users that need the full component suite (grids, charts, maps, gauges, Dock Manager) |
 | `IgniteUI.Blazor.Trial` | NuGet.org | Evaluation users — same full suite as `IgniteUI.Blazor` but with a trial watermark |
 
-`IgniteUI.Blazor.Lite` contains the open-source UI component set, while `IgniteUI.Blazor.GridLite` contains the free `IgbGridLite` data grid package. Both use the `IgniteUI.Blazor.Controls` namespace. Do **not** mix the licensed `IgniteUI.Blazor` package with `IgniteUI.Blazor.Lite` in the same project; they use the same namespaces and duplicate some components.
+`IgniteUI.Blazor.Lite` contains the open-source UI component set, while `IgniteUI.Blazor.GridLite` contains the free `IgbGridLite` data grid package. Both use the `IgniteUI.Blazor.Controls` namespace. Do **not** mix the licensed `IgniteUI.Blazor` package with `IgniteUI.Blazor.Lite` in the same project; they use the same namespaces and duplicate some components. If full `IgniteUI.Blazor` is already referenced, do not add Lite/GridLite unless the user explicitly asks to switch package strategy.
 
 ## Key Blazor-Specific Notes
 

--- a/skills/igniteui-blazor-theming/SKILL.md
+++ b/skills/igniteui-blazor-theming/SKILL.md
@@ -13,7 +13,7 @@ This skill teaches AI agents how to theme Ignite UI for Blazor applications usin
 ## Prerequisites
 
 - A Blazor project using Ignite UI for Blazor components
-- A theme CSS file linked in the host page (see [`references/common-patterns.md`](./references/common-patterns.md))
+- A theme CSS file and `_content/IgniteUI.Blazor/app.bundle.js` runtime script linked in the host page (see [`references/common-patterns.md`](./references/common-patterns.md))
 - The **Ignite UI Theming MCP server** (`igniteui-theming`) available as a tool provider
 
 > **AGENT INSTRUCTION - MCP Server Setup (REQUIRED)**
@@ -182,6 +182,7 @@ Place generated CSS in an app stylesheet loaded after the Ignite UI theme CSS, s
 ```html
 <link href="_content/IgniteUI.Blazor/themes/light/bootstrap.css" rel="stylesheet" />
 <link href="css/app.css" rel="stylesheet" />
+<script src="_content/IgniteUI.Blazor/app.bundle.js"></script>
 ```
 
 Palette and global layout CSS normally go in `:root`. Component theme CSS goes on the generated `igc-*` selector or under a scoped wrapper selector.

--- a/skills/igniteui-blazor-theming/references/common-patterns.md
+++ b/skills/igniteui-blazor-theming/references/common-patterns.md
@@ -46,6 +46,14 @@ Add a single `<link>` tag in your host page:
 <link href="_content/IgniteUI.Blazor/themes/light/material.css" rel="stylesheet" />
 ```
 
+### Additional
+
+Also add the Ignite UI runtime script before the Blazor framework script:
+
+```html
+<script src="_content/IgniteUI.Blazor/app.bundle.js"></script>
+```
+
 ### .NET 9+ Web App - use `Assets` collection
 
 ```razor


### PR DESCRIPTION
Closes #https://github.com/IgniteUI/igniteui-cli/issues/1703

## Description
Updates the Ignite UI Blazor setup guidance to include the required runtime script:

<script src="_content/IgniteUI.Blazor/app.bundle.js"></script>

Previously, the guidance only mentioned the theme CSS, which made the setup incomplete.

## Motivation / Context
This change is needed because Ignite UI Blazor components require the runtime script to function correctly. Without it, users can follow the setup guidance exactly but still end up with an incomplete Blazor configuration.


### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [x] Skills

### Component(s) / Area(s) Affected:
Blazor setup guidance, Ignite UI Blazor configuration skills

## How Has This Been Tested?
 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**: N/A
 - **Hosting model**: Blazor
 - **Browser(s)**: N/A
 - **OS**: N/A

## Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified