### PR TITLE
ci: pin SDK version and rework MTF test run in single run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,19 @@ jobs:
     name: Build & Validate
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        dotnet-version: ['8.0.x', '9.0.x', '10.0.x']
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup .NET ${{ matrix.dotnet-version }}
+      # The SDK is pinned via global.json (10.0.x builds all TFMs);
+      # older runtimes are needed to run tests targeting net8.0/net9.0.
+      - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -81,6 +82,6 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report-${{ matrix.dotnet-version }}
+          name: coverage-report
           path: CoverageReport
           retention-days: 14

--- a/IgniteUI.Blazor.Lite.slnx
+++ b/IgniteUI.Blazor.Lite.slnx
@@ -6,6 +6,7 @@
   </Configurations>
   <Folder Name="/Solution Items/">
     <File Path=".runsettings" />
+    <File Path="global.json" />
   </Folder>
   <Folder Name="/stories/">
     <Project Path="stories/IgniteUI.Blazor.Stories.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/tests/IgniteUI.Blazor.Tests/IgniteUI.Blazor.Tests.csproj
+++ b/tests/IgniteUI.Blazor.Tests/IgniteUI.Blazor.Tests.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Multi-targeted to run the suite against each TFM of the library,
+         validating all supported .NET versions in a single `dotnet test`. -->
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Description
Pin the .NET SDK in [global.json as recommended for CI scenarios](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json). 
That also required to replace matrix with a single multiple TFM (TargetFrameworks) single test run that actually works (see Motivation below). Not that the test project targets all supported frameworks you get this in a single `dotnet test`:
<img width="784" height="177" alt="image" src="https://github.com/user-attachments/assets/cc87bfde-c1a9-4cc7-b087-ccae1354b4c2" />
Or in VS:
<img width="447" height="219" alt="image" src="https://github.com/user-attachments/assets/6527aa98-748c-409e-b198-68537fd8b273" />

## Motivation / Context
The old matrix **wasn't actually testing net8/net9 the way it looked like it was**.
Each of the three legs checked out the repo, installed one SDK (8.0.x / 9.0.x / 10.0.x), and ran the same dotnet build + dotnet test on the whole solution. Two things undercut it:
  1. The solution contains net10.0 projects (stories, TestBed, IntegrationTests), so the "8.0.x" and "9.0.x" legs could never have built with SDK 8 or 9 — they only worked because GitHub's runners come with newer SDKs preinstalled, and without a global.json the CLI silently picks the newest one available. All three legs were almost certainly building with the same SDK 10 and just repeating identical work three times.
  2. Part of the per-TFM validation we actually care about — "does the library compile for net8.0 and net9.0?" — happens in every leg anyway, because the library csproj multi-targets net8.0;net9.0;net10.0, so one dotnet build produces and validates all three assemblies.

**The real gap (which existed before too)**: nothing ever runs tests against the net8.0 build of the library. The unit tests target net9.0 only (so they exercise the lib's net9 assembly) and the integration tests target net10.0. 


### Type of Change (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [x] CI/CD
 - [x] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:
<!-- List the component(s) or area(s) this PR touches, e.g. Grid, Combo, Theming -->


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**:
 - **Hosting model**: <!-- Blazor Server / WebAssembly / Hybrid / United -->
 - **Browser(s)**:
 - **OS**:

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified

Closes #
