### PR TITLE
fix(stories): add HttpClient registration to resolve missing contributors on About page

### DIFF
--- a/stories/Program.cs
+++ b/stories/Program.cs
@@ -9,6 +9,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddIgniteUIBlazor();
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Description

Register `HttpClient` in the DI container in the Blazing Story app's `Program.cs` to enable HTTP requests required by the About page.

## Motivation / Context

The About page in the Blazing Story (Ignite UI for Blazor Lite) was not displaying the Contributors list. The root cause was that `HttpClient` was not registered as a service, causing the HTTP request to fetch contributor data to fail silently.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [X] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:

Blazing Story (stories) / About page / Contributors list

## How Has This Been Tested?

 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**: .NET 10
 - **Hosting model**: Blazor Server (InteractiveServer)
 - **Browser(s)**: Microsoft Edge 148.0.3967.96
 - **OS**: Windows

## Screenshots / Recordings

<img width="958" height="570" alt="image" src="https://github.com/user-attachments/assets/fa62a689-368b-43c6-98a7-3f53d652b1f0" />

## Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
