### PR TITLE
fix(stories): drop iframe body styles causing expanding docs preview

### DIFF
--- a/stories/Components/Pages/IFramePage.razor
+++ b/stories/Components/Pages/IFramePage.razor
@@ -20,7 +20,7 @@
     <HeadOutlet @rendermode="@InteractiveServer" />
 </head>
 
-<body style="margin: 0; padding: 16px; min-height: calc(100vh - 32px); font-family: var(--ig-font-family); color: var(--ig-surface-500-contrast);" class="ig-typography">
+<body style="font-family: var(--ig-font-family); color: var(--ig-surface-500-contrast);" class="ig-typography">
     <IgniteUI.Blazor.Stories.Components.App @rendermode="@InteractiveServer" />
 
     <div id="blazor-error-ui">


### PR DESCRIPTION
## Description

Remove `margin`, `padding`, and `min-height` styles from the `<body>` element in `IFramePage.razor` to fix the ever-growing preview window height in the Blazing Story Docs page.

## Motivation / Context

Blazing Story v1.0.0-preview.81 resolved unpredictable zoom behavior in preview frames as part of its layout mechanism improvements. With that fix in place, the `min-height: calc(100vh - 32px)` style that had been applied to the `<body>` element of the iframe page became unnecessary and started causing a new problem.

Because the iframe's own height expanded to match the content height, which in turn was set to `100vh` of that iframe, this created a feedback loop that kept stretching the story preview window taller on every render cycle, especially noticeable on the Docs page.

This PR removes the `margin`, `padding`, and `min-height` properties from the `<body>` inline style to align with the layout behavior introduced in Blazing Story v1.0.0-preview.81, and allows the preview to size itself naturally based on its actual content.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [x] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:

Blazing Story / Stories iframe page (`IFramePage.razor`)

## How Has This Been Tested?

Opened the Blazing Story Docs page and confirmed that the story preview window no longer grows beyond the expected height.

 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**: .NET 10
 - **Hosting model**: Blazor Server (InteractiveServer)
 - **Browser(s)**: Microsoft Edge 148.0.3967.96 
 - **OS**: Windows

## Screenshots / Recordings

<img width="1903" height="1137" alt="image" src="https://github.com/user-attachments/assets/87780269-3c59-4638-8a95-79ea7cf65378" />

## Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
