### PR TITLE
test: add interop unit tests

### DIFF
--- a/skills/igniteui-blazor-lite-testing/SKILL.md
+++ b/skills/igniteui-blazor-lite-testing/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: igniteui-blazor-lite-testing
+description: "Testing in the IgniteUI Blazor (Lite) repository itself: the bUnit unit suite (tests/IgniteUI.Blazor.Tests — base classes, attribute/serialization specs, declarative interop wire contracts) and the Playwright integration suite (tests/IgniteUI.Blazor.Lite.IntegrationTests + TestBed — reflection-driven live-browser sweep, componentsConfig.json). Use when adding or changing tests in this repo, covering a new component, pinning interop behavior, or deciding which suite a check belongs in. Not for consumer-facing component usage — use igniteui-blazor-components for that."
+user-invocable: true
+---
+
+# Testing in the IgniteUI Blazor (Lite) repo
+
+Three test projects under `tests/`, two suites:
+
+| Project | Suite | What it is |
+|---|---|---|
+| `IgniteUI.Blazor.Tests` | **Unit** | xUnit + bUnit, multi-targeted `net8.0`/`net9.0`/`net10.0`; renders components in-process with a recording JS runtime — no browser |
+| `IgniteUI.Blazor.Lite.IntegrationTests` | **Integration** | NUnit + Playwright; one generated test fixture per component |
+| `IgniteUI.Blazor.Lite.TestBed` | (integration host) | Blazor app the integration tests drive; renders one component per run and sweeps its surface |
+
+## How the suites divide the work
+
+| Behavior | Where it's tested |
+|---|---|
+| Property → rendered attribute (direct-render components) | unit: plain bUnit facts (`cut.Find(...).GetAttribute(...)`) |
+| Markup/child content rendering | unit: plain bUnit facts |
+| Message-borne state serialization shapes | unit: `PropertySerializationTests` / `EnumSerializationTests` / `RenderingSerializationTests` |
+| **Interop wire behavior** — method identifiers, argument serialization + type tags, return decoding, event-handler registration/removal transmissions + JS→.NET event dispatch, interop-borne props/data | unit: the component's `ComponentContract` — full authoring guide: [`references/interop-contracts.md`](./references/interop-contracts.md) |
+| `<Member>Script` parameters (JS-side handlers/providers) | unit: automated sweep (`ScriptPropTests`, all components at once — no per-contract entries, no integration coverage exists) |
+| End-to-end prop/event/method behavior against the **real web component in a real browser** | integration: the TestBed sweep |
+| Visual output, client-side component logic | integration / e2e — never unit |
+
+The two suites overlap on purpose but answer different questions: integration proves the full pipeline works end-to-end (but can't attribute a failure to a side of the boundary, and skips everything excluded in `componentsConfig.json`); interop contracts pin the .NET side of the wire protocol at unit speed, per member — including the members integration excludes — and can accommodate different implementations via the `InteropHarness` seam (`InteropHarnessRegistry` swaps stacks per component).
+
+## Unit suite (`tests/IgniteUI.Blazor.Tests`)
+
+### Base classes
+
+- **`BlazorComponentTestBase`** — bUnit `TestContext` with setup `IIgniteUIBlazor` service, a recording JS runtime (`JSRuntimeMode.Loose`; every invocation recorded) and an `Interop` harness property (an `InteropHarness`, resolved per component type via `InteropFor<TComponent>()`). Default base for suites without an interop contract.
+- **`ComponentWithContractTestBase<TComponent>`** — adds a declarative `ComponentContract<TComponent>`, `protected` runners (`VerifyMethodContract`/`VerifyPropContract`/`VerifyEventContract`) that the suite exposes as one-liner `[Fact]`s, and an inherited `Contract_SectionsHaveFacts` guard that fails if a non-empty contract section has no runner fact. Exactly one suite per component carries the contract; sync/async method pairs are declared together via the twin overloads.
+
+### Running
+
+```
+dotnet test tests/IgniteUI.Blazor.Tests -f net10.0 --nologo --filter "FullyQualifiedName~<Name>Tests"
+```
+
+- Iterate on one TFM (`-f net10.0`); finish with a full run on all TFMs (drop `-f`).
+- Contract failure stacks carry the violated contract line as the top frame — the test UI navigates to the spec, not the shared runner.
+
+### Conventions
+
+- **Suites may live per class, instead per file** — search for the class (`BannerTests` is in `MiscComponentTests.cs`, `SnackbarTests`/`ToastTests` in `AlertTests.cs`).
+- **Skips need a mechanism reason.** Bug-tracker or `componentsConfig.json` listings are not skip reasons. If a member's decode hits a gap in shared infrastructure the change doesn't own, cover it pinning current behavior and write the *correct* assertion commented out under a `// TODO:` explaining the gap — ready to uncomment when fixed. A gap in a component under construction is a bug to fix, not to pin — see the two authoring modes in the interop reference.
+- Components are `partial` — the generated `src/components/Blazor/<Name>.cs` is not the whole class; always check `src/componentsBase/WebInputs/<Name>.cs` for hand-written extensions before drawing conclusions.
+- Formatting: only `dotnet format whitespace --folder` is safe in this repo — a full `dotnet format` writes conflict markers into multi-targeted sources.
+
+## Integration suite (Playwright + TestBed)
+
+One generic NUnit test per component (`ComponentTest`, fixture-sourced from the TestBed's
+component list): it boots the TestBed app (in-memory by default), calls the browser-side
+`renderComponent('<IgbName>')`, and asserts `getErrors()` returns nothing. The real work
+happens inside the TestBed (`Components/Pages/Home.razor`): a **reflection-driven sweep**
+over the component's public surface —
+
+- **`TestProps`**: sets each `[Parameter]` server-side with generated sample values and compares against the live web component's DOM property in the browser (`TestUtil.PropertyValuesAreEqual`, client value via `stringifyObject`).
+- **`TestEvents`**: dispatches synthetic events against the web component and verifies the bound .NET callbacks fire.
+- **Method spies** (`spyOnMethod`/`checkOnSpy` in `wwwroot/app.js`): invoking the .NET API must call the matching web-component method with the right args/result. **Async methods only** — the sweep filters to `*Async` and also excludes `Get*Async` getters; sync variants can't run on the Server-hosted TestBed (no in-process JS runtime), so sync variants, getters, and `<Member>Script` params have no integration coverage — the unit suite is their only net.
+
+**`componentsConfig.json`** (in the TestBed project) gates the sweep per component:
+`ExcludedProps`, `ExcludedEvents`, `DependantProps`/`DependantMethods` — each entry usually cites a BUG number or a shape the generic sweep can't model. An excluded member has **no integration coverage at all** — treat those as *higher* priority for the unit interop contract, never as members to skip there too.
+
+### Running
+
+- One-time: build, then install browsers — `pwsh tests/IgniteUI.Blazor.Lite.IntegrationTests/bin/Debug/net<version>/playwright.ps1 install chromium`.
+- `dotnet test tests/IgniteUI.Blazor.Lite.IntegrationTests` (or per component from the Test Explorer — fixtures are named by component).
+- `.runsettings` knobs: headless off for local debugging; `useInMemoryClient: false` to run against your own `dotnet run` instance of the TestBed.
+- Full setup details: [tests/IgniteUI.Blazor.Lite.IntegrationTests/README.md](../../tests/IgniteUI.Blazor.Lite.IntegrationTests/README.md).
+
+## Adding coverage for a new component — checklist
+
+1. Unit suite: bUnit facts for rendered attributes/markup; if the component has an interop surface (it sends interop invocations or registers JS-originated event handlers — the reference explains how to identify these per stack), add a `ComponentContract` per [`references/interop-contracts.md`](./references/interop-contracts.md). For a brand-new component this works TDD-style: author the contract first from the intended API following the library's conventions; the contract doubles as the API design record (spec mode in the reference).
+2. Integration: the sweep picks the component up automatically; add  `componentsConfig.json` entries only for members the generic sweep genuinely cannot  model (cite why), and mirror each exclusion with unit contract coverage.
+3. Verify: unit full-suite on all TFMs, plus the component's integration fixture.

--- a/skills/igniteui-blazor-lite-testing/SKILL.md
+++ b/skills/igniteui-blazor-lite-testing/SKILL.md
@@ -46,7 +46,7 @@ dotnet test tests/IgniteUI.Blazor.Tests -f net10.0 --nologo --filter "FullyQuali
 
 ### Conventions
 
-- **Suites may live per class, instead per file** — search for the class (`BannerTests` is in `MiscComponentTests.cs`, `SnackbarTests`/`ToastTests` in `AlertTests.cs`).
+- **Suites may live per class, instead of per file** — search for the class (`BannerTests` is in `MiscComponentTests.cs`, `SnackbarTests`/`ToastTests` in `AlertTests.cs`).
 - **Skips need a mechanism reason.** Bug-tracker or `componentsConfig.json` listings are not skip reasons. If a member's decode hits a gap in shared infrastructure the change doesn't own, cover it pinning current behavior and write the *correct* assertion commented out under a `// TODO:` explaining the gap — ready to uncomment when fixed. A gap in a component under construction is a bug to fix, not to pin — see the two authoring modes in the interop reference.
 - Components are `partial` — the generated `src/components/Blazor/<Name>.cs` is not the whole class; always check `src/componentsBase/WebInputs/<Name>.cs` for hand-written extensions before drawing conclusions.
 - Formatting: only `dotnet format whitespace --folder` is safe in this repo — a full `dotnet format` writes conflict markers into multi-targeted sources.

--- a/skills/igniteui-blazor-lite-testing/references/interop-contracts.md
+++ b/skills/igniteui-blazor-lite-testing/references/interop-contracts.md
@@ -123,7 +123,7 @@ Object details are envelope-wrapped by the client bridge (`src/src/index.ts` `to
 ```csharp
 public class <Name>Tests : ComponentWithContractTestBase<Igb<Name>>
 {
-    protected override ComponentContract<Igb<Name>> Contract { get; } = new ComponentContract<Igb<Name>>()
+    protected override ComponentContract<Igb<Name>> InteropContract { get; } = new ComponentContract<Igb<Name>>()
         .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
         .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: ...)
         .Event(c => c.SomeEvent, ...)

--- a/skills/igniteui-blazor-lite-testing/references/interop-contracts.md
+++ b/skills/igniteui-blazor-lite-testing/references/interop-contracts.md
@@ -1,0 +1,167 @@
+# Interop wire contracts — authoring reference
+
+Goal: every component with an interop surface carries a declarative `ComponentContract<TComponent>` in its test suite, pinning how its public API maps onto the wire — method identifiers, argument serialization and type tags, return decoding, and event names + args deserialization. Contracts run through the `InteropHarness` seam (`tests/IgniteUI.Blazor.Tests/Interop/`), so the contract verifies a component regardless of the interop stack (swap per component via `InteropHarnessRegistry`).
+
+Scope note: contracts cover **methods, current-state getters, events, and props that travel over interop**. Simple property → attribute rendering (direct-render components) is already covered by the existing attribute tests and the integration suite — never duplicate it with `.Prop`.
+
+Exemplars to imitate: `ButtonTests.cs` (simplest), `CarouselTests.cs` (void/bool methods, args, getters, number event), `ChipTests.cs` (bool-detail events, getter), `ChatTests.cs` (renderer-container component: `.Prop` config object, complex event args), `ComboTests.cs` (data sources, uuid refs), `TreeTests.cs` (child refs, hosted getter).
+
+Cross-check the integration exclusions: members listed for the component in `tests/IgniteUI.Blazor.Lite.TestBed/componentsConfig.json` (`ExcludedProps`, `DependantMethods`, `ExcludedEvents`) have **no integration coverage at all** — treat them as higher priority for the contract, never as members to skip. Client-side bugs cannot reach the stubbed boundary, so the contract covers the public API as exposed today; reference the bug in a note (not the skip comment) for context.
+
+**The file is not the whole class.** `partial` classes may have split implementations — always check `src/` for other parts.
+
+## Two authoring modes — know which one you're in
+
+- **Pin mode** — the component exists and is presumed working (retrofitting coverage, gating a migration). Author specs from the source and run them; when a spec disagrees with what actually crossed (failure output shows the recorded wire values), judge which side is off. Usually the spec mis-derived a wire form — correct it. When the *implementation* looks wrong instead, decide whether there is an issue that can't be asserted correctly right now: if so, assert what holds today and leave the correct assertion commented out under a `// TODO:` explaining the issue (exemplars: `StepperTests` `GetSteps`, `ComboTests` `ChangeType`; grep `TODO` in the test project — every hit is an uncomment-when-fixed marker).
+- **Spec mode (TDD / new component / intended behavior change)** — the contract is the reference and is written *first*, from the intended public API and the stack's wire conventions (cheat-sheet). Where the component wraps a web component, its emitted shapes (`node_modules/igniteui-webcomponents` `.d.ts` / `custom-elements.json`) supply the payload truth. For a **Blazor-specific component with no web-component counterpart**, the API and the wire vocabulary are themselves design deliverables: propose them from the component's requirements, patterned on the library's conventions (`*Async` methods with sync twins, `EventCallback<TArgs>` with a dedicated args type, camelCase wire identifiers, the existing type-tag vocabulary) and the closest existing contracts as exemplars — the contract then doubles as the reviewable API design record.
+
+The recipe below is phrased for pin mode ("read the source"); in spec mode, substitute the intended API design for the source — everything else (the DSL, the guards, the payload derivation from WC metadata) applies unchanged.
+
+## Where a contract lives
+
+Each component has (at most) **one** suite carrying the contract:
+
+- If the component already has a test class, change its base from `BlazorComponentTestBase` to `ComponentWithContractTestBase<Igb<Name>>`, add `using IgniteUI.Blazor.Tests.Interop;`, and add the `Contract` property at the top. Leave all existing facts untouched. **Search for the class, not the file** — some suites live in shared files (e.g. `BannerTests` is in `MiscComponentTests.cs`, `SnackbarTests`/`ToastTests` in `AlertTests.cs`). If several classes exist for one component (`XTests` + `XExtendedTests`), put the contract on the primary (`XTests`) only.
+- If no suite exists anywhere, create `<Name>Tests.cs` with the contract.
+- Components with **no interop surface** (they never send an interop invocation and register no JS-originated event handlers — e.g. Badge) stay on `BlazorComponentTestBase`.
+
+## Recipe — pin the component's interop surface
+
+Read the component's source (all `partial` parts) and find every place it:
+
+1. **sends an outbound interop invocation** from a public API member → a `.Method` or `.Getter` spec;
+2. **registers a handler for a JS-originated event** (paired with an `EventCallback<TArgs>` parameter) → an `.Event` spec;
+3. **transmits state over interop** rather than rendering it as an attribute → a `.Prop` spec.
+
+The *concrete idioms* for all three depend on which interop stack the component currently sits on — the [cheat-sheet below](#current-stack-cheat-sheet-legacy-renderermessage-pipeline) lists them for the legacy `RendererMessage` pipeline. For a component on a different stack, find the equivalent call sites in its implementation (whatever sits between the public member and the JS runtime — a direct `IJSRuntime.InvokeAsync`, a channel service, etc.); the principles and the DSL below are unchanged.
+
+### 1. Methods and getters
+
+- Every public API member that produces an outbound invocation gets a spec. Distinguish two kinds:
+  - **Actions** → `.Method(c => c.NextAsync(), c => c.Next(), "next", ...)` — async selector, sync twin selector, then the wire identifier (matching the member-first pattern of `.Event`/`.Prop`; single-selector overloads exist for async-only members). The contract pins the identifier, the serialized arguments, their type tags, and the decoded return — for both dispatches.
+  - **Current-state reads** (a `Get...Async` that decodes a component property's live value) → `.Getter(c => c.GetTotalAsync(), "Total", returns: 5.0)` with the **bare property name** — how a read travels (its wire identifier or call shape) is implementation-specific and owned by the harness, never written in contracts.
+- **Args and type tags**: state what crosses — sample values chosen by you, wire forms derived from the member's serialization (cheat-sheet for the legacy conversions) or, in pin mode, by running the spec and reading the recorded wire values from the failure output. Write both as collection expressions: `args: [2.0, "next"], types: ["Number", "Json"]`. Structured values use `new JsonSubset(...)` (subset match) or `new RawJson(...)` (exact).
+- **Returns** — choose by the *semantic* return kind:
+  | Return kind | Contract form |
+  |---|---|
+  | none | omit — void overload |
+  | scalar (bool/number/string/date) | just the value: `returns: true` / `5.0` / a UTC `DateTime` — the wire return kind is derived from the value's type, and the decoded .NET return must round-trip back to it (dates compared as instants) |
+  | single serialized object | arranged `Getter` overload with `InteropReturn.Object(...)` + value-level `assert:` — see `ChatTests.cs` `DraftMessage` |
+  | array of component/data-item references | arranged `Getter` overload with `InteropReturn.Array` of refs, `Assert.Same` against arranged instances — see `TileManagerTests.cs` `Tiles`, `ComboTests.cs` `Value` |
+  | single bound-object reference | arranged `Getter` overload with `InteropReturn.Ref(...)`, `Assert.Same` against the arranged child — see `SelectTests.cs`/`DropdownTests.cs` `SelectedItem` |
+
+  (An explicit `InteropReturn` + separate `expect:` overload exists for wire returns that decode to a different value than sent — rare.)
+- **Value-returning methods must state their return** — enforced at compile time: a `Task<TResult>`-returning lambda on the void `.Method` overload is `[Obsolete(error: true)]` as a guard, so the contract states the `returns:` stub. The void overload needs no stub.
+- **Hosted arrange — child components that only exist inside a parent** - Currently available in the hosted `Getter` overload (e.g. a tree item's `GetPathAsync` needs real ancestors). Build the full render with `ContractHost.Of<THost>(ps => ps.AddChildContent(...))` (parent as the root, structure nested inside), pick the component under test with `target: h => h.FindComponents<TComponent>()[n]`, and note that `returns:`/`assert:` receive the whole host render — so `interop.ContainerIdOf(h, "<selector>")` reaches ancestors and siblings outside the cut's subtree. The read still travels on the target's own container. See `TreeItemTests` in `TreeTests.cs`.
+- **Sync twins are declared inside the member's spec**: every `X()`/`XAsync()` pair uses the twin overloads — both selectors up front, async first: `.Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)` (same for `.Getter`, including the arranged/hosted forms). The runner re-invokes the sync twin against the same expectations (identifier, args, types, decoded return). Declaring the twin is the contract author's responsibility — when enumerating methods, treat an `X()`/`XAsync()` pair as one member and use the twin overload. Sync dispatch rides the in-process JS runtime (`IJSInProcessRuntime` — WASM/WebView-only in production; the Server-hosted integration TestBed can't run sync variants, so contracts are their only coverage).
+- **Skip and list**: a member whose decode hits an implementation gap (unregistered child type, missing marshal-by-value entry) is covered, not skipped — per the authoring modes above.
+
+### 2. Events
+
+- The contract entry is member-first — `.Event(c => c.SlideChanged, argsJson, assert)`, or the bare `.Event(c => c.Closing)` for a void event. The wire event name is derived from the member name (it matches the registered handler name on every generated component — if you ever hit one that differs, pass `name:` explicitly), the args type is inferred from the `EventCallback<TArgs>` signature.
+- **What an `.Event` spec verifies** — the full loop, automatically: (1) binding round-trips — the member returns the exact callback assigned; (2) binding transmits an **event-handler registration** over interop, carrying the member's event identity — the client's cue to subscribe (same ref machinery as Script props, harness-normalized); (3) dispatching the spec's payload under the wire event name reaches the handler with args of the declared type, satisfying the spec's asserts; (4) unbinding (setting the parameter back to an empty callback) resets the member, transmits the **cleared registration** — the client's cue to unsubscribe — and stops delivery: a subsequent dispatch must not reach the handler.
+- **The bare form compiles only for `EventCallback<IgbVoidEventArgs>` members** (the type is invariant), and `argsJson` is required on the data overload.
+- **Args JSON**: derive from the args type's deserialization code (which keys it reads, into which .NET properties), and/or the web component's emitted event detail (the events are not black boxes: check `node_modules/igniteui-webcomponents` `.d.ts` / `custom-elements.json` for the emitted shape). Wire envelope framing for object details is stack-specific — see the cheat-sheet; `ChatTests.cs` `MessageCreated` is the exemplar.
+- **Assert** each property you put in the payload: `assert: args => Assert.Equal(3, args.Detail)`. Keep assertions **value-level** (compare data, not instance identity) — with one exception: **self-reference details**
+- **Assert references**
+  - When a component's own event carries a reference to itself, the contract asserts it resolves back to the instance via the component-aware overload: `assert: (panel, a) => Assert.Same(panel, a.Detail)` (see `ExpansionPanelTests.cs`, `TileTests` in `TileManagerTests.cs`). Resolution of a reference IS its value semantics.
+  - For child-component references (a parent's event whose detail contains a child — Accordion's panels, Tabs' tab, Tree's items, TileManager's tiles): use the arranged-children `Event` overload — `arrange:` adds child components via `AddChildContent`, `argsJson:` is a factory building a reference payload with `interop.ContainerIdOf(cut, "igc-tab:nth-of-type(2)")`, and `assert:` receives the cut to `Assert.Same` against the arranged child instance. See `TabsTests.cs` `Change` for example.
+- Specs need no component state by default — the interop boundary is state-free (a method sends its invocation regardless of slides/messages existing; effects are integration's job). Use `arrange:` only when a member genuinely needs .NET-side arrangement (bound children, data) just to *reach* the boundary — e.g. payloads carrying references that must resolve, or data-source items referenced by uuid.
+- The `<PropName>Script` string parameters are not events but ARE valid public API — covered **automatically** by the generic sweep in `ScriptPropTests`: every generated `<Member>Script` prop must transmit a script reference for its target member, carrying the script name. No per-contract entries needed (the integration TestBed does not exercise these either, so the sweep is their only coverage).
+
+### 3. Interop-borne props
+
+The contract entry is the member selector plus a sample value: the wire name is derived from the member (camelCase, honoring `[WCWidgetMemberName]`; `wireName:` overrides), and for scalar values the wire value is the value itself — `.Prop(c => c.Open, true)`. Enums and serialized objects/arrays must state the wire form explicitly: `.Prop(c => c.GroupSorting, GroupingDirection.Desc, wire: "desc")`, `.Prop(c => c.Options, new IgbChatOptions { ... }, wire: new JsonSubset("""..."""))`.
+
+- A property belongs in the contract **only when its value travels over interop** rather than as a rendered attribute. Determine which from the component's serialization path (stack-specific — see the cheat-sheet) or empirically: for an attribute prop, the runner fails with *"no property update transmission was observed"*. Attribute props are covered by the suite's attribute facts instead.
+- **Serialized config objects and arrays**: set an instance with 2–3 distinctive values and expect a `JsonSubset` — subset match, extra bookkeeping fields on the transmitted value are ignored; arrays compare element-wise (equal length, per-element subset). See `ChatTests.cs`, `CalendarTests.cs`.
+- **Data sources** (`Data`/`DataSource` props): covered by `.Prop(c => c.Data, ...)` too — the harness follows whatever indirection the stack uses to the actual transfer. Item property names cross with their .NET names (not camelized). See `ComboTests.cs`.
+- **Props referencing data items** (e.g. Combo's `Value`): use the arranged overload — arrange the `Data` the value points into and state the wire value as a factory, since tracked items cross as refs whose ids are only assigned on transfer: `.Prop(c => c.Value, [_item1], arrange: ps => ps.Add(c => c.Data, items), wire: (interop, cut) => new RawJson(...))`.
+
+## Current-stack cheat-sheet (legacy `RendererMessage` pipeline)
+
+> Everything in this section is specific to components still on the legacy
+> `BaseRendererControl`/`RendererMessage` stack.
+
+**Surface markers** in the component's source:
+- `InvokeMethod("...", args, types)` inside `public async Task...` wrappers → methods/getters;
+- `SetHandler<TArgs>(this.Name, "EventName", ...)` (the `[Parameter] EventCallback<TArgs>` is right above it) → events;
+- `SerializeCore` at the bottom of the class (each `if (IsPropDirty("X")) { ser.AddXxxProp(...) }` line) → interop-borne props.
+
+**Methods**: the JS name is the first `InvokeMethod` argument, used verbatim — *except* a `p:` prefix (e.g. `InvokeMethod("p:Total", ...)`), which marks a current-state read: use `.Getter` with the bare property name; the prefix is harness-owned. `types:` = the `new string[] { ... }` values verbatim (getters have none).
+
+**Argument wire forms** (per argument expression in the source):
+
+| Argument expression in source              | Sample .NET arg          | Expected wire arg (contract `args:`) |
+|--------------------------------------------|--------------------------|--------------------------------------|
+| bare value, type tag `"Number"`            | `2` / `2.5`              | `2.0` / `2.5` (always as double)     |
+| `StringToString(x)`, tag `"String"`        | `"message-42"`           | `"message-42"`                       |
+| bare bool, tag `"Boolean"`                 | `true`                   | `true`                               |
+| `ObjectToParam(x, typeof(SomeEnum))`, tag `"Json"` | `SomeEnum.Member` | the `[WCEnumName("...")]` value if the member has one, else camelCase of the member name (`Next` → `"next"`) |
+| `ObjectToParam(x)` with a plain string, tag `"Json"` | `"item-1"`     | `"item-1"`                           |
+| `ObjectToParam(x)` with a marshal-by-value object, tag `"Json"` | an options object | `new JsonSubset("""{"key": value, ...}""")` |
+| `x` DateTime, tag `"Date"`                 | a `DateTime`             | the same `DateTime` (compared as instant) |
+| array helpers (`IntArrayToString`, ...), tag `"NumberArray"` etc. | array | `new RawJson("[1,2,3]")`            |
+
+**Return decodes** (the line after `InvokeMethod` → the semantic kinds in the recipe's table):
+
+| Source decode | Semantic kind |
+|---|---|
+| `ReturnToBoolean/Double/Int/Long/String/Date(iv)` | scalar (`returns:` the value; note `ReturnToBoolean(null) == false` — why unstubbed void specs would pass silently) |
+| `ReturnToObject<T>(iv, "TypeName")` | single serialized object — stub `InteropReturn.Object("", ...)`: the wire type is empty, .NET fills it from its typeGuess |
+| `ReturnToObjectArray<T>` | array of refs — component refs are `{"refType": "name", "id": <containerId>}`; data-item refs are `{"refType": "uuid", "id": <observed ___id>}` |
+| bare `ConvertReturnValue(iv)` cast to a component | single bound-object reference — crosses as a bare `{"refType": "name", "id": ...}` with no retType envelope (`InteropReturn.Ref`) |
+| `StringToEnum` returns | not modeled — skip with this reason |
+
+**Events**: Payload keys come from the args type's `FromEventJson` (`if (args.ContainsKey("key")) { this.X = ReturnToXxx(args["key"]); }` → key + sample value: `ReturnToBoolean` → `true`, `ReturnToDouble` → `3`, `ReturnToDate` → `"2026-01-02T03:04:05.000Z"`).
+Object details are envelope-wrapped by the client bridge (`src/src/index.ts` `toReturn` → `Loader.transformReturn`) as `{"detail": {"retType": "object", "type": "", "value": { ...detail... }}}` — type empty, .NET fills it from the typeGuess. Child references resolve through named cascading-parameter registration.
+
+**Props**: Wire details: enum values are `[WCEnumName]` or camelCase; nested keys camelCase; dates inside serialized objects cross as `"@d:<ISO>"` strings (`AddPrimitiveProp`) while dedicated date arrays (`AddDateArrayProp`) cross as plain ISO strings; data sources ride a `refChanged` transfer under a generated ref id the description advertises as `<wireName>Ref` (the harness follows it). Skip `SerializeCore` entries whose wire name ends in `Ref` (event/script ref advertisements — the script side is swept by `ScriptPropTests`; script refs transmit as `refChanged` with refValue `script:::<name>`, which the harness normalizes to the bare name).
+
+## Contract template
+
+```csharp
+public class <Name>Tests : ComponentWithContractTestBase<Igb<Name>>
+{
+    protected override ComponentContract<Igb<Name>> Contract { get; } = new ComponentContract<Igb<Name>>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: ...)
+        .Event(c => c.SomeEvent, ...)
+        .Prop(c => c.SomeProp, ...);
+
+    // One runner fact per non-empty contract section (omit facts for empty sections
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
+    // ... other/existing facts ...
+}
+```
+
+Contract failures carry the violated member and, as the top stack frame, the contract line that declared it (captured via caller info).
+
+## Verify
+
+```
+dotnet test tests/IgniteUI.Blazor.Tests/IgniteUI.Blazor.Tests.csproj -f net10.0 --nologo --filter "FullyQualifiedName~<Name>Tests"
+```
+
+Common failures:
+
+- `handler was not invoked` → wrong event name (must match the name the component registers) or a payload key the args deserialization doesn't read.
+- Types/args mismatch → the assertion message shows the recorded wire values; judge which side is off per the authoring modes (in spec mode an unintended wire value is the implementation's bug — the red spec is doing its job).
+- A method call that never returns (test timeout) means its identifier reached JS without a stub match — check the name matches the stub you declared (getters: bare property name).
+- `no property update transmission was observed` → wrong wire name, an attribute-rendered prop, or a serialization exception upstream (nothing transmits at all).
+
+Finish with a full-suite sanity run: same command without `--filter`.
+
+## Definition of done (per component)
+
+- Contract on exactly one suite, all facts green, plus full suite green on all TFMs.
+- Every public method that goes out through interop — async **and** its sync twin (declared together via the twin overloads) — every registered JS-originated event, and every interop-borne prop is either covered, globally excluded, or named in the skip comment with a mechanism reason — nothing silently omitted. (`<Member>Script` params are covered by the `ScriptPropTests` sweep.)
+- Implementation issues found along the way are handled per the authoring modes (`// TODO:` markers or fixes), never silently skipped.

--- a/tests/IgniteUI.Blazor.Tests/AlertTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/AlertTests.cs
@@ -1,10 +1,23 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class SnackbarTests : BlazorComponentTestBase
+public class SnackbarTests : ComponentWithContractTestBase<IgbSnackbar>
 {
+    protected override ComponentContract<IgbSnackbar> InteropContract { get; } = new ComponentContract<IgbSnackbar>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Event(c => c.Action);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Snackbar_RendersCorrectElement()
     {
@@ -75,8 +88,16 @@ public class SnackbarTests : BlazorComponentTestBase
     }
 }
 
-public class ToastTests : BlazorComponentTestBase
+public class ToastTests : ComponentWithContractTestBase<IgbToast>
 {
+    protected override ComponentContract<IgbToast> InteropContract { get; } = new ComponentContract<IgbToast>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
     [Fact]
     public void Toast_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/BlazorComponentTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/BlazorComponentTestBase.cs
@@ -1,27 +1,59 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.JSInterop;
-using Moq;
+using IgniteUI.Blazor.Tests.Interop;
+using Microsoft.AspNetCore.Components;
 
 namespace IgniteUI.Blazor.Tests;
 
 /// <summary>
 /// Base class for component tests providing shared test context setup.
+/// JS interop runs on bUnit's recording runtime in loose mode (unconfigured calls
+/// return <c>default</c>, like the previous swallow-everything mock, but every
+/// invocation is recorded). Interop traffic is observed and driven through the
+/// <see cref="InteropHarness"/> seam rather than against the wire format directly.
 /// </summary>
 public abstract class BlazorComponentTestBase : TestContext
 {
-    protected Mock<IJSRuntime> JsRuntimeMock { get; }
     protected IIgniteUIBlazor IgniteUIBlazor { get; }
+
+    /// <summary>The interop harness for components on the default (current) interop stack.</summary>
+    protected InteropHarness Interop { get; }
+
+    private Dictionary<Func<BunitJSInterop, InteropHarness>, InteropHarness>? _overrideHarnesses;
 
     protected BlazorComponentTestBase()
     {
-        JsRuntimeMock = new Mock<IJSRuntime>();
-        JsRuntimeMock
-            .Setup(x => x.InvokeAsync<object>(It.IsAny<string>(), It.IsAny<object[]>()))
-            .ReturnsAsync((object)null!);
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Interop = InteropHarnessRegistry.CreateDefault(JSInterop);
+        Interop.ConfigureServices(Services);
+        IgniteUIBlazor = Interop.Service;
+    }
 
-        IgniteUIBlazor = new IgniteUIBlazor(JsRuntimeMock.Object);
-        Services.AddSingleton<IIgniteUIBlazor>(IgniteUIBlazor);
+    /// <summary>
+    /// Resolves the interop harness for a component type: the shared default unless the
+    /// type was remapped in <see cref="InteropHarnessRegistry"/> (used while migrating
+    /// components to new interop infrastructure one by one). Call it before rendering
+    /// the component so a remapped harness can register its services first.
+    /// </summary>
+    protected InteropHarness InteropFor<TComponent>() where TComponent : IComponent
+        => InteropFor(typeof(TComponent));
+
+    /// <summary>Non-generic <see cref="InteropFor{TComponent}"/> for reflection-driven sweeps over component types.</summary>
+    protected InteropHarness InteropFor(Type componentType)
+    {
+        var factory = InteropHarnessRegistry.OverrideFor(componentType);
+        if (factory is null)
+        {
+            return Interop;
+        }
+
+        _overrideHarnesses ??= new();
+        if (!_overrideHarnesses.TryGetValue(factory, out var harness))
+        {
+            harness = factory(JSInterop);
+            harness.ConfigureServices(Services);
+            _overrideHarnesses[factory] = harness;
+        }
+        return harness;
     }
 }

--- a/tests/IgniteUI.Blazor.Tests/ButtonGroupTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ButtonGroupTests.cs
@@ -1,10 +1,22 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class ButtonGroupTests : BlazorComponentTestBase
+public class ButtonGroupTests : ComponentWithContractTestBase<IgbButtonGroup>
 {
+    protected override ComponentContract<IgbButtonGroup> InteropContract { get; } = new ComponentContract<IgbButtonGroup>()
+        .Event(c => c.Select,
+            argsJson: """{"detail": "toggle-1"}""",
+            assert: args => Assert.Equal("toggle-1", args.Detail))
+        .Event(c => c.Deselect,
+            argsJson: """{"detail": "toggle-1"}""",
+            assert: args => Assert.Equal("toggle-1", args.Detail));
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void ButtonGroup_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/ButtonTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ButtonTests.cs
@@ -1,10 +1,26 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class ButtonTests : BlazorComponentTestBase
+public class ButtonTests : ComponentWithContractTestBase<IgbButton>
 {
+    protected override ComponentContract<IgbButton> InteropContract { get; } = new ComponentContract<IgbButton>()
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }),
+            "focus",
+            args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.ClickAsync(), c => c.Click(), "click")
+        .Event(c => c.Focus)
+        .Event(c => c.Blur);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Button_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/CalendarTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CalendarTests.cs
@@ -1,9 +1,75 @@
+using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class CalendarTests : BlazorComponentTestBase
+public class CalendarTests : ComponentWithContractTestBase<IgbCalendar>
 {
+    protected override ComponentContract<IgbCalendar> InteropContract { get; } = new ComponentContract<IgbCalendar>()
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value",
+            returns: new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc))
+        .Getter(c => c.GetCurrentValuesAsync(), c => c.GetCurrentValues(), "Values",
+            arrange: _ => { },
+            returns: (interop, cut) => InteropReturn.Array("""["2026-01-02T03:04:05.000Z", "2026-03-16T12:30:00.000Z"]"""),
+            assert: (cut, result) =>
+            {
+                Assert.Equal(2, result.Length);
+                Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), result[0].ToUniversalTime());
+                Assert.Equal(new DateTime(2026, 3, 16, 12, 30, 0, DateTimeKind.Utc), result[1].ToUniversalTime());
+            })
+        .Event(c => c.Change,
+            argsJson: """{"detail": {"retType": "date", "value": "2026-01-02T03:04:05.000Z"}}""",
+            assert: args => Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), ((DateTime)args.Detail).ToUniversalTime()))
+        .Prop(c => c.Selection, CalendarSelection.Range, wire: "range")
+        .Prop(c => c.ShowWeekNumbers, true)
+        .Prop(c => c.WeekStart, WeekDays.Monday, wire: "monday")
+        .Prop(c => c.Locale, "en-US")
+        .Prop(c => c.Value, new DateTime(2026, 3, 15))
+        .Prop(c => c.Values,
+            [new DateTime(2026, 3, 15), new DateTime(2026, 3, 16)],
+            wire: new RawJson("""["2026-03-15T00:00:00.0000000", "2026-03-16T00:00:00.0000000"]"""))
+        .Prop(c => c.SpecialDates,
+            [new IgbDateRangeDescriptor { RangeType = DateRangeType.Specific, DateRange = new DateTime(2026, 1, 1) }],
+            wire: new JsonSubset("""[{"rangeType": "specific", "dateRange": "@d:2026-01-01T00:00:00.0000000"}]"""))
+        .Prop(c => c.DisabledDates,
+            [
+                new IgbDateRangeDescriptor { RangeType = DateRangeType.Before, DateRange = new DateTime(2025, 12, 31) },
+                new IgbDateRangeDescriptor { RangeType = DateRangeType.Weekdays },
+            ],
+            wire: new JsonSubset("""[{"rangeType": "before", "dateRange": "@d:2025-12-31T00:00:00.0000000"}, {"rangeType": "weekdays"}]"""))
+        .Prop(c => c.ActiveDate, new DateTime(2026, 4, 1))
+        .Prop(c => c.HideOutsideDays, true)
+        .Prop(c => c.HideHeader, true)
+        .Prop(c => c.HeaderOrientation, CalendarHeaderOrientation.Vertical, wire: "vertical")
+        .Prop(c => c.Orientation, ContentOrientation.Vertical, wire: "vertical")
+        .Prop(c => c.VisibleMonths, 2.0)
+        .Prop(c => c.ActiveView, CalendarActiveView.Months, wire: "months")
+        .Prop(c => c.FormatOptions,
+            new IgbCalendarFormatOptions
+            {
+                Weekday = "short",
+                Month = "long",
+            },
+            wire: new JsonSubset("""{"weekday": "short", "month": "long"}"""))
+        .Prop(c => c.ResourceStrings,
+            new IgbCalendarResourceStrings
+            {
+                SelectMonth = "Choose month",
+                SelectYear = "Choose year",
+                WeekLabel = "Wk",
+            },
+            wire: new JsonSubset("""{"selectMonth": "Choose month", "selectYear": "Choose year", "weekLabel": "Wk"}"""));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Calendar_TypeMetadata()
     {

--- a/tests/IgniteUI.Blazor.Tests/CarouselTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CarouselTests.cs
@@ -1,10 +1,35 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class CarouselTests : BlazorComponentTestBase
+public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
 {
+    protected override ComponentContract<IgbCarousel> InteropContract { get; } = new ComponentContract<IgbCarousel>()
+        .Method(c => c.PlayAsync(), c => c.Play(), "play")
+        .Method(c => c.PauseAsync(), c => c.Pause(), "pause")
+        .Method(c => c.NextAsync(), c => c.Next(), "next", returns: true)
+        .Method(c => c.PrevAsync(), c => c.Prev(), "prev", returns: false)
+        .Method(c => c.SelectAsync(2, CarouselAnimationDirection.Next), c => c.Select(2, CarouselAnimationDirection.Next),
+            "select", returns: true,
+            args: [2.0, "next"], types: ["Number", "Json"])
+        .Getter(c => c.GetTotalAsync(), c => c.GetTotal(), "Total", returns: 5.0)
+        .Getter(c => c.GetCurrentAsync(), c => c.GetCurrent(), "Current", returns: 2.0)
+        .Getter(c => c.GetIsPlayingAsync(), c => c.GetIsPlaying(), "IsPlaying", returns: true)
+        .Getter(c => c.GetIsPausedAsync(), c => c.GetIsPaused(), "IsPaused", returns: false)
+        .Event(c => c.SlideChanged,
+            argsJson: """{"detail": 3}""",
+            assert: args => Assert.Equal(3, args.Detail))
+        .Event(c => c.Playing)
+        .Event(c => c.Paused);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Carousel_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/ChatTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ChatTests.cs
@@ -1,10 +1,84 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class ChatTests : BlazorComponentTestBase
+public class ChatTests : ComponentWithContractTestBase<IgbChat>
 {
+    protected override ComponentContract<IgbChat> InteropContract { get; } = new ComponentContract<IgbChat>()
+        .Method(c => c.ScrollToMessageAsync("message-42"), c => c.ScrollToMessage("message-42"), "scrollToMessage",
+            args: ["message-42"], types: ["String"])
+        .Getter(c => c.GetCurrentDraftMessageAsync(), c => c.GetCurrentDraftMessage(), "DraftMessage",
+            arrange: _ => { },
+            returns: (interop, cut) => InteropReturn.Object("", """{"text": "wip draft"}"""),
+            assert: (cut, result) => Assert.Equal("wip draft", result.Text))
+        .Event(c => c.TypingChange,
+            argsJson: """{"detail": true}""",
+            assert: args => Assert.True(args.Detail))
+        .Event(c => c.InputChange,
+            argsJson: """{"detail": "draft text"}""",
+            assert: args => Assert.Equal("draft text", args.Detail))
+        .Event(c => c.InputFocus)
+        .Event(c => c.InputBlur)
+        .Event(c => c.MessageCreated,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"id": "m-1", "text": "hello", "sender": "user-1"}}}""",
+            assert: args =>
+            {
+                Assert.Equal("m-1", args.Detail.Id);
+                Assert.Equal("hello", args.Detail.Text);
+                Assert.Equal("user-1", args.Detail.Sender);
+            })
+        .Event(c => c.AttachmentClick,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"id": "a-1", "name": "photo.png", "url": "https://host/photo.png"}}}""",
+            assert: args =>
+            {
+                Assert.Equal("a-1", args.Detail.Id);
+                Assert.Equal("photo.png", args.Detail.Name);
+                Assert.Equal("https://host/photo.png", args.Detail.Url);
+            })
+        .Event(c => c.MessageReact,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"message": {"retType": "object", "type": "", "value": {"id": "m-1", "text": "hello"}}, "reaction": "like"}}}""",
+            assert: args =>
+            {
+                // The reaction's message currently decoded by value
+                // (it is NOT restored by reference to an instance in Messages on the current stack).
+                Assert.Equal("like", args.Detail.Reaction);
+                Assert.Equal("m-1", args.Detail.Message.Id);
+                Assert.Equal("hello", args.Detail.Message.Text);
+            })
+        .Prop(c => c.Options,
+            new IgbChatOptions
+            {
+                HeaderText = "Support",
+                SuggestionsPosition = ChatSuggestionsPosition.BelowMessages,
+                DisableAutoScroll = true,
+                Suggestions = ["How do I install?", "Show me theming"],
+            },
+            wire: new JsonSubset("""{"headerText": "Support", "suggestionsPosition": "below-messages", "disableAutoScroll": true, "suggestions": ["How do I install?", "Show me theming"]}"""))
+        .Prop(c => c.Messages,
+            [
+                new IgbChatMessage { Id = "m-1", Text = "hello", Sender = "user-1" },
+                new IgbChatMessage { Id = "m-2", Text = "hi there", Sender = "agent" },
+            ],
+            wire: new JsonSubset("""[{"id": "m-1", "text": "hello", "sender": "user-1"}, {"id": "m-2", "text": "hi there", "sender": "agent"}]"""))
+        .Prop(c => c.DraftMessage,
+            new IgbChatDraftMessage
+            {
+                Text = "draft text 2",
+                Attachments = [new IgbChatMessageAttachment { Id = "a-2", Url = "https://host/file.pdf", AttachmentType = "application/pdf", Thumbnail = "thumb.png" }],
+            },
+            wire: new JsonSubset("""{"text": "draft text 2", "attachments": [{"id": "a-2", "url": "https://host/file.pdf", "attachmentType": "application/pdf", "thumbnail": "thumb.png"}]}"""));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void Chat_RendersCorrectElement()
     {
@@ -18,7 +92,7 @@ public class ChatTests : BlazorComponentTestBase
         var chat = new IgbChat();
 
         Assert.NotNull(chat.Options);
-        Assert.True(chat.Options!.DisableInputAttachments);
+        Assert.True(chat.Options.DisableInputAttachments);
     }
 
     [Fact]
@@ -29,7 +103,7 @@ public class ChatTests : BlazorComponentTestBase
         chat.Options = null;
 
         Assert.NotNull(chat.Options);
-        Assert.True(chat.Options!.DisableInputAttachments);
+        Assert.True(chat.Options.DisableInputAttachments);
     }
 
     [Fact]
@@ -41,6 +115,6 @@ public class ChatTests : BlazorComponentTestBase
         chat.Options = options;
 
         Assert.NotNull(chat.Options);
-        Assert.True(chat.Options!.DisableInputAttachments);
+        Assert.True(chat.Options.DisableInputAttachments);
     }
 }

--- a/tests/IgniteUI.Blazor.Tests/CheckboxTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CheckboxTests.cs
@@ -1,10 +1,37 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class CheckboxTests : BlazorComponentTestBase
+public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
 {
+    protected override ComponentContract<IgbCheckbox> InteropContract { get; } = new ComponentContract<IgbCheckbox>()
+        .Getter(c => c.GetCurrentCheckedAsync(), c => c.GetCurrentChecked(), "Checked", returns: true)
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }), "focus",
+            args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.ClickAsync(), c => c.Click(), "click")
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("Please check this box"), c => c.SetCustomValidity("Please check this box"), "setCustomValidity",
+            args: ["Please check this box"], types: ["String"])
+        .Event(c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"checked": true, "value": "checkbox-value"}}}""",
+            assert: args =>
+            {
+                Assert.True(args.Detail.Checked);
+                Assert.Equal("checkbox-value", args.Detail.Value);
+            })
+        .Event(c => c.Focus)
+        .Event(c => c.Blur);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Checkbox_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/ChipTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ChipTests.cs
@@ -1,10 +1,26 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class ChipTests : BlazorComponentTestBase
+public class ChipTests : ComponentWithContractTestBase<IgbChip>
 {
+    protected override ComponentContract<IgbChip> InteropContract { get; } = new ComponentContract<IgbChip>()
+        .Getter(c => c.GetCurrentSelectedAsync(), c => c.GetCurrentSelected(), "Selected", returns: true)
+        .Event(c => c.Select,
+            argsJson: """{"detail": true}""",
+            assert: args => Assert.True(args.Detail))
+        .Event(c => c.Remove,
+            argsJson: """{"detail": true}""",
+            assert: args => Assert.True(args.Detail));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Chip_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/ComboTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComboTests.cs
@@ -1,9 +1,152 @@
+using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class ComboTests : BlazorComponentTestBase
+public class ComboItem
 {
+    public required string Text { get; set; }
+    public required int Id { get; set; }
+}
+
+public class ComboTests : ComponentWithContractTestBase<IgbCombo<ComboItem>>
+{
+    private static readonly ComboItem _valueItem1 = new() { Id = 1, Text = "First" };
+    private static readonly ComboItem _valueItem2 = new() { Id = 2, Text = "Second" };
+
+    // Data items cross as {"refType": "uuid", "id": "<guid>"} references (see
+    // JsonDataSourceItem.ToJson's "___id" marker), assigned once item is added to DS.
+    internal static string DataItemId(InteropHarness interop, IRenderedFragment cut, int index)
+    {
+        var items = interop.FindPropertyUpdate(interop.ContainerIdOf(cut), "data")!.Value.EnumerateArray().ToArray();
+        return items[index].GetProperty("___id").GetString()!;
+    }
+
+    internal static string UuidRef(InteropHarness interop, IRenderedFragment cut, int index) =>
+        $$"""{"refType": "uuid", "id": "{{DataItemId(interop, cut, index)}}"}""";
+
+    internal static string ChangeDetail(string newValues, string items, string type = "selection") =>
+        $$$$"""{"detail": {"retType": "object", "type": "WebComboChangeEventArgsDetail", "value": {"newValue": {"retType": "Array", "type": "", "value": [{{{{newValues}}}}]}, "items": {"retType": "Array", "type": "", "value": [{{{{items}}}}]}, "type": "{{{{type}}}}"}}}""";
+
+    protected override ComponentContract<IgbCombo<ComboItem>> InteropContract { get; } = new ComponentContract<IgbCombo<ComboItem>>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }), "focus",
+            args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.SelectAsync(["item-1"]), c => c.Select(["item-1"]), "select",
+            args: [new RawJson("""["item-1"]""")], types: [""])
+        .Method(c => c.DeselectAsync(["item-1"]), c => c.Deselect(["item-1"]), "deselect",
+            args: [new RawJson("""["item-1"]""")], types: [""])
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("invalid entry"), c => c.SetCustomValidity("invalid entry"), "setCustomValidity",
+            args: ["invalid entry"], types: ["String"])
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value",
+            arrange: ps => ps.Add(c => c.Data, new[] { _valueItem1, _valueItem2 }),
+            returns: (interop, cut) => InteropReturn.Array(
+                $$"""[{"refType": "uuid", "id": "{{DataItemId(interop, cut, 0)}}"}]"""),
+            assert: (cut, result) => Assert.Same(_valueItem1, Assert.Single(result)))
+        .Getter(c => c.GetSelectionAsync(), c => c.GetSelection(), "Selection",
+            arrange: ps => ps.Add(c => c.Data, new[] { _valueItem1, _valueItem2 }),
+            returns: (interop, cut) => InteropReturn.Array(
+                $$"""[{"refType": "uuid", "id": "{{DataItemId(interop, cut, 1)}}"}]"""),
+            assert: (cut, result) => Assert.Same(_valueItem2, Assert.Single(result)))
+        .Event(c => c.Change,
+            arrange: ps => ps.Add(c => c.Data, new[] { _valueItem1, _valueItem2 }),
+            argsJson: (interop, cut) => ChangeDetail(UuidRef(interop, cut, 0), UuidRef(interop, cut, 0)),
+            assert: (cut, args) =>
+            {
+                Assert.Same(_valueItem1, Assert.Single(args.Detail.NewValue));
+                Assert.Same(_valueItem1, Assert.Single(args.Detail.Items));
+                Assert.Equal(ComboChangeType.Selection, args.Detail.ChangeType);
+            })
+        .Event(c => c.Change,
+            arrange: ps => ps
+                .Add(c => c.Data, new[] { _valueItem1, _valueItem2 })
+                .Add(c => c.Value, [_valueItem1]),
+            argsJson: (interop, cut) => ChangeDetail("", UuidRef(interop, cut, 0), "deselection"),
+            assert: (cut, args) =>
+            {
+                Assert.Empty(args.Detail.NewValue);
+                Assert.Same(_valueItem1, Assert.Single(args.Detail.Items));
+                // TODO: wire detail carries kind as "type", but FromEventJson reads "changeType", so
+                // Detail.ChangeType never decodes and stays default (wrong for deselection events):
+                // Assert.Equal(ComboChangeType.Deselection, args.Detail.ChangeType);
+            })
+        .Event(c => c.Change,
+            arrange: ps => ps.Add(c => c.Data, new[] { _valueItem1, _valueItem2 }),
+            argsJson: (interop, cut) => ChangeDetail(
+                UuidRef(interop, cut, 0) + ", " + UuidRef(interop, cut, 1),
+                UuidRef(interop, cut, 0) + ", " + UuidRef(interop, cut, 1)),
+            assert: (cut, args) =>
+            {
+                // Multi-selection: every element resolves back to its original data instance.
+                Assert.Equal([_valueItem1, _valueItem2], args.Detail.NewValue);
+                Assert.Equal([_valueItem1, _valueItem2], args.Detail.Items);
+                Assert.Same(args.Detail.NewValue[0], args.Detail.Items[0]);
+            })
+        .Event(c => c.Focus)
+        .Event(c => c.Blur)
+        .Event(c => c.Opening)
+        .Event(c => c.Opened)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed)
+        .Prop(c => c.Open, true)
+        .Prop(c => c.Outlined, true)
+        .Prop(c => c.SingleSelect, true)
+        .Prop(c => c.Autofocus, true)
+        .Prop(c => c.AutofocusList, true)
+        .Prop(c => c.Locale, "en-US")
+        .Prop(c => c.Label, "Select item")
+        .Prop(c => c.Placeholder, "Choose...")
+        .Prop(c => c.PlaceholderSearch, "Search...")
+        .Prop(c => c.ValueKey, "Id")
+        .Prop(c => c.DisplayKey, "Text")
+        .Prop(c => c.GroupKey, "Text")
+        .Prop(c => c.GroupSorting, GroupingDirection.Desc, wire: "desc")
+        .Prop(c => c.FilteringOptions,
+            new IgbFilteringOptions
+            {
+                FilterKey = "text",
+                CaseSensitive = true,
+                MatchDiacritics = true,
+            },
+            wire: new JsonSubset("""{"filterKey": "text", "caseSensitive": true, "matchDiacritics": true}"""))
+        .Prop(c => c.CaseSensitiveIcon, true)
+        .Prop(c => c.DisableFiltering, true)
+        .Prop(c => c.DisableClear, true)
+        .Prop(c => c.Disabled, true)
+        .Prop(c => c.Required, true)
+        .Prop(c => c.Invalid, true)
+        // Value items tracked by the data source cross as uuid refs into it (the
+        // "___id" assigned on transfer); without Data arranged they'd fall to
+        // ObjectToParam's generic ToString() branch, which no real app hits.
+        .Prop(c => c.Value,
+            value: [_valueItem1],
+            arrange: ps => ps.Add(c => c.Data, new[] { _valueItem1, _valueItem2 }),
+            wire: (interop, cut) => new RawJson($"[{UuidRef(interop, cut, 0)}]"))
+        .Prop(c => c.Data,
+            new[]
+            {
+                new ComboItem { Id = 1, Text = "First" },
+                new ComboItem { Id = 2, Text = "Second" },
+            },
+            // Data source: crosses as a refChanged transfer under a generated ref id that the
+            // description advertises as "dataRef" (JSON marshalling channel, as on Blazor Server).
+            wire: new JsonSubset("""[{"Id": 1, "Text": "First"}, {"Id": 2, "Text": "Second"}]"""));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Combo_TypeMetadata()
     {
@@ -130,4 +273,45 @@ public class ComboTests : BlazorComponentTestBase
         combo.CaseSensitiveIcon = true;
         Assert.True(combo.CaseSensitiveIcon);
     }
+}
+
+// TODO: Mismatched T=int - handling (T[])DowncastArray<T>(Detail.NewValue) for
+// two-way Value propagation: a mismatched T (e.g. the item type on a keyed combo)
+// throws InvalidCastException — swallowed by OnRaiseEvent, so delivery silently dies;
+// and numeric keys decode as JSON numbers → boxed double, so T=int fails the unbox
+// cast too — numeric keys need T=double (or object).
+public class ComboValueKeyTests : ComponentWithContractTestBase<IgbCombo<double>>
+{
+
+    private static readonly ComboItem _item1 = new() { Id = 1, Text = "First" };
+    private static readonly ComboItem _item2 = new() { Id = 2, Text = "Second" };
+
+    static readonly Action<ComponentParameterCollectionBuilder<IgbCombo<double>>> arrange =
+        ps => ps
+            .Add(c => c.Data, new[] { _item1, _item2 })
+            .Add(c => c.ValueKey, "Id");
+
+    protected override ComponentContract<IgbCombo<double>> InteropContract { get; } = new ComponentContract<IgbCombo<double>>()
+        .Event(c => c.Change,
+            arrange,
+            argsJson: (interop, cut) => ComboTests.ChangeDetail("2", ComboTests.UuidRef(interop, cut, 1)),
+            assert: (cut, args) =>
+            {
+                Assert.Equal(2.0, Assert.Single(args.Detail.NewValue)); // numbers decode as double
+                Assert.Same(_item2, Assert.Single(args.Detail.Items));
+                // Two-way Value propagation through the generated wrapper works when T
+                // matches the key value type.
+                Assert.Equal(2.0, Assert.Single(cut.Instance.Value));
+            });
+    // TODO: Value set with struct types (int, double) doesn't work - RendererSerializer.AddArrayProp object cast
+    // .Prop(c => c.Value,
+    //     value: [1, 3],
+    //     arrange,
+    //     wire: (interop, cut) => new JsonSubset("[1, 3]"))
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
 }

--- a/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
@@ -1,0 +1,482 @@
+using System.Text.Json;
+using Bunit;
+using IgniteUI.Blazor.Tests.Interop;
+using Microsoft.AspNetCore.Components;
+using Xunit.Sdk;
+
+namespace IgniteUI.Blazor.Tests;
+
+/// <summary>
+/// Marker type so a violation from a contract spec never gets double-wrapped, while
+/// every other exception (asserts, harness errors, and unexpected ones like a bad cast
+/// inside a component's generated handler) gains the offending member's name.
+/// </summary>
+public sealed class ContractViolationException : XunitException
+{
+    private readonly string? _specFrame;
+
+    public ContractViolationException(string message, Exception inner, SpecSource? source)
+        : base(message, inner)
+    {
+        if (source is { File.Length: > 0 })
+        {
+            _specFrame = $"   at contract spec in {source.File}:line {source.Line}";
+        }
+    }
+
+    /// <summary>
+    /// Prepends the declaring contract line as a synthetic top frame, so test UIs
+    /// navigate to the violated spec instead of the shared runner.
+    /// </summary>
+    public override string? StackTrace => _specFrame is null
+        ? base.StackTrace
+        : _specFrame + Environment.NewLine + base.StackTrace;
+}
+
+/// <summary>
+/// Test base for component suites whose component has an interop surface: extends
+/// <see cref="BlazorComponentTestBase"/> with a declarative
+/// <see cref="ComponentContract{TComponent}"/> executed against the component's
+/// <see cref="InteropHarness"/> (resolved via <see cref="BlazorComponentTestBase.InteropFor{TComponent}"/>,
+/// so a component remapped to a new interop stack runs the same contract unchanged).
+/// Exactly one suite per component should carry the contract; components without
+/// interop (e.g. Badge) stay on <see cref="BlazorComponentTestBase"/>.
+/// </summary>
+public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponentTestBase
+    where TComponent : IComponent
+{
+    /// <summary>
+    /// The component's interop contract to exercise against a harness.
+    /// <remarks>
+    /// Pair with one or more specs:
+    /// <code>Methods_FollowContract() => <see cref="VerifyMethodContract"/></code>
+    /// <code>Props_FollowContract() => <see cref="VerifyPropContract"/></code>
+    /// <code>Events_FollowContract() => <see cref="VerifyEventContract"/></code>
+    /// Each method, property, and event in the contract is exercised in isolation, with a fresh component instance (or a shared instance for methods that don't require an arrangement).
+    /// The harness is primed to a ready state before each test, and any stubbed return values are set up before invoking the method or reading the property.
+    /// The test asserts that the expected interop calls are made with the correct arguments and types, and that the return values are as expected.
+    /// For events, the test raises the event with the specified arguments.
+    /// </remarks>
+    /// </summary>
+    protected abstract ComponentContract<TComponent> InteropContract { get; }
+
+    /// <summary>
+    /// Ensures a suite can't declare contract specs that never run: every non-empty
+    /// contract section must have its runner fact declared on the suite (they are
+    /// per-suite one-liners so failures navigate to the suite, and suites with nothing
+    /// to check in a section simply omit that fact).
+    /// </summary>
+    [Fact]
+    public void Contract_SectionsHaveFacts()
+    {
+        var contract = InteropContract;
+        RequireSectionFact(contract.Methods.Count > 0, "Methods_FollowContract", nameof(VerifyMethodContract));
+        RequireSectionFact(contract.Props.Count > 0, "Props_FollowContract", nameof(VerifyPropContract));
+        RequireSectionFact(contract.Events.Count > 0, "Events_FollowContract", nameof(VerifyEventContract));
+    }
+
+    private void RequireSectionFact(bool hasSpecs, string factName, string runnerName)
+    {
+        if (!hasSpecs)
+        {
+            return;
+        }
+        var fact = GetType().GetMethod(factName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        if (fact is null || fact.GetCustomAttributes(typeof(FactAttribute), true).Length == 0)
+        {
+            throw new XunitException(
+                $"{GetType().Name}'s contract declares specs that never run — add: " +
+                $"[Fact] public {(runnerName == nameof(VerifyMethodContract) ? "Task" : "void")} {factName}() => {runnerName}();");
+        }
+    }
+
+    /// <summary>
+    /// Runner for the contract's <c>.Method</c>/<c>.Getter</c> specs — expose it on the suite as
+    /// <c>[Fact] public Task Methods_FollowContract() => VerifyMethodContract();</c>.
+    /// For each spec: stubs the JS-side result, invokes the .NET API member, and asserts
+    /// the wire identifier, argument values, type tags, and the decoded return. Specs
+    /// without an arrangement share one rendered instance; arranged specs render their own.
+    /// </summary>
+    /// <exception cref="ContractViolationException">
+    /// Any spec failure, naming the violated member and carrying the declaring contract
+    /// line as the top stack frame.
+    /// </exception>
+    protected async Task VerifyMethodContract()
+    {
+        var harness = InteropFor<TComponent>();
+        harness.PrimeReady();
+        IRenderedComponent<TComponent>? sharedCut = null;
+
+        foreach (var method in InteropContract.Methods)
+        {
+            try
+            {
+                // Hosted specs render the parent structure and pick the cut out of it;
+                // specs with an arrangement render their own instance.
+                IRenderedComponent<TComponent> cut;
+                IRenderedFragment scope;
+                if (method.Host is not null)
+                {
+                    scope = Render(method.Host);
+                    cut = method.Target!(scope);
+                }
+                else
+                {
+                    cut = method.Arrange is null
+                        ? sharedCut ??= RenderComponent<TComponent>()
+                        : RenderComponent<TComponent>(ps => method.Arrange(ps));
+                    scope = cut;
+                }
+
+                if (method.ReadsProperty is not null)
+                {
+                    await RunGetterSpec(harness, cut, scope, method);
+                }
+                else
+                {
+                    await RunMethodSpec(harness, cut, scope, method);
+                }
+            }
+            catch (Exception ex) when (ex is not ContractViolationException)
+            {
+                var member = method.ReadsProperty is not null
+                    ? $"getter \"{method.ReadsProperty}\""
+                    : $"method \"{method.JsName}\"";
+                throw Violation(member, method.Source, ex);
+            }
+        }
+    }
+
+    /// <summary>Stub → invoke → assert the recorded call's identifier, args, and type tags, then the decoded return.</summary>
+    private static async Task RunMethodSpec(
+        InteropHarness harness, IRenderedComponent<TComponent> cut, IRenderedFragment scope, MethodContractSpec<TComponent> method)
+    {
+        // Stub immediately before invoking so specs may reuse a method name
+        // with different stubbed results.
+        var stub = method.StubFactory?.Invoke(harness, scope) ?? method.Stub;
+        if (stub is not null)
+        {
+            harness.SetupMethodResult(method.JsName!, stub);
+        }
+
+        var containerId = harness.ContainerIdOf(cut);
+        var (call, result) = await InvokeExpectingNewCall(
+            () => harness.CallsOf(method.JsName!, containerId),
+            () => method.Invoke(cut.Instance),
+            $"\"{method.JsName}\" sent no new invocation");
+        AssertCallShape(method, call, result);
+        method.AssertReturnWithCut?.Invoke(scope, result);
+
+        if (method.SyncInvoke is not null)
+        {
+            // The sync twin must produce the same invocation and decode the same reply
+            // (the stub persists) to the same result.
+            var (syncCall, syncResult) = await InvokeExpectingNewCall(
+                () => harness.CallsOf(method.JsName!, containerId),
+                () => Task.FromResult(method.SyncInvoke(cut.Instance)),
+                $"sync twin \"{method.JsName}\" sent no new invocation");
+            AssertCallShape(method, syncCall, syncResult);
+            method.AssertReturnWithCut?.Invoke(scope, syncResult);
+        }
+    }
+
+    /// <summary>
+    /// Runs an invocation and returns the newest call it added to the matching set —
+    /// requiring a NEW entry regardless of prior history, so specs may chain the same
+    /// member repeatedly (different args/stubs) without matching a predecessor's call.
+    /// </summary>
+    private static async Task<(InteropMethodCall Call, object? Result)> InvokeExpectingNewCall(
+        Func<IEnumerable<InteropMethodCall>> matching,
+        Func<Task<object?>> invoke,
+        string noNewCallMessage)
+    {
+        var before = matching().Count();
+        var result = await invoke();
+        var after = matching().ToList();
+        if (after.Count <= before)
+        {
+            throw new XunitException(noNewCallMessage);
+        }
+        return (after[^1], result);
+    }
+
+    /// <summary>Asserts a recorded invocation matches the spec's expected args and type tags.</summary>
+    private static void AssertCallShape(MethodContractSpec<TComponent> method, InteropMethodCall call, object? result)
+    {
+        Assert.Equal(method.ExpectedTypes, call.Types);
+        Assert.Equal(method.ExpectedArgs.Length, call.Arguments.Count);
+        for (var i = 0; i < method.ExpectedArgs.Length; i++)
+        {
+            AssertWireValue(method.ExpectedArgs[i], call.Arguments[i]);
+        }
+
+        if (method.HasExpectedReturn)
+        {
+            AssertReturn(method.ExpectedReturn, result);
+        }
+    }
+
+    /// <summary>Stub the property's JS-side value → invoke → assert a current-state read was issued and the return decoded.</summary>
+    private static async Task RunGetterSpec(
+        InteropHarness harness, IRenderedComponent<TComponent> cut, IRenderedFragment scope, MethodContractSpec<TComponent> method)
+    {
+        var stub = method.StubFactory?.Invoke(harness, scope) ?? method.Stub;
+        harness.SetupPropertyRead(method.ReadsProperty!, stub!);
+
+        var containerId = harness.ContainerIdOf(cut);
+        var (_, result) = await InvokeExpectingNewCall(
+            () => harness.PropertyReads(containerId, method.ReadsProperty!),
+            () => method.Invoke(cut.Instance),
+            "no new current-state read was issued for the property");
+        if (method.HasExpectedReturn)
+        {
+            AssertReturn(method.ExpectedReturn, result);
+        }
+        method.AssertReturnWithCut?.Invoke(scope, result);
+
+        if (method.SyncInvoke is not null)
+        {
+            // The sync twin must issue its own read (the read's wire identifier stays
+            // harness-owned) and decode the persisting stub to the same result.
+            var (_, syncResult) = await InvokeExpectingNewCall(
+                () => harness.PropertyReads(containerId, method.ReadsProperty!),
+                () => Task.FromResult(method.SyncInvoke(cut.Instance)),
+                $"sync twin issued no new current-state read for \"{method.ReadsProperty}\"");
+            if (method.HasExpectedReturn)
+            {
+                AssertReturn(method.ExpectedReturn, syncResult);
+            }
+            method.AssertReturnWithCut?.Invoke(scope, syncResult);
+        }
+    }
+
+    /// <summary>
+    /// Runner for the contract's <c>.Prop</c> specs — expose it on the suite as
+    /// <c>[Fact] public void Props_FollowContract() => VerifyPropContract();</c>.
+    /// Renders a fresh instance per spec with the parameter (plus any arrangement) set,
+    /// then asserts a property update carrying the expected wire value was transmitted —
+    /// on whichever channel the current stack uses (the harness abstracts state
+    /// descriptions vs. ref transfers).
+    /// </summary>
+    /// <exception cref="ContractViolationException">
+    /// Any spec failure, naming the violated member and carrying the declaring contract
+    /// line as the top stack frame.
+    /// </exception>
+    protected void VerifyPropContract()
+    {
+        var harness = InteropFor<TComponent>();
+        harness.PrimeReady();
+        foreach (var prop in InteropContract.Props)
+        {
+            try
+            {
+                var cut = RenderComponent<TComponent>(ps =>
+                {
+                    prop.Arrange?.Invoke(ps);
+                    prop.Set(ps);
+                });
+
+                var actual = harness.FindPropertyUpdate(harness.ContainerIdOf(cut), prop.WireName);
+
+                if (actual is null)
+                {
+                    throw new XunitException(
+                        "no property update transmission was observed — check the wire name, " +
+                        "and whether this prop crosses as a rendered attribute instead (not a .Prop case)");
+                }
+                var expected = prop.ExpectedValueFactory is not null
+                    ? prop.ExpectedValueFactory(harness, cut)
+                    : prop.ExpectedValue;
+                AssertWireValue(expected, actual.Value);
+            }
+            catch (Exception ex) when (ex is not ContractViolationException)
+            {
+                throw Violation($"prop \"{prop.WireName}\"", prop.Source, ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runner for the contract's <c>.Event</c> specs — expose it on the suite as
+    /// <c>[Fact] public void Events_FollowContract() => VerifyEventContract();</c>.
+    /// Renders a fresh instance per spec with the callback bound (plus any arrangement),
+    /// then verifies the full loop: the member returns the exact callback bound and an
+    /// event-handler registration transmits over interop (the client's cue to subscribe); the
+    /// spec's args payload dispatched under the wire event name reaches the handler
+    /// with args of the declared type satisfying the spec's asserts; and unbinding
+    /// (setting the parameter back to an empty callback) resets the member, transmits
+    /// the cleared registration (the client's cue to unsubscribe), and stops delivery —
+    /// a subsequent dispatch must not reach the handler.
+    /// </summary>
+    /// <exception cref="ContractViolationException">
+    /// Any spec failure, naming the violated member and carrying the declaring contract
+    /// line as the top stack frame.
+    /// </exception>
+    protected void VerifyEventContract()
+    {
+        var harness = InteropFor<TComponent>();
+        // Dispatch itself needs no readiness, but arranged data (e.g. data-source items
+        // referenced by uuid in payloads) only transfers once the component is ready.
+        harness.PrimeReady();
+        foreach (var evt in InteropContract.Events)
+        {
+            try
+            {
+                object? received = null;
+                object bound = null!;
+                var cut = RenderComponent<TComponent>(ps =>
+                {
+                    evt.Arrange?.Invoke(ps);
+                    bound = evt.Bind(ps, args => received = args);
+                });
+                var containerId = harness.ContainerIdOf(cut);
+
+                // Binding must round-trip: the member returns the exact callback
+                // assigned — and it must transmit an event-handler registration
+                // (the client's cue to subscribe) carrying the member's event
+                // identity; dispatch alone can't catch a registration that never
+                // reached the wire.
+                Assert.Equal(bound, evt.Get(cut.Instance));
+                var wireName = char.ToLowerInvariant(evt.EventName[0]) + evt.EventName[1..];
+                var registration = harness.FindPropertyUpdate(containerId, wireName)
+                    ?? throw new XunitException("no event-handler registration transmission was observed");
+                Assert.Equal(evt.EventName, registration.GetString());
+
+                var argsJson = evt.ArgsJsonFactory?.Invoke(harness, cut) ?? evt.ArgsJson;
+                harness.RaiseEvent(containerId, evt.EventName, argsJson);
+
+                if (received is null)
+                {
+                    // Dispatch failures are swallowed by the control, so a missing
+                    // callback is the signal for a wrong name or malformed payload.
+                    throw new XunitException(
+                        "handler was not invoked — check the event name and the args JSON shape");
+                }
+                Assert.IsAssignableFrom(evt.ArgsType, received);
+                evt.AssertArgs?.Invoke(received);
+                evt.AssertWithComponent?.Invoke(cut.Instance, received);
+                evt.AssertWithCut?.Invoke(cut, received);
+
+                // TODO: removing a bound callback crashes today, on either path. Razor-bound
+                // values arrive wrapped by EventCallback.Factory.Create, so a "default"
+                // carries a Receiver with a null Delegate — that fails the setter's Empty
+                // check, takes the *bound* branch, and NREs in
+                // BaseRendererControl.CompareEventCallbacks on leftDelegate.Equals(...);
+                // a raw Empty (what bUnit/programmatic SetParameters passes) does reach the
+                // unset branch and NREs in OnRefChanged on newValue.ToString(). Once fixed,
+                // validate the removal round-trip; pin the actual cleared wire shape then:
+                // cut.SetParametersAndRender(ps => bound = evt.Bind(ps, null));
+                // Assert.Equal(bound, evt.Get(cut.Instance)); // member resets to the empty callback
+                // var cleared = harness.FindPropertyUpdate(containerId, wireName);
+                // Assert.Equal(JsonValueKind.Null, cleared!.Value.ValueKind);
+                // received = null;
+                // harness.RaiseEvent(containerId, evt.EventName, argsJson);
+                // Assert.Null(received); // deregistered handlers must not be invoked
+            }
+            catch (Exception ex) when (ex is not ContractViolationException)
+            {
+                throw Violation($"event \"{evt.EventName}\"", evt.Source, ex);
+            }
+        }
+    }
+
+    /// <summary>Wraps a spec failure with the component and member it violates (see <see cref="ContractViolationException"/>).</summary>
+    private static ContractViolationException Violation(string member, SpecSource? source, Exception inner) =>
+        new($"{typeof(TComponent).Name} contract violated at {member}: {inner.Message}", inner, source);
+
+    /// <summary>
+    /// Compares an expected contract value against the transmitted JSON: scalars by value
+    /// (numbers as double, dates as instants), <see cref="RawJson"/> structurally and
+    /// exactly, <see cref="JsonSubset"/> per <see cref="AssertJsonSubset"/>.
+    /// </summary>
+    private static void AssertWireValue(object? expected, JsonElement actual)
+    {
+        switch (expected)
+        {
+            case null:
+                Assert.Equal(JsonValueKind.Null, actual.ValueKind);
+                break;
+            case bool b:
+                Assert.Equal(b ? JsonValueKind.True : JsonValueKind.False, actual.ValueKind);
+                break;
+            case string s:
+                Assert.Equal(JsonValueKind.String, actual.ValueKind);
+                Assert.Equal(s, actual.GetString());
+                break;
+            case DateTime dt:
+                Assert.Equal(JsonValueKind.String, actual.ValueKind);
+                Assert.Equal(
+                    dt.ToUniversalTime(),
+                    DateTime.Parse(actual.GetString()!, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime());
+                break;
+            case RawJson raw:
+                using (var doc = JsonDocument.Parse(raw.Json))
+                {
+                    Assert.Equal(JsonSerializer.Serialize(doc.RootElement), JsonSerializer.Serialize(actual));
+                }
+                break;
+            case JsonSubset subset:
+                using (var doc = JsonDocument.Parse(subset.Json))
+                {
+                    AssertJsonSubset(doc.RootElement, actual);
+                }
+                break;
+            case IConvertible:
+                Assert.Equal(JsonValueKind.Number, actual.ValueKind);
+                Assert.Equal(Convert.ToDouble(expected), actual.GetDouble());
+                break;
+            default:
+                throw new ArgumentException(
+                    $"Unsupported expected wire value of type {expected.GetType().Name}; use RawJson for structured values.");
+        }
+    }
+
+    /// <summary>
+    /// Subset comparison: objects require every expected property to match (extra actual
+    /// properties are ignored, recursively); arrays require equal length with element-wise
+    /// subset matching; scalars compare exactly.
+    /// </summary>
+    private static void AssertJsonSubset(JsonElement expected, JsonElement actual)
+    {
+        switch (expected.ValueKind)
+        {
+            case JsonValueKind.Object:
+                Assert.Equal(JsonValueKind.Object, actual.ValueKind);
+                foreach (var expectedProp in expected.EnumerateObject())
+                {
+                    if (!actual.TryGetProperty(expectedProp.Name, out var actualProp))
+                    {
+                        throw new XunitException(
+                            $"expected property \"{expectedProp.Name}\" missing from transmitted value: {actual}");
+                    }
+                    AssertJsonSubset(expectedProp.Value, actualProp);
+                }
+                break;
+            case JsonValueKind.Array:
+                Assert.Equal(JsonValueKind.Array, actual.ValueKind);
+                Assert.Equal(expected.GetArrayLength(), actual.GetArrayLength());
+                var actualItems = actual.EnumerateArray().ToArray();
+                var i = 0;
+                foreach (var expectedItem in expected.EnumerateArray())
+                {
+                    AssertJsonSubset(expectedItem, actualItems[i++]);
+                }
+                break;
+            default:
+                Assert.Equal(JsonSerializer.Serialize(expected), JsonSerializer.Serialize(actual));
+                break;
+        }
+    }
+
+    /// <summary>Compares a decoded .NET return against the spec's expected value.</summary>
+    private static void AssertReturn(object? expected, object? actual)
+    {
+        // Date returns are decoded to local time; compare instants instead of kinds.
+        if (expected is DateTime expectedDate && actual is DateTime actualDate)
+        {
+            Assert.Equal(expectedDate.ToUniversalTime(), actualDate.ToUniversalTime());
+            return;
+        }
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/DatePickerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DatePickerTests.cs
@@ -1,9 +1,96 @@
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class DatePickerTests : BlazorComponentTestBase
+public class DatePickerTests : ComponentWithContractTestBase<IgbDatePicker>
 {
+    protected override ComponentContract<IgbDatePicker> InteropContract { get; } = new ComponentContract<IgbDatePicker>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Method(c => c.ClearAsync(), c => c.Clear(), "clear")
+        .Method(c => c.StepUpAsync(DatePart.Month, 2), c => c.StepUp(DatePart.Month, 2), "stepUp",
+            args: ["month", 2.0], types: ["Json", "Number"])
+        .Method(c => c.StepDownAsync(DatePart.Year, 3), c => c.StepDown(DatePart.Year, 3), "stepDown",
+            args: ["year", 3.0], types: ["Json", "Number"])
+        .Method(c => c.SelectAsync(), c => c.Select(), "select")
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("Please choose a valid date"), c => c.SetCustomValidity("Please choose a valid date"),
+            "setCustomValidity", args: ["Please choose a valid date"], types: ["String"])
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value",
+            returns: new DateTime(2026, 3, 15, 9, 30, 0, DateTimeKind.Utc))
+        .Event(c => c.Opening)
+        .Event(c => c.Opened)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed)
+        .Event(c => c.Change,
+            argsJson: """{"detail": "2026-01-02T03:04:05.000Z"}""",
+            assert: args => Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), args.Detail.ToUniversalTime()))
+        .Event(c => c.Input,
+            argsJson: """{"detail": "2026-01-02T03:04:05.000Z"}""",
+            assert: args => Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), args.Detail.ToUniversalTime()))
+        .Prop(c => c.Open, true)
+        .Prop(c => c.KeepOpenOnSelect, true)
+        .Prop(c => c.KeepOpenOnOutsideClick, true)
+        .Prop(c => c.Label, "Pick a date")
+        .Prop(c => c.Mode, PickerMode.Dialog, wire: "dialog")
+        .Prop(c => c.NonEditable, true)
+        .Prop(c => c.ReadOnly, true)
+        .Prop(c => c.Value, new DateTime(2026, 3, 15, 9, 30, 0))
+        .Prop(c => c.ActiveDate, new DateTime(2026, 4, 1))
+        .Prop(c => c.Min, new DateTime(2026, 1, 1))
+        .Prop(c => c.Max, new DateTime(2026, 12, 31))
+        .Prop(c => c.HeaderOrientation, CalendarHeaderOrientation.Vertical, wire: "vertical")
+        .Prop(c => c.Orientation, ContentOrientation.Vertical, wire: "vertical")
+        .Prop(c => c.HideHeader, true)
+        .Prop(c => c.HideOutsideDays, true)
+        .Prop(c => c.DisabledDates,
+            [
+                new IgbDateRangeDescriptor { RangeType = DateRangeType.Weekends },
+                new IgbDateRangeDescriptor
+                {
+                    RangeType = DateRangeType.Specific,
+                    DateRange = new DateTime(2026, 12, 25, 0, 0, 0, DateTimeKind.Utc),
+                },
+            ],
+            wire: new JsonSubset("""[{"rangeType": "weekends"}, {"rangeType": "specific", "dateRange": "@d:2026-12-25T00:00:00.0000000Z"}]"""))
+        .Prop(c => c.SpecialDates,
+            [
+                new IgbDateRangeDescriptor { RangeType = DateRangeType.Weekdays },
+            ],
+            wire: new JsonSubset("""[{"rangeType": "weekdays"}]"""))
+        .Prop(c => c.Outlined, true)
+        .Prop(c => c.Placeholder, "mm/dd/yyyy")
+        .Prop(c => c.VisibleMonths, 2.0)
+        .Prop(c => c.ShowWeekNumbers, true)
+        .Prop(c => c.DisplayFormat, "MM/dd/yyyy")
+        .Prop(c => c.InputFormat, "MM/dd/yyyy")
+        .Prop(c => c.Prompt, "_")
+        .Prop(c => c.Locale, "en-US")
+        .Prop(c => c.ResourceStrings,
+            new IgbCalendarResourceStrings
+            {
+                SelectMonth = "Choose month",
+                SelectYear = "Choose year",
+                WeekLabel = "Wk",
+            },
+            wire: new JsonSubset("""{"selectMonth": "Choose month", "selectYear": "Choose year", "weekLabel": "Wk"}"""))
+        .Prop(c => c.WeekStart, WeekDays.Monday, wire: "monday")
+        .Prop(c => c.Disabled, true)
+        .Prop(c => c.Required, true)
+        .Prop(c => c.Invalid, true);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void DatePicker_TypeMetadata()
     {

--- a/tests/IgniteUI.Blazor.Tests/DateRangePickerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DateRangePickerTests.cs
@@ -1,0 +1,132 @@
+using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
+
+namespace IgniteUI.Blazor.Tests;
+
+public class DateRangePickerTests : ComponentWithContractTestBase<IgbDateRangePicker>
+{
+    private static readonly IgbDateRangeValue _selectValue = new()
+    {
+        Start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+        End = new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc),
+    };
+
+    protected override ComponentContract<IgbDateRangePicker> InteropContract { get; } = new ComponentContract<IgbDateRangePicker>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Method(c => c.ClearAsync(), c => c.Clear(), "clear")
+        .Method(
+            c => c.SelectAsync(_selectValue), c => c.Select(_selectValue), "select",
+            // TODO: "WebDateRangeValue" not in MarshalByValueFactory, so ObjectToParam
+            // does not serialize as {start, end} during serialization; it falls through to
+            // BaseRendererElement branch and sends an "reference" instead (to nothing):
+            //args: [new JsonSubset("""{"start": "2026-03-01T00:00:00.0000000Z", "end": "2026-03-10T00:00:00.0000000Z"}""")], types: ["Json"]),
+            args: [new RawJson($$"""{"refType": "name", "id": "{{_selectValue.Name}}"}""")],
+            types: ["Json"])
+        // TODO: Same "WebDateRangeValue" not in MarshalByValueFactory issue:
+        //.Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value",
+        //     arrange: _ => { },
+        //     returns: (interop, cut) => InteropReturn.Object("WebDateRangeValue",
+        //         """{"start": "2026-03-01T00:00:00.0000000Z", "end": "2026-03-10T00:00:00.0000000Z"}"""),
+        //     assert: (cut, result) =>
+        //     {
+        //         //Assert.Equal(new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc), result.Start.ToUniversalTime());
+        //         //Assert.Equal(new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc), result.End.ToUniversalTime());
+        //     })
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("Please choose a valid range"), c => c.SetCustomValidity("Please choose a valid range"), "setCustomValidity",
+            args: ["Please choose a valid range"], types: ["String"])
+        .Event(c => c.Opening)
+        .Event(c => c.Opened)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed)
+        .Event(c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"start": "2026-03-01T00:00:00.000Z", "end": "2026-03-10T00:00:00.000Z"}}}""",
+            assert: args =>
+            {
+                Assert.Equal(new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc), args.Detail.Start.ToUniversalTime());
+                Assert.Equal(new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc), args.Detail.End.ToUniversalTime());
+            })
+        .Event(c => c.Input,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"start": "2026-03-01T00:00:00.000Z", "end": "2026-03-10T00:00:00.000Z"}}}""",
+            assert: args =>
+            {
+                Assert.Equal(new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc), args.Detail.Start.ToUniversalTime());
+                Assert.Equal(new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc), args.Detail.End.ToUniversalTime());
+            })
+        .Prop(c => c.Open, true)
+        .Prop(c => c.KeepOpenOnSelect, true)
+        .Prop(c => c.KeepOpenOnOutsideClick, true)
+        .Prop(c => c.Value,
+            new IgbDateRangeValue
+            {
+                Start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+                End = new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc),
+            },
+            wire: new JsonSubset("""{"start": "2026-03-01T00:00:00.0000000Z", "end": "2026-03-10T00:00:00.0000000Z"}"""))
+        .Prop(c => c.CustomRanges,
+            [
+                new IgbCustomDateRange
+                {
+                    Label = "This week",
+                    DateRange = new IgbDateRangeValue
+                    {
+                        Start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+                        End = new DateTime(2026, 3, 7, 0, 0, 0, DateTimeKind.Utc),
+                    },
+                },
+            ],
+            wire: new JsonSubset("""[{"label": "This week", "dateRange": {"start": "2026-03-01T00:00:00.0000000Z", "end": "2026-03-07T00:00:00.0000000Z"}}]"""))
+        .Prop(c => c.Mode, PickerMode.Dialog, wire: "dialog")
+        .Prop(c => c.UseTwoInputs, true)
+        .Prop(c => c.UsePredefinedRanges, true)
+        .Prop(c => c.Locale, "en-US")
+        .Prop(c => c.ResourceStrings, new IgbDateRangePickerResourceStrings(), wire: new JsonSubset("""{}"""))
+        .Prop(c => c.ReadOnly, true)
+        .Prop(c => c.NonEditable, true)
+        .Prop(c => c.Outlined, true)
+        .Prop(c => c.Label, "Date range")
+        .Prop(c => c.LabelStart, "From")
+        .Prop(c => c.LabelEnd, "To")
+        .Prop(c => c.Placeholder, "mm/dd/yyyy - mm/dd/yyyy")
+        .Prop(c => c.PlaceholderStart, "mm/dd/yyyy")
+        .Prop(c => c.PlaceholderEnd, "mm/dd/yyyy")
+        .Prop(c => c.Prompt, "_")
+        .Prop(c => c.DisplayFormat, "MM/dd/yyyy")
+        .Prop(c => c.InputFormat, "MM/dd/yyyy")
+        .Prop(c => c.Min, new DateTime(2026, 1, 1))
+        .Prop(c => c.Max, new DateTime(2026, 12, 31))
+        .Prop(c => c.DisabledDates,
+            [
+                new IgbDateRangeDescriptor { RangeType = DateRangeType.Weekends },
+                new IgbDateRangeDescriptor { RangeType = DateRangeType.Specific, DateRange = new DateTime(2026, 3, 1) },
+            ],
+            wire: new JsonSubset($$"""[{"rangeType": "weekends"}, {"rangeType": "specific", "dateRange": "@d:2026-03-01T00:00:00.0000000"}]"""))
+        .Prop(c => c.SpecialDates,
+            [
+                new IgbDateRangeDescriptor { RangeType = DateRangeType.Weekdays },
+            ],
+            wire: new JsonSubset("""[{"rangeType": "weekdays"}]"""))
+        .Prop(c => c.VisibleMonths, 2.0)
+        .Prop(c => c.HeaderOrientation, ContentOrientation.Vertical, wire: "vertical")
+        .Prop(c => c.Orientation, ContentOrientation.Vertical, wire: "vertical")
+        .Prop(c => c.HideHeader, true)
+        .Prop(c => c.ActiveDate, new DateTime(2026, 4, 1))
+        .Prop(c => c.ShowWeekNumbers, true)
+        .Prop(c => c.HideOutsideDays, true)
+        .Prop(c => c.WeekStart, WeekDays.Monday, wire: "monday")
+        .Prop(c => c.Disabled, true)
+        .Prop(c => c.Required, true)
+        .Prop(c => c.Invalid, true);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+}

--- a/tests/IgniteUI.Blazor.Tests/DateTimeInputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DateTimeInputTests.cs
@@ -1,10 +1,65 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class DateTimeInputTests : BlazorComponentTestBase
+public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput>
 {
+    protected override ComponentContract<IgbDateTimeInput> InteropContract { get; } = new ComponentContract<IgbDateTimeInput>()
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: new DateTime(2026, 7, 4, 12, 30, 0, DateTimeKind.Utc))
+        .Method(c => c.StepUpAsync(DatePart.Month, 2), c => c.StepUp(DatePart.Month, 2), "stepUp", args: ["month", 2.0], types: ["Json", "Number"])
+        .Method(c => c.StepDownAsync(DatePart.Hours, 3), c => c.StepDown(DatePart.Hours, 3), "stepDown", args: ["hours", 3.0], types: ["Json", "Number"])
+        .Method(c => c.ClearAsync(), c => c.Clear(), "clear")
+        .Method(c => c.SelectAsync(), c => c.Select(), "select")
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }), "focus",
+            args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.HasDatePartsAsync(), c => c.HasDateParts(), "hasDateParts", returns: true)
+        .Method(c => c.HasTimePartsAsync(), c => c.HasTimeParts(), "hasTimeParts", returns: false)
+        .Method(c => c.SetSelectionRangeAsync(1, 3, "forward"), c => c.SetSelectionRange(1, 3, "forward"), "setSelectionRange",
+            args: [1.0, 3.0, "forward"], types: ["Number", "Number", "String"])
+        .Method(c => c.SetRangeTextAsync("abc", 1, 3, "end"), c => c.SetRangeText("abc", 1, 3, "end"), "setRangeText",
+            args: ["abc", 1.0, 3.0, "end"], types: ["String", "Number", "Number", "String"])
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("custom message"), c => c.SetCustomValidity("custom message"), "setCustomValidity",
+            args: ["custom message"], types: ["String"])
+        .Event(c => c.Change,
+            argsJson: """{"detail": "2026-01-02T03:04:05.000Z"}""",
+            assert: args => Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), args.Detail.ToUniversalTime()))
+        .Event(c => c.InputOcurred,
+            argsJson: """{"detail": "typed text"}""", assert: args => Assert.Equal("typed text", args.Detail))
+        .Event(c => c.Focus)
+        .Event(c => c.Blur)
+        .Prop(c => c.Outlined, true)
+        .Prop(c => c.Placeholder, "Enter date")
+        .Prop(c => c.Label, "Date")
+        .Prop(c => c.InputFormat, "dd/MM/yyyy")
+        .Prop(c => c.Min, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+        .Prop(c => c.Max, new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+        .Prop(c => c.DisplayFormat, "MMMM dd, yyyy")
+        .Prop(c => c.SpinDelta, new IgbDatePartDeltas { Hours = 2, Minutes = 5 },
+            wire: new JsonSubset("""{"hours": 2, "minutes": 5}"""))
+        .Prop(c => c.SpinLoop, true)
+        .Prop(c => c.Locale, "en-GB")
+        .Prop(c => c.ReadOnly, true)
+        .Prop(c => c.Mask, "00/00/0000")
+        .Prop(c => c.Prompt, "*")
+        .Prop(c => c.Disabled, true)
+        .Prop(c => c.Required, true)
+        .Prop(c => c.Invalid, true)
+        .Prop(c => c.Value, new DateTime(2026, 3, 4, 8, 0, 0, DateTimeKind.Utc));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/DialogTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DialogTests.cs
@@ -1,10 +1,24 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class DialogTests : BlazorComponentTestBase
+public class DialogTests : ComponentWithContractTestBase<IgbDialog>
 {
+    protected override ComponentContract<IgbDialog> InteropContract { get; } = new ComponentContract<IgbDialog>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Dialog_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/DropdownTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DropdownTests.cs
@@ -1,10 +1,85 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class DropdownTests : BlazorComponentTestBase
+public class DropdownTests : ComponentWithContractTestBase<IgbDropdown>
 {
+    /// <summary>Arranges two IgbDropdownItem children</summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbDropdown>> itemsArrange =
+        ps => ps.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IgbDropdownItem>(0);
+            builder.AddAttribute(1, "id", "item-1");
+            builder.CloseComponent();
+            builder.OpenComponent<IgbDropdownItem>(2);
+            builder.AddAttribute(3, "id", "item-2");
+            builder.CloseComponent();
+        });
+
+    /// <summary>Arranges two IgbDropdownGroup children</summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbDropdown>> groupsArrange =
+        ps => ps.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IgbDropdownGroup>(0);
+            builder.AddAttribute(1, "id", "group-1");
+            builder.CloseComponent();
+            builder.OpenComponent<IgbDropdownGroup>(2);
+            builder.AddAttribute(3, "id", "group-2");
+            builder.CloseComponent();
+        });
+
+    protected override ComponentContract<IgbDropdown> InteropContract { get; } = new ComponentContract<IgbDropdown>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Method(c => c.ClearSelectionAsync(), c => c.ClearSelection(), "clearSelection")
+        .Method(c => c.SelectAsync("item-1"), c => c.Select("item-1"), "select",
+            InteropReturn.Undefined, expect: null!, args: ["item-1"], types: ["Json"])
+        .Method(c => c.NavigateToAsync(2), c => c.NavigateTo(2), "navigateTo",
+            InteropReturn.Undefined, expect: null!, args: [2.0], types: ["Json"])
+        .Getter(c => c.GetItemsAsync(), c => c.GetItems(), "Items",
+            itemsArrange,
+            returns: (interop, cut) => InteropReturn.Array($$$"""[{"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-dropdown-item:nth-of-type(1)")}}}"}, {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-dropdown-item:nth-of-type(2)")}}}"}]"""),
+            assert: (cut, result) =>
+            {
+                Assert.Equal(2, result.Length);
+                Assert.Same(cut.FindComponents<IgbDropdownItem>()[0].Instance, result[0]);
+                Assert.Same(cut.FindComponents<IgbDropdownItem>()[1].Instance, result[1]);
+            })
+        .Getter(c => c.GetGroupsAsync(), c => c.GetGroups(), "Groups",
+            groupsArrange,
+            returns: (interop, cut) => InteropReturn.Array($$$"""[{"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-dropdown-group:nth-of-type(1)")}}}"}, {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-dropdown-group:nth-of-type(2)")}}}"}]"""),
+            assert: (cut, result) =>
+            {
+                Assert.Equal(2, result.Length);
+                // TODO: unlike IgbDropdownItem (registers via the "DropdownParent" CascadingParameter,
+                // resolved through IgbDropdown.ContentItems), IgbDropdownGroup carries no CascadingParameter
+                // and there's no FindByNameDropdownGroup impl., so the refs currently resolve to null elements;
+                // Assert.Same(cut.FindComponents<IgbDropdownGroup>()[0].Instance, result[0]);
+                // Assert.Same(cut.FindComponents<IgbDropdownGroup>()[1].Instance, result[1]);
+            })
+        .Getter(c => c.GetSelectedItemAsync(), c => c.GetSelectedItem(), "SelectedItem", InteropReturn.Undefined, expect: null!)
+        .Getter(c => c.GetSelectedItemAsync(), c => c.GetSelectedItem(), "SelectedItem",
+            itemsArrange,
+            returns: (interop, cut) => InteropReturn.Ref($$"""{"refType": "name", "id": "{{interop.ContainerIdOf(cut, "igc-dropdown-item:nth-of-type(1)")}}"}"""),
+            assert: (cut, result) => Assert.Same(cut.FindComponents<IgbDropdownItem>()[0].Instance, result))
+        .Event(c => c.Opening)
+        .Event(c => c.Opened)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed)
+        .Event(c => c.Change,
+            itemsArrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-dropdown-item:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbDropdownItem>()[1].Instance, args.Detail));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Dropdown_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/ExpansionPanelTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ExpansionPanelTests.cs
@@ -1,10 +1,36 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class ExpansionPanelTests : BlazorComponentTestBase
+public class ExpansionPanelTests : ComponentWithContractTestBase<IgbExpansionPanel>
 {
+    // The panel's own events carry a self-reference detail ({"refType": "name",
+    // "id": "mainControl"}) that must resolve back to the .NET instance via FindByName.
+    protected override ComponentContract<IgbExpansionPanel> InteropContract { get; } = new ComponentContract<IgbExpansionPanel>()
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Event(c => c.Opening,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (panel, args) => Assert.Same(panel, args.Detail))
+        .Event(c => c.Opened,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (panel, args) => Assert.Same(panel, args.Detail))
+        .Event(c => c.Closing,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (panel, args) => Assert.Same(panel, args.Detail))
+        .Event(c => c.Closed,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (panel, args) => Assert.Same(panel, args.Detail));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void ExpansionPanel_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/HighlightTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/HighlightTests.cs
@@ -1,10 +1,25 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class HighlightTests : BlazorComponentTestBase
+public class HighlightTests : ComponentWithContractTestBase<IgbHighlight>
 {
+    protected override ComponentContract<IgbHighlight> InteropContract { get; } = new ComponentContract<IgbHighlight>()
+        .Getter(c => c.GetSizeAsync(), c => c.GetSize(), "Size", returns: 3.0)
+        .Getter(c => c.GetCurrentAsync(), c => c.GetCurrent(), "Current", returns: 1.0)
+        .Method(c => c.NextAsync(new IgbHighlightNavigation { PreventScroll = true }), c => c.Next(new IgbHighlightNavigation { PreventScroll = true }),
+            "next", args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.PreviousAsync(new IgbHighlightNavigation { PreventScroll = false }), c => c.Previous(new IgbHighlightNavigation { PreventScroll = false }),
+            "previous", args: [new JsonSubset("""{"preventScroll": false}""")], types: ["Json"])
+        .Method(c => c.SetActiveAsync(2, new IgbHighlightNavigation { PreventScroll = true }), c => c.SetActive(2, new IgbHighlightNavigation { PreventScroll = true }),
+            "setActive", args: [2.0, new JsonSubset("""{"preventScroll": true}""")], types: ["Number", "Json"])
+        .Method(c => c.SearchAsync(), c => c.Search(), "search");
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
     [Fact]
     public void Highlight_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/IconButtonTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/IconButtonTests.cs
@@ -1,10 +1,29 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class IconButtonTests : BlazorComponentTestBase
+public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
 {
+    protected override ComponentContract<IgbIconButton> InteropContract { get; } = new ComponentContract<IgbIconButton>()
+        .Method(c => c.RegisterIconAsync("home", "https://example.com/home.svg", "material"), c => c.RegisterIcon("home", "https://example.com/home.svg", "material"),
+            "registerIcon", args: ["home", "https://example.com/home.svg", "material"], types: ["String", "String", "String"])
+        .Method(c => c.RegisterIconFromTextAsync("home", "<svg></svg>", "material"), c => c.RegisterIconFromText("home", "<svg></svg>", "material"),
+            "registerIconFromText", args: ["home", "<svg></svg>", "material"], types: ["String", "String", "String"])
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }),
+            "focus", args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.ClickAsync(), c => c.Click(), "click")
+        .Event(c => c.Focus)
+        .Event(c => c.Blur);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void IconButton_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/IconTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/IconTests.cs
@@ -1,10 +1,26 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class IconTests : BlazorComponentTestBase
+public class IconTests : ComponentWithContractTestBase<IgbIcon>
 {
+    protected override ComponentContract<IgbIcon> InteropContract { get; } = new ComponentContract<IgbIcon>()
+        .Method(c => c.RegisterIconAsync("home", "https://example.com/home.svg", "material"), c => c.RegisterIcon("home", "https://example.com/home.svg", "material"),
+            "registerIcon", args: ["home", "https://example.com/home.svg", "material"], types: ["String", "String", "String"])
+        .Method(c => c.RegisterIconFromTextAsync("home", "<svg></svg>", "material"), c => c.RegisterIconFromText("home", "<svg></svg>", "material"),
+            "registerIconFromText", args: ["home", "<svg></svg>", "material"], types: ["String", "String", "String"])
+        // IgbIconMeta is a MarshalByValueFactory type ("WebIconMeta")
+        // wire object carries name/collection plus bookkeeping (___byValue, type), hence JsonSubset.
+        .Method(c => c.SetIconRefAsync("chevron", "material", new IgbIconMeta { Name = "chevron_right", Collection = "custom" }), c => c.SetIconRef("chevron", "material", new IgbIconMeta { Name = "chevron_right", Collection = "custom" }),
+            "setIconRef",
+            args: ["chevron", "material", new JsonSubset("""{"name": "chevron_right", "collection": "custom"}""")],
+            types: ["String", "String", "Json"]);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
     [Fact]
     public void Icon_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/InputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InputTests.cs
@@ -1,10 +1,38 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class InputTests : BlazorComponentTestBase
+public class InputTests : ComponentWithContractTestBase<IgbInput>
 {
+    protected override ComponentContract<IgbInput> InteropContract { get; } = new ComponentContract<IgbInput>()
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: "hello")
+        .Method(c => c.StepUpAsync(2), c => c.StepUp(2), "stepUp", args: [2.0], types: ["Number"])
+        .Method(c => c.StepDownAsync(2), c => c.StepDown(2), "stepDown", args: [2.0], types: ["Number"])
+        .Method(c => c.SelectAsync(), c => c.Select(), "select")
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }),
+            "focus", args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("custom message"), c => c.SetCustomValidity("custom message"),
+            "setCustomValidity", args: ["custom message"], types: ["String"])
+        .Event(c => c.Change,
+            argsJson: """{"detail": "new value"}""",
+            assert: args => Assert.Equal("new value", args.Detail))
+        .Event(c => c.InputOcurred,
+            argsJson: """{"detail": "typed text"}""",
+            assert: args => Assert.Equal("typed text", args.Detail))
+        .Event(c => c.Focus)
+        .Event(c => c.Blur);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Input_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/Interop/ComponentContract.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/ComponentContract.cs
@@ -1,0 +1,721 @@
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Bunit;
+using IgniteUI.Blazor.Controls;
+using Microsoft.AspNetCore.Components;
+
+namespace IgniteUI.Blazor.Tests.Interop;
+
+/// <summary>Where a contract spec was declared (captured by the builders) — lets a violation point back at the suite's contract line.</summary>
+public sealed record SpecSource(string File, int Line);
+
+/// <summary>
+/// Builds the render for a hosted spec: the parent (plus structure) as the root, with the
+/// component under test nested inside and picked out by the spec's target selector. For
+/// child components that only meaningfully exist inside a parent (e.g. a tree item's
+/// GetPath needs real ancestors).
+/// </summary>
+public static class ContractHost
+{
+    public static RenderFragment Of<THost>(Action<ComponentParameterCollectionBuilder<THost>> arrange)
+        where THost : IComponent
+    {
+        var ps = new ComponentParameterCollectionBuilder<THost>();
+        arrange(ps);
+        return ps.Build().ToRenderFragment<THost>();
+    }
+}
+
+/// <summary>Expected wire value that is itself JSON (object/array arguments); compared structurally and exactly.</summary>
+public sealed record RawJson(string Json);
+
+/// <summary>
+/// Expected wire value for JSON objects compared as a subset: every property listed here
+/// must match the actual value; extra properties on the actual value are ignored (useful
+/// for serialized config objects that carry bookkeeping fields).
+/// </summary>
+public sealed record JsonSubset(string Json);
+
+public sealed class MethodContractSpec<TComponent> where TComponent : IComponent
+{
+    /// <summary>Wire identifier; null when <see cref="ReadsProperty"/> is set (resolved via the harness).</summary>
+    public string? JsName { get; init; }
+
+    /// <summary>For current-state property reads: the property name, translated to a wire id by the harness.</summary>
+    public string? ReadsProperty { get; init; }
+
+    public required Func<TComponent, Task<object?>> Invoke { get; init; }
+    public object?[] ExpectedArgs { get; init; } = Array.Empty<object?>();
+    public string[] ExpectedTypes { get; init; } = Array.Empty<string>();
+    public InteropReturn? Stub { get; init; }
+    public object? ExpectedReturn { get; init; }
+    public bool HasExpectedReturn { get; init; }
+
+    /// <summary>Extra render setup the member needs (child components, data). A spec with an arrangement renders its own instance.</summary>
+    public Action<ComponentParameterCollectionBuilder<TComponent>>? Arrange { get; init; }
+
+    /// <summary>
+    /// Hosted specs: the full render, parent included (see <see cref="ContractHost.Of{THost}"/>);
+    /// the component under test is picked out of it by <see cref="Target"/>.
+    /// </summary>
+    public RenderFragment? Host { get; init; }
+
+    /// <summary>Selects which rendered <typeparamref name="TComponent"/> inside <see cref="Host"/> is the component under test.</summary>
+    public Func<IRenderedFragment, IRenderedComponent<TComponent>>? Target { get; init; }
+
+    /// <summary>
+    /// The member's sync twin (<c>Show()</c> for <c>ShowAsync()</c>), when declared: the
+    /// runner re-invokes it against the same expectations after the async path.
+    /// </summary>
+    public Func<TComponent, object?>? SyncInvoke { get; init; }
+
+    /// <summary>
+    /// Dynamic stub for returns referencing arranged children (ids only known after render);
+    /// wins over <see cref="Stub"/>. The fragment is the render scope: the cut itself for
+    /// arranged specs, the whole host for hosted ones (so ancestors are reachable).
+    /// </summary>
+    public Func<InteropHarness, IRenderedFragment, InteropReturn>? StubFactory { get; init; }
+
+    /// <summary>Dynamic return assert receiving the render scope (see <see cref="StubFactory"/>) to compare against arranged instances.</summary>
+    public Action<IRenderedFragment, object?>? AssertReturnWithCut { get; init; }
+
+    public SpecSource? Source { get; init; }
+}
+
+public sealed class StatePropContractSpec<TComponent> where TComponent : IComponent
+{
+    public required string WireName { get; init; }
+    public required Action<ComponentParameterCollectionBuilder<TComponent>> Set { get; init; }
+    public object? ExpectedValue { get; init; }
+
+    /// <summary>Extra render setup the transmission depends on (e.g. data items the value must reference).</summary>
+    public Action<ComponentParameterCollectionBuilder<TComponent>>? Arrange { get; init; }
+
+    /// <summary>Dynamic wire value for transmissions referencing arranged state (ids only known after render); wins over <see cref="ExpectedValue"/>.</summary>
+    public Func<InteropHarness, IRenderedComponent<TComponent>, object?>? ExpectedValueFactory { get; init; }
+
+    public SpecSource? Source { get; init; }
+}
+
+public sealed class EventContractSpec<TComponent> where TComponent : IComponent
+{
+    public required string EventName { get; init; }
+
+    /// <summary>
+    /// Sets the event parameter and returns the boxed <see cref="EventCallback{TValue}"/> it
+    /// assigned, so the runner can assert the member round-trips that exact value: with a
+    /// sink, a callback forwarding received args to it; with null, an empty callback (the
+    /// removal round-trip — bUnit has no parameter removal, unbinding IS an add).
+    /// </summary>
+    public required Func<ComponentParameterCollectionBuilder<TComponent>, Action<object>?, object> Bind { get; init; }
+
+    /// <summary>Reads the event member back (boxed) — the typed read half of <see cref="Bind"/>.</summary>
+    public required Func<TComponent, object> Get { get; init; }
+
+    /// <summary>The declared event args type; the runner asserts the received args are assignable to it.</summary>
+    public required Type ArgsType { get; init; }
+    public string ArgsJson { get; init; } = "{}";
+    public Action<object>? AssertArgs { get; init; }
+
+    /// <summary>Like <see cref="AssertArgs"/> but also receives the rendered component (for reference-resolution asserts).</summary>
+    public Action<TComponent, object>? AssertWithComponent { get; init; }
+
+    /// <summary>Extra render setup the event needs to be reachable (child components, data, ...).</summary>
+    public Action<ComponentParameterCollectionBuilder<TComponent>>? Arrange { get; init; }
+
+    /// <summary>Dynamic payload builder for references only known after render (child ids); wins over <see cref="ArgsJson"/>.</summary>
+    public Func<InteropHarness, IRenderedComponent<TComponent>, string>? ArgsJsonFactory { get; init; }
+
+    /// <summary>Like <see cref="AssertWithComponent"/> but receives the rendered cut (to reach arranged children).</summary>
+    public Action<IRenderedComponent<TComponent>, object>? AssertWithCut { get; init; }
+
+    public SpecSource? Source { get; init; }
+}
+
+/// <summary>
+/// Pins a component's interop contract: how its public API maps onto the wire —
+/// method identifiers, argument serialization and type tags, return decoding, and
+/// event names + args deserialization. Runs through the <see cref="InteropHarness"/>
+/// seam, so the same contract verifies the component before and after it migrates to
+/// a new interop stack (see <see cref="InteropHarnessRegistry"/>). Authoring guide:
+/// skills/igniteui-blazor-lite-testing/references/interop-contracts.md.
+/// </summary>
+public sealed class ComponentContract<TComponent> where TComponent : IComponent
+{
+    private readonly List<MethodContractSpec<TComponent>> _methods = new();
+    private readonly List<EventContractSpec<TComponent>> _events = new();
+    private readonly List<StatePropContractSpec<TComponent>> _props = new();
+
+    public IReadOnlyList<MethodContractSpec<TComponent>> Methods => _methods;
+    public IReadOnlyList<EventContractSpec<TComponent>> Events => _events;
+    public IReadOnlyList<StatePropContractSpec<TComponent>> Props => _props;
+
+    /// <summary>A void API method (async-only members): asserts identifier, arguments and type tags.</summary>
+    public ComponentContract<TComponent> Method(
+        Func<TComponent, Task> invoke,
+        string jsName,
+        object?[]? args = null,
+        string[]? types = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            JsName = jsName,
+            Invoke = async c => { await invoke(c); return null; },
+            ExpectedArgs = args ?? Array.Empty<object?>(),
+            ExpectedTypes = types ?? Array.Empty<string>(),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary> Compile-time guard: a value-returning API method must state its wire return. </summary>
+    [Obsolete("This method returns a value — its return decoding is part of the contract. Use the overload with returns: (or InteropReturn + expect:).", error: true)]
+    public ComponentContract<TComponent> Method<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        string jsName,
+        object?[]? args = null,
+        string[]? types = null)
+        => throw new NotSupportedException();
+
+    /// <summary>
+    /// A value-returning API method (async-only members): the wire return kind is derived
+    /// from <typeparamref name="TResult"/>, the JS side is stubbed with <paramref name="returns"/>,
+    /// and the decoded .NET return must round-trip back to the same value.
+    /// </summary>
+    public ComponentContract<TComponent> Method<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        string jsName,
+        TResult returns,
+        object?[]? args = null,
+        string[]? types = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+        => Method(invoke, jsName, StubFor(returns), returns, args, types, atFile, atLine);
+
+    /// <summary>
+    /// Value-returning method overload (async-only members) for wire returns the value
+    /// form can't express (object/array envelopes, or stubs that decode to a different
+    /// value than sent).
+    /// </summary>
+    public ComponentContract<TComponent> Method<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        string jsName,
+        InteropReturn returns,
+        TResult expect,
+        object?[]? args = null,
+        string[]? types = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            JsName = jsName,
+            Invoke = async c => await invoke(c),
+            ExpectedArgs = args ?? Array.Empty<object?>(),
+            ExpectedTypes = types ?? Array.Empty<string>(),
+            Stub = returns,
+            ExpectedReturn = expect,
+            HasExpectedReturn = true,
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// A void API method declared with its sync twin (<c>Toggle()</c> for <c>ToggleAsync()</c>):
+    /// the runner re-invokes the twin against the same expectations after the async path.
+    /// </summary>
+    public ComponentContract<TComponent> Method(
+        Func<TComponent, Task> invoke,
+        Action<TComponent> sync,
+        string jsName,
+        object?[]? args = null,
+        string[]? types = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            JsName = jsName,
+            Invoke = async c => { await invoke(c); return null; },
+            SyncInvoke = c => { sync(c); return null; },
+            ExpectedArgs = args ?? Array.Empty<object?>(),
+            ExpectedTypes = types ?? Array.Empty<string>(),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>Value-returning method with its sync twin; wire return derived from <paramref name="returns"/>.</summary>
+    public ComponentContract<TComponent> Method<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        Func<TComponent, TResult> sync,
+        string jsName,
+        TResult returns,
+        object?[]? args = null,
+        string[]? types = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+        => Method(invoke, sync, jsName, StubFor(returns), returns, args, types, atFile, atLine);
+
+    /// <summary>Value-returning method with its sync twin, for wire returns the value form can't express.</summary>
+    public ComponentContract<TComponent> Method<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        Func<TComponent, TResult> sync,
+        string jsName,
+        InteropReturn returns,
+        TResult expect,
+        object?[]? args = null,
+        string[]? types = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            JsName = jsName,
+            Invoke = async c => await invoke(c),
+            SyncInvoke = c => sync(c),
+            ExpectedArgs = args ?? Array.Empty<object?>(),
+            ExpectedTypes = types ?? Array.Empty<string>(),
+            Stub = returns,
+            ExpectedReturn = expect,
+            HasExpectedReturn = true,
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    // Compile-time drift guards for twin declarations (same rationale as the single-selector
+    // poison above): each candidate is a better overload-resolution match than the legitimate
+    // void twin form when one or both sides start returning a value, so drift fails the build
+    // instead of silently decoding defaults.
+    [Obsolete("This method pair returns a value — state the wire return via the returns: twin overload.", error: true)]
+    public ComponentContract<TComponent> Method<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        Func<TComponent, TResult> sync,
+        string jsName,
+        object?[]? args = null,
+        string[]? types = null)
+        => throw new NotSupportedException();
+
+    [Obsolete("The async method returns a value but its sync twin is void — align the pair and state the wire return.", error: true)]
+    public ComponentContract<TComponent> Method<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        Action<TComponent> sync,
+        string jsName,
+        object?[]? args = null,
+        string[]? types = null)
+        => throw new NotSupportedException();
+
+    [Obsolete("The sync twin returns a value but the async method is void — align the pair and state the wire return.", error: true)]
+    public ComponentContract<TComponent> Method<TResult>(
+        Func<TComponent, Task> invoke,
+        Func<TComponent, TResult> sync,
+        string jsName,
+        object?[]? args = null,
+        string[]? types = null)
+        => throw new NotSupportedException();
+
+    /// <summary>
+    /// A current-state property read (async-only members; e.g. <c>GetTotalAsync</c> reading
+    /// "Total"): the wire identifier is implementation-specific and resolved by the
+    /// harness, the wire return kind is derived from <typeparamref name="TResult"/>, and
+    /// the decoded .NET return must round-trip back to <paramref name="returns"/>.
+    /// </summary>
+    public ComponentContract<TComponent> Getter<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        string propertyName,
+        TResult returns,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+        => Getter(invoke, propertyName, StubFor(returns), returns, atFile, atLine);
+
+    /// <summary>Getter overload (async-only members) for wire returns the value form can't express.</summary>
+    public ComponentContract<TComponent> Getter<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        string propertyName,
+        InteropReturn returns,
+        TResult expect,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            ReadsProperty = propertyName,
+            Invoke = async c => await invoke(c),
+            Stub = returns,
+            ExpectedReturn = expect,
+            HasExpectedReturn = true,
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// A current-state read (async-only members) whose stubbed return references arranged
+    /// children (e.g. an array of child component refs): <paramref name="arrange"/> adds
+    /// the children, <paramref name="returns"/> builds the stub after render (when child
+    /// ids exist), and <paramref name="assert"/> receives the rendered cut plus the
+    /// decoded return.
+    /// </summary>
+    public ComponentContract<TComponent> Getter<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        string propertyName,
+        Action<ComponentParameterCollectionBuilder<TComponent>> arrange,
+        Func<InteropHarness, IRenderedComponent<TComponent>, InteropReturn> returns,
+        Action<IRenderedComponent<TComponent>, TResult> assert,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            ReadsProperty = propertyName,
+            Invoke = async c => await invoke(c),
+            Arrange = arrange,
+            // For arranged specs the render scope IS the typed cut.
+            StubFactory = (h, scope) => returns(h, (IRenderedComponent<TComponent>)scope),
+            AssertReturnWithCut = (scope, o) => assert((IRenderedComponent<TComponent>)scope, (TResult)o!),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// A current-state read (async-only members) on a component hosted inside a parent —
+    /// for child components whose member only makes sense with real ancestors (e.g. a tree
+    /// item's path). <paramref name="host"/> is the full render (see
+    /// <see cref="ContractHost.Of{THost}"/>), <paramref name="target"/> picks the component
+    /// under test out of it, and <paramref name="returns"/>/<paramref name="assert"/>
+    /// receive the whole host render so refs to ancestors and siblings can be built and compared.
+    /// </summary>
+    public ComponentContract<TComponent> Getter<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        string propertyName,
+        RenderFragment host,
+        Func<IRenderedFragment, IRenderedComponent<TComponent>> target,
+        Func<InteropHarness, IRenderedFragment, InteropReturn> returns,
+        Action<IRenderedFragment, TResult> assert,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            ReadsProperty = propertyName,
+            Invoke = async c => await invoke(c),
+            Host = host,
+            Target = target,
+            StubFactory = returns,
+            AssertReturnWithCut = (scope, o) => assert(scope, (TResult)o!),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>Current-state read with its sync twin (<c>GetTotal()</c> for <c>GetTotalAsync()</c>); wire return derived from <paramref name="returns"/>.</summary>
+    public ComponentContract<TComponent> Getter<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        Func<TComponent, TResult> sync,
+        string propertyName,
+        TResult returns,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+        => Getter(invoke, sync, propertyName, StubFor(returns), returns, atFile, atLine);
+
+    /// <summary>Current-state read with its sync twin, for wire returns the value form can't express.</summary>
+    public ComponentContract<TComponent> Getter<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        Func<TComponent, TResult> sync,
+        string propertyName,
+        InteropReturn returns,
+        TResult expect,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            ReadsProperty = propertyName,
+            Invoke = async c => await invoke(c),
+            SyncInvoke = c => sync(c),
+            Stub = returns,
+            ExpectedReturn = expect,
+            HasExpectedReturn = true,
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>Arranged current-state read with its sync twin (see the arranged overload).</summary>
+    public ComponentContract<TComponent> Getter<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        Func<TComponent, TResult> sync,
+        string propertyName,
+        Action<ComponentParameterCollectionBuilder<TComponent>> arrange,
+        Func<InteropHarness, IRenderedComponent<TComponent>, InteropReturn> returns,
+        Action<IRenderedComponent<TComponent>, TResult> assert,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            ReadsProperty = propertyName,
+            Invoke = async c => await invoke(c),
+            SyncInvoke = c => sync(c),
+            Arrange = arrange,
+            StubFactory = (h, scope) => returns(h, (IRenderedComponent<TComponent>)scope),
+            AssertReturnWithCut = (scope, o) => assert((IRenderedComponent<TComponent>)scope, (TResult)o!),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>Hosted current-state read with its sync twin (see the hosted overload).</summary>
+    public ComponentContract<TComponent> Getter<TResult>(
+        Func<TComponent, Task<TResult>> invoke,
+        Func<TComponent, TResult> sync,
+        string propertyName,
+        RenderFragment host,
+        Func<IRenderedFragment, IRenderedComponent<TComponent>> target,
+        Func<InteropHarness, IRenderedFragment, InteropReturn> returns,
+        Action<IRenderedFragment, TResult> assert,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _methods.Add(new MethodContractSpec<TComponent>
+        {
+            ReadsProperty = propertyName,
+            Invoke = async c => await invoke(c),
+            SyncInvoke = c => sync(c),
+            Host = host,
+            Target = target,
+            StubFactory = returns,
+            AssertReturnWithCut = (scope, o) => assert(scope, (TResult)o!),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// A property whose value travels to the client over interop (rather than as a
+    /// rendered attribute): setting the parameter must produce a property update
+    /// transmission. The wire name is derived from the member (camelCase, honoring
+    /// WCWidgetMemberName), and for scalar values the wire value is the value itself.
+    /// </summary>
+    public ComponentContract<TComponent> Prop<TValue>(
+        Expression<Func<TComponent, TValue>> member,
+        TValue value,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+        => Prop(member, value, wire: ScalarWire(value), atFile: atFile, atLine: atLine);
+
+    /// <summary>
+    /// Prop overload stating the wire value explicitly — required for enums (wire enum
+    /// value) and serialized objects/arrays (<see cref="JsonSubset"/>/<see cref="RawJson"/>).
+    /// </summary>
+    public ComponentContract<TComponent> Prop<TValue>(
+        Expression<Func<TComponent, TValue>> member,
+        TValue value,
+        object? wire,
+        string? wireName = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _props.Add(new StatePropContractSpec<TComponent>
+        {
+            WireName = wireName ?? WirePropertyName(member),
+            Set = ps => ps.Add(member, value),
+            ExpectedValue = wire,
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Prop overload with render arrangement and a dynamic wire value — for values whose
+    /// transmission references arranged state (e.g. data items crossing as uuid refs
+    /// whose ids are only assigned once the data source transfers).
+    /// </summary>
+    public ComponentContract<TComponent> Prop<TValue>(
+        Expression<Func<TComponent, TValue>> member,
+        TValue value,
+        Action<ComponentParameterCollectionBuilder<TComponent>> arrange,
+        Func<InteropHarness, IRenderedComponent<TComponent>, object?> wire,
+        string? wireName = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _props.Add(new StatePropContractSpec<TComponent>
+        {
+            WireName = wireName ?? WirePropertyName(member),
+            Set = ps => ps.Add(member, value),
+            Arrange = arrange,
+            ExpectedValueFactory = wire,
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary> A void JS-originated event (dispatched with an empty payload) shorthand. </summary>
+    public ComponentContract<TComponent> Event(
+        Expression<Func<TComponent, EventCallback<IgbVoidEventArgs>>> member,
+        string? name = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _events.Add(new EventContractSpec<TComponent>
+        {
+            EventName = name ?? MemberName(member),
+            Bind = (ps, on) => BindMember(ps, member, on),
+            Get = GetterOf(member),
+            ArgsType = typeof(IgbVoidEventArgs),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// A JS-originated event, identified by its EventCallback parameter: the wire event
+    /// name is the member name (all generated components register handlers under it;
+    /// override via <paramref name="name"/> should they ever differ) and the args type is
+    /// inferred from the callback signature and asserted on the received args.
+    /// <paramref name="argsJson"/> is the plain JS args payload (e.g. <c>{"detail": true}</c>).
+    /// The runner verifies the full loop: the member round-trips the exact callback bound
+    /// and the event-handler registration transmits over interop; dispatch delivers the
+    /// decoded args; and unbinding resets the member, transmits the cleared registration,
+    /// and stops delivery.
+    /// </summary>
+    public ComponentContract<TComponent> Event<TArgs>(
+        Expression<Func<TComponent, EventCallback<TArgs>>> member,
+        string argsJson,
+        Action<TArgs>? assert = null,
+        string? name = null,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _events.Add(new EventContractSpec<TComponent>
+        {
+            EventName = name ?? MemberName(member),
+            Bind = (ps, on) => BindMember(ps, member, on),
+            Get = GetterOf(member),
+            ArgsType = typeof(TArgs),
+            ArgsJson = argsJson,
+            AssertArgs = assert is null ? null : o => assert((TArgs)o),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Event overload whose assert also receives the rendered component — for payloads
+    /// carrying references (e.g. <c>{"refType": "name", "id": "mainControl"}</c> details)
+    /// that must resolve back to the .NET instance.
+    /// </summary>
+    public ComponentContract<TComponent> Event<TArgs>(
+        Expression<Func<TComponent, EventCallback<TArgs>>> member,
+        string argsJson,
+        Action<TComponent, TArgs> assert,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _events.Add(new EventContractSpec<TComponent>
+        {
+            EventName = MemberName(member),
+            Bind = (ps, on) => BindMember(ps, member, on),
+            Get = GetterOf(member),
+            ArgsType = typeof(TArgs),
+            ArgsJson = argsJson,
+            AssertWithComponent = (c, o) => assert(c, (TArgs)o),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Event overload for payloads referencing arranged children: <paramref name="arrange"/>
+    /// adds the children (or data) the event needs, <paramref name="argsJson"/> builds the
+    /// payload after render (when child ids exist), and <paramref name="assert"/> receives
+    /// the rendered cut so it can compare against the arranged child instances.
+    /// </summary>
+    public ComponentContract<TComponent> Event<TArgs>(
+        Expression<Func<TComponent, EventCallback<TArgs>>> member,
+        Action<ComponentParameterCollectionBuilder<TComponent>> arrange,
+        Func<InteropHarness, IRenderedComponent<TComponent>, string> argsJson,
+        Action<IRenderedComponent<TComponent>, TArgs> assert,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        _events.Add(new EventContractSpec<TComponent>
+        {
+            EventName = MemberName(member),
+            Bind = (ps, on) => BindMember(ps, member, on),
+            Get = GetterOf(member),
+            ArgsType = typeof(TArgs),
+            Arrange = arrange,
+            ArgsJsonFactory = argsJson,
+            AssertWithCut = (cut, o) => assert(cut, (TArgs)o),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    private static System.Reflection.MemberInfo MemberOf(LambdaExpression member) =>
+        member.Body is MemberExpression m
+            ? m.Member
+            : throw new ArgumentException("Selector must be a simple member access (c => c.Member).", nameof(member));
+
+    private static string MemberName<TArgs>(Expression<Func<TComponent, EventCallback<TArgs>>> member) =>
+        MemberOf(member).Name;
+
+    /// <summary>
+    /// The write half of an event spec's bind/read loop, captured here where the args type
+    /// is known: assigns the parameter (an empty callback when <paramref name="sink"/> is
+    /// null) and returns the exact boxed callback for the runner's round-trip assert.
+    /// </summary>
+    private static object BindMember<TArgs>(
+        ComponentParameterCollectionBuilder<TComponent> ps,
+        Expression<Func<TComponent, EventCallback<TArgs>>> member,
+        Action<object>? sink)
+    {
+        var callback = sink is null ? default : new EventCallback<TArgs>(null, sink);
+        ps.Add(member, callback);
+        return callback;
+    }
+
+    /// <summary>The read half: the compiled member getter, boxed (see <see cref="EventContractSpec{TComponent}.Get"/>).</summary>
+    private static Func<TComponent, object> GetterOf<TArgs>(Expression<Func<TComponent, EventCallback<TArgs>>> member)
+    {
+        var get = member.Compile();
+        return c => get(c);
+    }
+
+    /// <summary>Derives the wire return kind from the .NET return type; exotic shapes use the InteropReturn overloads.</summary>
+    private static InteropReturn StubFor<TResult>(TResult value) => value switch
+    {
+        bool b => InteropReturn.Bool(b),
+        double d => InteropReturn.Number(d),
+        int i => InteropReturn.Number(i),
+        long l => InteropReturn.Number(l),
+        string s => InteropReturn.String(s),
+        DateTime dt => InteropReturn.Date(dt),
+        _ => throw new ArgumentException(
+            $"Cannot derive a wire return for {typeof(TResult).Name}; use the InteropReturn overload."),
+    };
+
+    /// <summary>Scalars cross the wire as themselves; enums and objects must state their wire form explicitly.</summary>
+    private static object ScalarWire<TValue>(TValue value) => value switch
+    {
+        bool or double or int or long or string or DateTime => value,
+        _ => throw new ArgumentException(
+            $"A wire value cannot be derived for {typeof(TValue).Name}; use the overload with an explicit wire: argument."),
+    };
+
+    private static string WirePropertyName<TValue>(Expression<Func<TComponent, TValue>> member)
+    {
+        var info = MemberOf(member);
+        var name = info.GetCustomAttributes(typeof(WCWidgetMemberNameAttribute), true)
+            .Cast<WCWidgetMemberNameAttribute>()
+            .FirstOrDefault()?.Name ?? info.Name;
+        return char.ToLowerInvariant(name[0]) + name[1..];
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/Interop/ComponentContract.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/ComponentContract.cs
@@ -45,8 +45,8 @@ public sealed class MethodContractSpec<TComponent> where TComponent : IComponent
     public string? ReadsProperty { get; init; }
 
     public required Func<TComponent, Task<object?>> Invoke { get; init; }
-    public object?[] ExpectedArgs { get; init; } = Array.Empty<object?>();
-    public string[] ExpectedTypes { get; init; } = Array.Empty<string>();
+    public object?[] ExpectedArgs { get; init; } = [];
+    public string[] ExpectedTypes { get; init; } = [];
     public InteropReturn? Stub { get; init; }
     public object? ExpectedReturn { get; init; }
     public bool HasExpectedReturn { get; init; }
@@ -142,9 +142,9 @@ public sealed class EventContractSpec<TComponent> where TComponent : IComponent
 /// </summary>
 public sealed class ComponentContract<TComponent> where TComponent : IComponent
 {
-    private readonly List<MethodContractSpec<TComponent>> _methods = new();
-    private readonly List<EventContractSpec<TComponent>> _events = new();
-    private readonly List<StatePropContractSpec<TComponent>> _props = new();
+    private readonly List<MethodContractSpec<TComponent>> _methods = [];
+    private readonly List<EventContractSpec<TComponent>> _events = [];
+    private readonly List<StatePropContractSpec<TComponent>> _props = [];
 
     public IReadOnlyList<MethodContractSpec<TComponent>> Methods => _methods;
     public IReadOnlyList<EventContractSpec<TComponent>> Events => _events;
@@ -163,8 +163,8 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
         {
             JsName = jsName,
             Invoke = async c => { await invoke(c); return null; },
-            ExpectedArgs = args ?? Array.Empty<object?>(),
-            ExpectedTypes = types ?? Array.Empty<string>(),
+            ExpectedArgs = args ?? [],
+            ExpectedTypes = types ?? [],
             Source = new SpecSource(atFile, atLine),
         });
         return this;
@@ -213,8 +213,8 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
         {
             JsName = jsName,
             Invoke = async c => await invoke(c),
-            ExpectedArgs = args ?? Array.Empty<object?>(),
-            ExpectedTypes = types ?? Array.Empty<string>(),
+            ExpectedArgs = args ?? [],
+            ExpectedTypes = types ?? [],
             Stub = returns,
             ExpectedReturn = expect,
             HasExpectedReturn = true,
@@ -241,8 +241,8 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
             JsName = jsName,
             Invoke = async c => { await invoke(c); return null; },
             SyncInvoke = c => { sync(c); return null; },
-            ExpectedArgs = args ?? Array.Empty<object?>(),
-            ExpectedTypes = types ?? Array.Empty<string>(),
+            ExpectedArgs = args ?? [],
+            ExpectedTypes = types ?? [],
             Source = new SpecSource(atFile, atLine),
         });
         return this;
@@ -277,8 +277,8 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
             JsName = jsName,
             Invoke = async c => await invoke(c),
             SyncInvoke = c => sync(c),
-            ExpectedArgs = args ?? Array.Empty<object?>(),
-            ExpectedTypes = types ?? Array.Empty<string>(),
+            ExpectedArgs = args ?? [],
+            ExpectedTypes = types ?? [],
             Stub = returns,
             ExpectedReturn = expect,
             HasExpectedReturn = true,
@@ -672,7 +672,7 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
     /// is known: assigns the parameter (an empty callback when <paramref name="sink"/> is
     /// null) and returns the exact boxed callback for the runner's round-trip assert.
     /// </summary>
-    private static object BindMember<TArgs>(
+    private static EventCallback<TArgs> BindMember<TArgs>(
         ComponentParameterCollectionBuilder<TComponent> ps,
         Expression<Func<TComponent, EventCallback<TArgs>>> member,
         Action<object>? sink)

--- a/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
@@ -1,0 +1,169 @@
+using System.Text.Json;
+using Bunit;
+using IgniteUI.Blazor.Controls;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IgniteUI.Blazor.Tests.Interop;
+
+/// <summary>
+/// A component API method invocation observed on the interop layer,
+/// normalized away from the concrete wire format.
+/// </summary>
+public sealed record InteropMethodCall(
+    string ContainerId,
+    string MethodName,
+    long InvokeId,
+    IReadOnlyList<JsonElement> Arguments,
+    IReadOnlyList<string> Types,
+    JsonElement RawMessage);
+
+/// <summary>
+/// A component state synchronization (full or delta) observed on the interop layer.
+/// </summary>
+public sealed record InteropStateSync(
+    string ContainerId,
+    JsonElement State,
+    bool IsDelta,
+    JsonElement RawMessage);
+
+public enum InteropReturnKind
+{
+    Undefined,
+    Boolean,
+    Number,
+    String,
+    Date,
+    Object,
+    Array,
+    Ref,
+    Deferred
+}
+
+/// <summary>
+/// Implementation-agnostic description of a value the JS side hands back for a
+/// method invocation. Concrete harnesses translate it into their wire format.
+/// </summary>
+public sealed class InteropReturn
+{
+    private InteropReturn(InteropReturnKind kind, object? value = null, string? typeName = null)
+    {
+        Kind = kind;
+        Value = value;
+        TypeName = typeName;
+    }
+
+    public InteropReturnKind Kind { get; }
+    public object? Value { get; }
+
+    /// <summary>Wire type name for <see cref="InteropReturnKind.Object"/> returns (e.g. "WebDropdownItem").</summary>
+    public string? TypeName { get; }
+
+    public static readonly InteropReturn Undefined = new(InteropReturnKind.Undefined);
+
+    /// <summary>
+    /// A deferred return: the reply carries no value, and the result arrives in a later
+    /// completion message — deliver it via <see cref="InteropHarness.CompleteDeferred"/>.
+    /// (No promise crosses the wire; how a stack tags deferral is its own spelling.)
+    /// </summary>
+    public static readonly InteropReturn Deferred = new(InteropReturnKind.Deferred);
+
+    public static InteropReturn Bool(bool value) => new(InteropReturnKind.Boolean, value);
+    public static InteropReturn Number(double value) => new(InteropReturnKind.Number, value);
+    public static InteropReturn String(string value) => new(InteropReturnKind.String, value);
+    public static InteropReturn Date(DateTime value) => new(InteropReturnKind.Date, value);
+    public static InteropReturn Object(string typeName, string valueJson) => new(InteropReturnKind.Object, valueJson, typeName);
+
+    /// <summary>An array return; <paramref name="itemsJson"/> is the JSON array (items may be reference objects).</summary>
+    public static InteropReturn Array(string itemsJson) => new(InteropReturnKind.Array, itemsJson);
+
+    /// <summary>
+    /// A single bound-object reference return (<c>{"refType": "name"|"uuid", "id": ...}</c>) —
+    /// the client sends these bare, resolved back to the .NET instance by reference.
+    /// </summary>
+    public static InteropReturn Ref(string refJson) => new(InteropReturnKind.Ref, refJson);
+}
+
+/// <summary>
+/// The seam between component tests and the concrete JS interop implementation.
+/// Tests speak only in terms of this API — observed <see cref="MethodCalls"/> and
+/// <see cref="StateSyncs"/>, stubbed returns, readiness, and JS-originated events.
+/// Everything specific to the current message-based renderer protocol lives in
+/// <see cref="RendererMessageInteropHarness"/>. When the interop infrastructure is
+/// rewritten, implement a new harness and map migrated components to it in
+/// <see cref="InteropHarnessRegistry"/> — the tests themselves stay unchanged.
+/// </summary>
+public abstract class InteropHarness
+{
+    /// <summary>The service instance components resolve via DI.</summary>
+    public abstract IIgniteUIBlazor Service { get; }
+
+    /// <summary>Registers whatever the implementation needs into the test DI container.</summary>
+    public abstract void ConfigureServices(IServiceCollection services);
+
+    /// <summary>
+    /// Arranges the interop layer so components rendered afterwards become ready
+    /// through their natural readiness flow.
+    /// </summary>
+    public abstract void PrimeReady();
+
+    /// <summary>Forces readiness on all already-rendered components (JS-side "loaded" signal).</summary>
+    public abstract void MakeReady();
+
+    /// <summary>Resolves the interop instance id of a rendered component.</summary>
+    public abstract string ContainerIdOf(IRenderedFragment cut);
+
+    /// <summary>Resolves the interop instance id of a child component inside a rendered fragment.</summary>
+    public abstract string ContainerIdOf(IRenderedFragment cut, string childSelector);
+
+    /// <summary>All API method invocations sent to JS so far, in order.</summary>
+    public abstract IReadOnlyList<InteropMethodCall> MethodCalls { get; }
+
+    /// <summary>All component state synchronizations sent to JS so far, in order.</summary>
+    public abstract IReadOnlyList<InteropStateSync> StateSyncs { get; }
+
+    /// <summary>Stubs the JS-side return value for invocations of <paramref name="methodName"/>.</summary>
+    public abstract void SetupMethodResult(string methodName, InteropReturn result);
+
+    /// <summary>
+    /// Stubs the JS-side value for current-state reads of <paramref name="propertyName"/>.
+    /// How a read travels is implementation-specific (a <c>"p:Name"</c> method message
+    /// today; possibly a dedicated interop call with different arguments later).
+    /// </summary>
+    public abstract void SetupPropertyRead(string propertyName, InteropReturn result);
+
+    /// <summary>All current-state reads of <paramref name="propertyName"/> issued for the instance so far, in order (count before/after an invocation to require a new one).</summary>
+    public abstract IEnumerable<InteropMethodCall> PropertyReads(string containerId, string propertyName);
+
+    /// <summary>
+    /// Dispatches a JS-originated component event into .NET.
+    /// <paramref name="argsJson"/> is the plain JSON payload of the event args
+    /// (e.g. <c>{"detail": true}</c>); the harness applies any wire framing.
+    /// </summary>
+    public abstract void RaiseEvent(string containerId, string eventName, string argsJson = "{}", string targetName = "mainControl");
+
+    /// <summary>Completes a method invocation that was answered with <see cref="InteropReturn.Deferred"/>.</summary>
+    public abstract void CompleteDeferred(InteropMethodCall call, InteropReturn result);
+
+    /// <summary>
+    /// Finds the client-bound property update transmission for <paramref name="wireName"/>
+    /// on the instance, returning the transmitted value normalized to JSON. Which channel
+    /// an update rides (bulk state description, ref transfer, a dedicated call) is
+    /// implementation-specific; simple props that cross as rendered attributes are not
+    /// interop and are covered by attribute tests instead. Returns null when no update
+    /// was transmitted.
+    /// </summary>
+    public abstract JsonElement? FindPropertyUpdate(string containerId, string wireName);
+
+    public IEnumerable<InteropMethodCall> CallsOf(string methodName, string? containerId = null) =>
+        MethodCalls.Where(c => c.MethodName == methodName && (containerId is null || c.ContainerId == containerId));
+
+    public InteropMethodCall? FindCall(string methodName, string? containerId = null) =>
+        CallsOf(methodName, containerId).LastOrDefault();
+
+    /// <summary>Like <see cref="FindCall"/> but fails the test when the call was never made.</summary>
+    public InteropMethodCall RequireCall(string methodName, string? containerId = null) =>
+        FindCall(methodName, containerId)
+        ?? throw new InvalidOperationException(
+            $"Expected an interop invocation of \"{methodName}\" but none was recorded. " +
+            $"Recorded methods: [{string.Join(", ", MethodCalls.Select(c => c.MethodName))}]");
+}

--- a/tests/IgniteUI.Blazor.Tests/Interop/InteropHarnessRegistry.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/InteropHarnessRegistry.cs
@@ -1,0 +1,26 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace IgniteUI.Blazor.Tests.Interop;
+
+/// <summary>
+/// Maps component types to <see cref="InteropHarness"/> implementations.
+/// Everything defaults to <see cref="RendererMessageInteropHarness"/> (the current
+/// interop stack). As components migrate to new interop infrastructure one by one,
+/// register the new harness for just those types — their tests keep working through
+/// the same seam while the rest of the suite stays on the default.
+/// </summary>
+public static class InteropHarnessRegistry
+{
+    private static readonly Dictionary<Type, Func<BunitJSInterop, InteropHarness>> Overrides = new();
+
+    public static void Register<TComponent>(Func<BunitJSInterop, InteropHarness> factory)
+        where TComponent : IComponent
+        => Overrides[typeof(TComponent)] = factory;
+
+    public static InteropHarness CreateDefault(BunitJSInterop jsInterop) =>
+        new RendererMessageInteropHarness(jsInterop);
+
+    internal static Func<BunitJSInterop, InteropHarness>? OverrideFor(Type componentType) =>
+        Overrides.TryGetValue(componentType, out var factory) ? factory : null;
+}

--- a/tests/IgniteUI.Blazor.Tests/Interop/InteropHarnessRegistry.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/InteropHarnessRegistry.cs
@@ -12,7 +12,7 @@ namespace IgniteUI.Blazor.Tests.Interop;
 /// </summary>
 public static class InteropHarnessRegistry
 {
-    private static readonly Dictionary<Type, Func<BunitJSInterop, InteropHarness>> Overrides = new();
+    private static readonly Dictionary<Type, Func<BunitJSInterop, InteropHarness>> Overrides = [];
 
     public static void Register<TComponent>(Func<BunitJSInterop, InteropHarness> factory)
         where TComponent : IComponent

--- a/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
@@ -1,0 +1,380 @@
+using System.Text;
+using System.Text.Json;
+using Bunit;
+using IgniteUI.Blazor.Controls;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IgniteUI.Blazor.Tests.Interop;
+
+/// <summary>
+/// <see cref="InteropHarness"/> adapter for the current interop implementation:
+/// global JS functions (<c>igSendMessage</c>, <c>igCheckReady</c>, <c>igWaitForLoaded</c>)
+/// carrying <c>RendererMessage</c> JSON envelopes, with JS→.NET traffic entering
+/// through the public <see cref="WebCallback"/> JSInvokable surface.
+/// All knowledge of that wire format is intentionally concentrated here.
+/// </summary>
+public sealed class RendererMessageInteropHarness : InteropHarness
+{
+    private const string SendMessage = "igSendMessage";
+
+    private readonly BunitJSInterop _js;
+    private readonly IgniteUIBlazor _service;
+    // Read by invocation matchers on background flush threads while tests add
+    // stubs on the test thread — must be thread-safe.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool> _stubbedMethods = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, JSRuntimeInvocationHandler<object>> _methodHandlers = new(StringComparer.Ordinal);
+
+    public RendererMessageInteropHarness(BunitJSInterop js)
+    {
+        _js = js;
+        // Force the JSON data-source channel (as on Blazor Server): bUnit's runtime is
+        // in-process but has no WASM InvokeUnmarshalled support, so the unmarshalled
+        // data channel is unreachable here; JSON marshalling keeps data transfers
+        // observable as refChanged messages.
+        _service = new IgniteUIBlazor(js.JSRuntime, IgniteUIBlazorSettings.Create().WithForceJsonDataMarshalling(true));
+
+        // Answer every message with an "undefined" return envelope by default —
+        // an unanswered invokeMethod would otherwise await its return forever.
+        // Method-specific stubs are excluded here so their handlers always win,
+        // regardless of bUnit's handler-resolution order.
+        _js.Setup<object>(SendMessage, inv => !IsStubbedInvokeMethod(inv))
+            .SetResult(ToResultPayload(InteropReturn.Undefined));
+    }
+
+    public override IIgniteUIBlazor Service => _service;
+
+    public override void ConfigureServices(IServiceCollection services) =>
+        services.AddSingleton<IIgniteUIBlazor>(_service);
+
+    private bool _primed;
+
+    public override void PrimeReady()
+    {
+        // Idempotent — several contract facts prime independently; registering the
+        // bUnit handlers once avoids piling up duplicates.
+        if (_primed)
+        {
+            return;
+        }
+        _primed = true;
+        _js.Setup<bool>("igCheckReady", _ => true).SetResult(true);
+        _js.SetupVoid("igWaitForLoaded", _ => true).SetVoidResult();
+    }
+
+    public override void MakeReady() => _service.WebCallback.OnReady();
+
+    public override string ContainerIdOf(IRenderedFragment cut) =>
+        cut.Find("[data-ig-id]").GetAttribute("data-ig-id")
+        ?? throw new InvalidOperationException("Rendered component has no data-ig-id container marker.");
+
+    public override string ContainerIdOf(IRenderedFragment cut, string childSelector) =>
+        cut.Find(childSelector).GetAttribute("data-ig-id")
+        ?? throw new InvalidOperationException($"Element \"{childSelector}\" has no data-ig-id container marker.");
+
+    public override IReadOnlyList<InteropMethodCall> MethodCalls
+    {
+        get
+        {
+            var calls = new List<InteropMethodCall>();
+            foreach (var (containerId, message) in Messages())
+            {
+                if (message.GetProperty("type").GetString() != "invokeMethod")
+                {
+                    continue;
+                }
+
+                calls.Add(new InteropMethodCall(
+                    containerId,
+                    message.GetProperty("methodName").GetString()!,
+                    message.GetProperty("invokeId").GetInt64(),
+                    message.TryGetProperty("arguments", out var args)
+                        ? args.EnumerateArray().ToArray()
+                        : Array.Empty<JsonElement>(),
+                    message.TryGetProperty("types", out var types)
+                        ? types.EnumerateArray().Select(t => t.GetString()!).ToArray()
+                        : Array.Empty<string>(),
+                    message));
+            }
+            return calls;
+        }
+    }
+
+    public override IReadOnlyList<InteropStateSync> StateSyncs
+    {
+        get
+        {
+            var syncs = new List<InteropStateSync>();
+            foreach (var (containerId, message) in Messages())
+            {
+                var type = message.GetProperty("type").GetString();
+                if (type is not ("description" or "descriptionDelta") ||
+                    !message.TryGetProperty("description", out var state))
+                {
+                    continue;
+                }
+
+                syncs.Add(new InteropStateSync(containerId, state, type == "descriptionDelta", message));
+            }
+            return syncs;
+        }
+    }
+
+    public override void SetupMethodResult(string methodName, InteropReturn result)
+    {
+        _stubbedMethods.TryAdd(methodName, true);
+        if (!_methodHandlers.TryGetValue(methodName, out var handler))
+        {
+            handler = _js.Setup<object>(SendMessage, inv => MethodNameOf(inv) == methodName);
+            _methodHandlers[methodName] = handler;
+        }
+        handler.SetResult(ToResultPayload(result));
+    }
+
+    public override void SetupPropertyRead(string propertyName, InteropReturn result) =>
+        SetupMethodResult(PropertyReadMethodName(propertyName), result);
+
+    public override IEnumerable<InteropMethodCall> PropertyReads(string containerId, string propertyName) =>
+        CallsOf(PropertyReadMethodName(propertyName), containerId);
+
+    /// <summary>On this stack a property read is an invokeMethod with a "p:"-prefixed name.</summary>
+    private static string PropertyReadMethodName(string propertyName) => "p:" + propertyName;
+
+    public override void RaiseEvent(string containerId, string eventName, string argsJson = "{}", string targetName = "mainControl")
+    {
+        var payload = $$"""{"sender": {"refType": "name", "id": "{{targetName}}"}, "args": {{argsJson}}}""";
+        _service.WebCallback.OnRaiseEvent(containerId, targetName, eventName, payload);
+    }
+
+    public override void CompleteDeferred(InteropMethodCall call, InteropReturn result) =>
+        _service.WebCallback.OnInvokeReturn(call.ContainerId, call.InvokeId, ToResultPayload(result));
+
+    public override JsonElement? FindPropertyUpdate(string containerId, string wireName)
+    {
+        // On this stack property updates ride description/descriptionDelta payloads;
+        // ref-typed values ride refChanged messages with refName "<containerId>/<PropName>";
+        // data sources ride refChanged messages under a generated ref id that the
+        // description advertises as "<wireName>Ref". All flush on an async queue tick,
+        // so retry briefly before concluding absence.
+        var pascalRefName = containerId + "/" + char.ToUpperInvariant(wireName[0]) + wireName[1..];
+        // Generous budget: multi-TFM test runs execute three processes concurrently and
+        // can starve the queue-flush continuations well past their usual few milliseconds.
+        for (var attempt = 0; attempt < 80; attempt++)
+        {
+            // One snapshot+parse per attempt, scanned newest-first.
+            var messages = Messages().Where(m => m.ContainerId == containerId).Reverse().ToList();
+
+            string? dataRefId = null;
+            foreach (var (_, message) in messages)
+            {
+                var type = message.GetProperty("type").GetString();
+                if (type is not ("description" or "descriptionDelta") ||
+                    !message.TryGetProperty("description", out var state))
+                {
+                    continue;
+                }
+                if (state.TryGetProperty(wireName, out var value))
+                {
+                    return value;
+                }
+                if (dataRefId is null &&
+                    state.TryGetProperty(wireName + "Ref", out var refId) &&
+                    refId.ValueKind == JsonValueKind.String)
+                {
+                    dataRefId = refId.GetString();
+                }
+            }
+
+            foreach (var (_, message) in messages)
+            {
+                if (message.GetProperty("type").GetString() == "refChanged" &&
+                    message.TryGetProperty("refName", out var name) &&
+                    (name.GetString() == pascalRefName || (dataRefId is not null && name.GetString() == dataRefId)) &&
+                    message.TryGetProperty("refValue", out var refValue))
+                {
+                    return NormalizeRefValue(refValue);
+                }
+            }
+
+            Thread.Sleep(25);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// refChanged values embed their payload as prefixed strings
+    /// (<c>localJson:::{...}</c>, <c>json:::{...}</c>); unwrap to the actual JSON value.
+    /// </summary>
+    private static JsonElement NormalizeRefValue(JsonElement refValue)
+    {
+        if (refValue.ValueKind != JsonValueKind.String)
+        {
+            return refValue;
+        }
+
+        var text = refValue.GetString()!;
+        var separator = text.IndexOf(":::", StringComparison.Ordinal);
+        if (separator < 0)
+        {
+            return refValue;
+        }
+        text = text[(separator + 3)..];
+
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            // Non-JSON payloads after the prefix are plain identifiers (script:::fnName,
+            // event:::Name) — the identifier is the value; the framing stays harness-owned.
+            return JsonSerializer.SerializeToElement(text);
+        }
+    }
+
+    /// <summary>Enumerates every recorded igSendMessage as (containerId, parsed message).</summary>
+    private IEnumerable<(string ContainerId, JsonElement Message)> Messages()
+    {
+        foreach (var invocation in SnapshotInvocations())
+        {
+            if (invocation.Identifier != SendMessage ||
+                invocation.Arguments.Count < 2 ||
+                invocation.Arguments[0] is not string containerId ||
+                invocation.Arguments[1] is not string json)
+            {
+                continue;
+            }
+
+            JsonElement message;
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                message = doc.RootElement.Clone();
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+
+            yield return (containerId, message);
+        }
+    }
+
+    /// <summary>
+    /// Components flush queued messages from background continuations, so bUnit's
+    /// append-only invocation record can grow while we read it. Snapshot with retry.
+    /// </summary>
+    private IReadOnlyList<JSRuntimeInvocation> SnapshotInvocations()
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                return _js.Invocations.ToArray();
+            }
+            catch (InvalidOperationException) when (attempt < 10)
+            {
+            }
+        }
+    }
+
+    private bool IsStubbedInvokeMethod(JSRuntimeInvocation invocation)
+    {
+        var methodName = MethodNameOf(invocation);
+        return methodName is not null && _stubbedMethods.ContainsKey(methodName);
+    }
+
+    private static string? MethodNameOf(JSRuntimeInvocation invocation)
+    {
+        if (invocation.Identifier != SendMessage ||
+            invocation.Arguments.Count < 2 ||
+            invocation.Arguments[1] is not string json)
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.GetProperty("type").GetString() == "invokeMethod" &&
+                   doc.RootElement.TryGetProperty("methodName", out var name)
+                ? name.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The value igSendMessage resolves with: a JSON *string* element containing the
+    /// return envelope (<c>{"retType": ..., "value": ...}</c>), matching what the JS
+    /// side produces for method invocations.
+    /// </summary>
+    private static JsonElement ToResultPayload(InteropReturn result) =>
+        JsonSerializer.SerializeToElement(BuildReturnEnvelope(result));
+
+    private static string BuildReturnEnvelope(InteropReturn result)
+    {
+        if (result.Kind == InteropReturnKind.Ref)
+        {
+            // Bound named objects cross as the bare reference itself — no retType
+            // envelope (Loader.ts doReplace emits {refType, id} directly).
+            return (string)result.Value!;
+        }
+
+        using var stream = new MemoryStream();
+        using (var w = new Utf8JsonWriter(stream))
+        {
+            w.WriteStartObject();
+            switch (result.Kind)
+            {
+                case InteropReturnKind.Undefined:
+                    w.WriteString("retType", "undefined");
+                    break;
+                case InteropReturnKind.Boolean:
+                    w.WriteString("retType", "boolean");
+                    w.WriteBoolean("value", (bool)result.Value!);
+                    break;
+                case InteropReturnKind.Number:
+                    w.WriteString("retType", "number");
+                    w.WriteNumber("value", (double)result.Value!);
+                    break;
+                case InteropReturnKind.String:
+                    w.WriteString("retType", "string");
+                    w.WriteString("value", (string)result.Value!);
+                    break;
+                case InteropReturnKind.Date:
+                    w.WriteString("retType", "date");
+                    w.WriteString("value", ((DateTime)result.Value!).ToString("o"));
+                    break;
+                case InteropReturnKind.Deferred:
+                    // This stack's spelling of a deferred reply: the client got a JS
+                    // promise it can't serialize, so it tags the reply and delivers the
+                    // real result later via WebCallback.OnInvokeReturn (invokeId-keyed).
+                    w.WriteString("retType", "promise");
+                    break;
+                case InteropReturnKind.Array:
+                    w.WriteString("retType", "Array");
+                    w.WritePropertyName("value");
+                    using (var doc = JsonDocument.Parse((string)result.Value!))
+                    {
+                        doc.RootElement.WriteTo(w);
+                    }
+                    break;
+                case InteropReturnKind.Object:
+                    w.WriteString("retType", "object");
+                    w.WriteString("type", result.TypeName);
+                    w.WritePropertyName("value");
+                    using (var doc = JsonDocument.Parse((string)result.Value!))
+                    {
+                        doc.RootElement.WriteTo(w);
+                    }
+                    break;
+            }
+            w.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Json;
-using System.Threading;
 using Bunit;
 using IgniteUI.Blazor.Controls;
 using Microsoft.Extensions.DependencyInjection;
@@ -89,11 +88,11 @@ public sealed class RendererMessageInteropHarness : InteropHarness
                     message.GetProperty("methodName").GetString()!,
                     message.GetProperty("invokeId").GetInt64(),
                     message.TryGetProperty("arguments", out var args)
-                        ? args.EnumerateArray().ToArray()
-                        : Array.Empty<JsonElement>(),
+                        ? [.. args.EnumerateArray()]
+                        : [],
                     message.TryGetProperty("types", out var types)
-                        ? types.EnumerateArray().Select(t => t.GetString()!).ToArray()
-                        : Array.Empty<string>(),
+                        ? [.. types.EnumerateArray().Select(t => t.GetString()!)]
+                        : [],
                     message));
             }
             return calls;
@@ -271,7 +270,7 @@ public sealed class RendererMessageInteropHarness : InteropHarness
         {
             try
             {
-                return _js.Invocations.ToArray();
+                return [.. _js.Invocations];
             }
             catch (InvalidOperationException) when (attempt < 10)
             {

--- a/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using Bunit;
 using IgniteUI.Blazor.Controls;
 using Microsoft.Extensions.DependencyInjection;
@@ -274,6 +275,7 @@ public sealed class RendererMessageInteropHarness : InteropHarness
             }
             catch (InvalidOperationException) when (attempt < 10)
             {
+                Thread.Yield();
             }
         }
     }

--- a/tests/IgniteUI.Blazor.Tests/InteropEventTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropEventTests.cs
@@ -1,0 +1,51 @@
+using IgniteUI.Blazor.Controls;
+
+namespace IgniteUI.Blazor.Tests;
+
+/// <summary>
+/// Shared JS → .NET event-pipeline semantics that per-component contracts don't
+/// cover: two-way binding propagation out of a JS-originated event, the delta
+/// state-sync it must send back, and dispatch without a bound handler being a
+/// no-op. (Per-member dispatch/args/registration coverage lives in each
+/// component's contract.)
+/// </summary>
+public class InteropEventTests : BlazorComponentTestBase
+{
+    [Fact]
+    public void BoolDetailEvent_FromJs_PropagatesTwoWayBinding()
+    {
+        var selected = false;
+        var cut = RenderComponent<IgbChip>(parameters => parameters
+            .Add(c => c.Select, _ => { })
+            .Add(c => c.SelectedChanged, value => selected = value));
+
+        Interop.RaiseEvent(Interop.ContainerIdOf(cut), "Select", """{"detail": true}""");
+
+        Assert.True(selected);
+        Assert.True(cut.Instance.Selected);
+    }
+
+    [Fact]
+    public void BoolDetailEvent_FromJs_SendsDeltaStateSyncBack()
+    {
+        var cut = RenderComponent<IgbChip>(parameters =>
+            parameters.Add(c => c.Select, _ => { }));
+        var containerId = Interop.ContainerIdOf(cut);
+
+        Interop.RaiseEvent(containerId, "Select", """{"detail": true}""");
+
+        // Two-way propagation out of the handler must sync the changed state back to JS.
+        var delta = Interop.StateSyncs.LastOrDefault(s => s.ContainerId == containerId && s.IsDelta);
+        Assert.NotNull(delta);
+        Assert.True(delta.State.GetProperty("selected").GetBoolean());
+    }
+
+    [Fact]
+    public void Event_WithoutBoundHandler_IsIgnored()
+    {
+        var cut = RenderComponent<IgbBanner>();
+
+        // No handler bound — dispatch must be a no-op rather than an error.
+        Interop.RaiseEvent(Interop.ContainerIdOf(cut), "Closing");
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/InteropReadinessTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropReadinessTests.cs
@@ -1,0 +1,47 @@
+using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
+
+namespace IgniteUI.Blazor.Tests;
+
+/// <summary>
+/// Covers the readiness gate: API methods must not reach JS before the component
+/// reports ready, and both readiness paths (the natural check during rendering and
+/// a later JS "loaded" signal) unlock method invocation.
+/// </summary>
+public class InteropReadinessTests : BlazorComponentTestBase
+{
+    [Fact]
+    public async Task MethodInvocation_BeforeReady_Throws()
+    {
+        var cut = RenderComponent<IgbBanner>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cut.Instance.ShowAsync());
+        Assert.Null(Interop.FindCall("show"));
+    }
+
+    [Fact]
+    public async Task PrimeReady_ReadiesComponent_ThroughNaturalRenderFlow()
+    {
+        Interop.PrimeReady();
+        Interop.SetupMethodResult("show", InteropReturn.Bool(true));
+        var cut = RenderComponent<IgbBanner>();
+
+        var shown = await cut.Instance.ShowAsync();
+
+        Assert.True(shown);
+        Assert.NotNull(Interop.FindCall("show", Interop.ContainerIdOf(cut)));
+    }
+
+    [Fact]
+    public async Task MakeReady_ReadiesComponents_RenderedBeforeTheLoadedSignal()
+    {
+        var cut = RenderComponent<IgbBanner>();
+        Interop.SetupMethodResult("hide", InteropReturn.Bool(false));
+
+        Interop.MakeReady();
+        var hidden = await cut.Instance.HideAsync();
+
+        Assert.False(hidden);
+        Assert.NotNull(Interop.FindCall("hide", Interop.ContainerIdOf(cut)));
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/MethodInteropTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/MethodInteropTests.cs
@@ -1,0 +1,30 @@
+using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
+
+namespace IgniteUI.Blazor.Tests;
+
+/// <summary>
+/// Semantics of the shared method-invocation pipeline that per-component contracts
+/// don't exercise: contracts stub replies that already carry the value, so the
+/// deferred return path — the reply says the result comes later, and a separate
+/// completion message delivers it — is proven here. (Identifier/argument/return-decoding
+/// coverage, sync twins included, lives in each component's
+/// <see cref="ComponentContract{TComponent}"/>.)
+/// </summary>
+public class MethodInteropTests : BlazorComponentTestBase
+{
+    [Fact]
+    public async Task DeferredReturn_StaysPendingUntilJsDeliversTheResult()
+    {
+        Interop.PrimeReady();
+        Interop.SetupMethodResult("toggle", InteropReturn.Deferred);
+        var cut = RenderComponent<IgbBanner>();
+
+        var pending = cut.Instance.ToggleAsync();
+        Assert.False(pending.IsCompleted);
+
+        Interop.CompleteDeferred(Interop.RequireCall("toggle"), InteropReturn.Bool(true));
+
+        Assert.True(await pending);
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/MiscComponentTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/MiscComponentTests.cs
@@ -1,10 +1,49 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class AccordionTests : BlazorComponentTestBase
+public class AccordionTests : ComponentWithContractTestBase<IgbAccordion>
 {
+    /// <summary> Static arrange for contract tests adding two child panel items </summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbAccordion>> arrange =
+        ps => ps.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IgbExpansionPanel>(0);
+            builder.AddAttribute(1, "id", "panel-1");
+            builder.CloseComponent();
+            builder.OpenComponent<IgbExpansionPanel>(2);
+            builder.AddAttribute(3, "id", "panel-2");
+            builder.CloseComponent();
+        });
+
+    protected override ComponentContract<IgbAccordion> InteropContract { get; } = new ComponentContract<IgbAccordion>()
+        .Method(c => c.HideAllAsync(), c => c.HideAll(), "hideAll")
+        .Method(c => c.ShowAllAsync(), c => c.ShowAll(), "showAll")
+        .Event(c => c.Opening,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-expansion-panel:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbExpansionPanel>()[1].Instance, args.Detail))
+        .Event(c => c.Opened,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-expansion-panel:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbExpansionPanel>()[1].Instance, args.Detail))
+        .Event(c => c.Closing,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-expansion-panel:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbExpansionPanel>()[1].Instance, args.Detail))
+        .Event(c => c.Closed,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-expansion-panel:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbExpansionPanel>()[1].Instance, args.Detail));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Accordion_RendersCorrectElement()
     {
@@ -45,8 +84,21 @@ public class AccordionTests : BlazorComponentTestBase
     }
 }
 
-public class BannerTests : BlazorComponentTestBase
+public class BannerTests : ComponentWithContractTestBase<IgbBanner>
 {
+    protected override ComponentContract<IgbBanner> InteropContract { get; } = new ComponentContract<IgbBanner>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Banner_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/NavigationTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/NavigationTests.cs
@@ -1,5 +1,6 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
@@ -35,8 +36,21 @@ public class NavbarTests : BlazorComponentTestBase
     }
 }
 
-public class NavDrawerTests : BlazorComponentTestBase
+public class NavDrawerTests : ComponentWithContractTestBase<IgbNavDrawer>
 {
+    protected override ComponentContract<IgbNavDrawer> InteropContract { get; } = new ComponentContract<IgbNavDrawer>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void NavDrawer_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/RadioTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RadioTests.cs
@@ -1,10 +1,37 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class RadioTests : BlazorComponentTestBase
+public class RadioTests : ComponentWithContractTestBase<IgbRadio>
 {
+    protected override ComponentContract<IgbRadio> InteropContract { get; } = new ComponentContract<IgbRadio>()
+        .Getter(c => c.GetCurrentCheckedAsync(), c => c.GetCurrentChecked(), "Checked", returns: true)
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }),
+            "focus", args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.ClickAsync(), c => c.Click(), "click")
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity", returns: true)
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity", returns: true)
+        .Method(c => c.SetCustomValidityAsync("Please select an option"), c => c.SetCustomValidity("Please select an option"),
+            "setCustomValidity", args: ["Please select an option"], types: ["String"])
+        .Event(c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"checked": true, "value": "option1"}}}""",
+            assert: args =>
+            {
+                Assert.True(args.Detail.Checked);
+                Assert.Equal("option1", args.Detail.Value);
+            })
+        .Event(c => c.Focus)
+        .Event(c => c.Blur);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Radio_RendersCorrectElement()
     {
@@ -85,8 +112,24 @@ public class RadioTests : BlazorComponentTestBase
     }
 }
 
-public class RadioGroupTests : BlazorComponentTestBase
+public class RadioGroupTests : ComponentWithContractTestBase<IgbRadioGroup>
 {
+    protected override ComponentContract<IgbRadioGroup> InteropContract { get; } = new ComponentContract<IgbRadioGroup>()
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: "selected-option")
+        .Event(c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"checked": true, "value": "selected-option"}}}""",
+            assert: args =>
+            {
+                Assert.True(args.Detail.Checked);
+                Assert.Equal("selected-option", args.Detail.Value);
+            });
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void RadioGroup_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/RangeSliderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RangeSliderTests.cs
@@ -1,10 +1,32 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class RangeSliderTests : BlazorComponentTestBase
+public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
 {
+    // TODO: ValueFormatOptions/ValueFormat (config objects on a direct-render component —
+    // they never cross as interop messages; BUG 35189 ).
+    protected override ComponentContract<IgbRangeSlider> InteropContract { get; } = new ComponentContract<IgbRangeSlider>()
+        .Event(c => c.Input,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"lower": 20, "upper": 80}}}""",
+            assert: args =>
+            {
+                Assert.Equal(20, args.Detail.Lower);
+                Assert.Equal(80, args.Detail.Upper);
+            })
+        .Event(c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"lower": 25, "upper": 75}}}""",
+            assert: args =>
+            {
+                Assert.Equal(25, args.Detail.Lower);
+                Assert.Equal(75, args.Detail.Upper);
+            });
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void RangeSlider_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/RatingTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RatingTests.cs
@@ -1,10 +1,32 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class RatingTests : BlazorComponentTestBase
+public class RatingTests : ComponentWithContractTestBase<IgbRating>
 {
+    protected override ComponentContract<IgbRating> InteropContract { get; } = new ComponentContract<IgbRating>()
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: 3.5)
+        .Method(c => c.StepUpAsync(2), c => c.StepUp(2), "stepUp", args: [2.0], types: ["Number"])
+        .Method(c => c.StepDownAsync(2), c => c.StepDown(2), "stepDown", args: [2.0], types: ["Number"])
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("custom message"), c => c.SetCustomValidity("custom message"),
+            "setCustomValidity", args: ["custom message"], types: ["String"])
+        .Event(c => c.Change,
+            argsJson: """{"detail": 4}""",
+            assert: args => Assert.Equal(4, args.Detail))
+        .Event(c => c.Hover,
+            argsJson: """{"detail": 2}""",
+            assert: args => Assert.Equal(2, args.Detail));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Rating_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/ScriptPropTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ScriptPropTests.cs
@@ -1,0 +1,87 @@
+using System.Reflection;
+using Bunit;
+using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
+using Microsoft.AspNetCore.Components;
+
+namespace IgniteUI.Blazor.Tests;
+
+/// <summary>
+/// Automated sweep over every generated <c>&lt;Member&gt;Script</c> parameter: setting one
+/// must transmit a script reference for the target member, carrying the script name.
+/// Unlike contract members (whose identifiers/args/decodes are component-specific facts),
+/// Script props are a single codegen template with a mechanically derived wire name — so
+/// one reflection-enumerated sweep pins the pipeline for all components at once and
+/// cannot go stale (new components/props are picked up automatically). Per-component
+/// interop migration is handled the same way contracts handle it: the harness is
+/// resolved through <see cref="InteropHarnessRegistry"/>, so a remapped component is
+/// swept through its new stack's harness — the wire form is harness-owned, the asserted
+/// semantics ("the script name crosses, keyed to the target member") are not. Only a
+/// component whose script *semantics* genuinely diverge graduates to an explicit
+/// contract entry with the divergent expectation. No per-contract entries otherwise
+/// (the integration TestBed does not exercise these either, making this their only
+/// coverage).
+/// </summary>
+public class ScriptPropTests : BlazorComponentTestBase
+{
+    public static TheoryData<Type> ComponentsWithScriptProps()
+    {
+        var data = new TheoryData<Type>();
+        foreach (var type in typeof(IgbBanner).Assembly.GetTypes())
+        {
+            if (type.IsAbstract || !typeof(BaseRendererControl).IsAssignableFrom(type))
+            {
+                continue;
+            }
+            var closed = type.IsGenericTypeDefinition ? type.MakeGenericType(typeof(object)) : type;
+            if (ScriptPropsOf(closed).Any())
+            {
+                data.Add(closed);
+            }
+        }
+        return data;
+    }
+
+    private static IEnumerable<PropertyInfo> ScriptPropsOf(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType == typeof(string)
+                && p.Name.EndsWith("Script", StringComparison.Ordinal)
+                && p.CanWrite
+                && p.GetCustomAttribute<ParameterAttribute>() is not null);
+
+    [Theory]
+    [MemberData(nameof(ComponentsWithScriptProps))]
+    public void ScriptProps_TransmitScriptRefs(Type componentType)
+    {
+        // Resolved through the registry, so a component remapped to a new interop stack
+        // is swept through its own harness — the assertion is stack-invariant.
+        var interop = InteropFor(componentType);
+        interop.PrimeReady();
+
+        foreach (var prop in ScriptPropsOf(componentType))
+        {
+            var scriptName = $"handle{prop.Name}";
+            // OpenComponent takes the runtime Type directly — no generic RenderComponent
+            // reflection; the typed base handle exposes Instance for the round-trip check.
+            var cut = Render(builder =>
+            {
+                builder.OpenComponent(0, componentType);
+                builder.AddAttribute(1, prop.Name, scriptName);
+                builder.CloseComponent();
+            }).FindComponent<ComponentBase>();
+
+            Assert.Equal(scriptName, prop.GetValue(cut.Instance));
+            // The ref targets the member the script stands in for: "ClosingScript" -> "closing".
+            var member = prop.Name[..^"Script".Length];
+            var wireName = char.ToLowerInvariant(member[0]) + member[1..];
+
+            var actual = interop.FindPropertyUpdate(interop.ContainerIdOf(cut), wireName);
+            if (actual is null)
+            {
+                throw new Xunit.Sdk.XunitException(
+                    $"{componentType.Name}.{prop.Name}: no script-ref transmission observed for \"{wireName}\"");
+            }
+            Assert.Equal(scriptName, actual.Value.GetString());
+        }
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/SelectTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SelectTests.cs
@@ -1,10 +1,88 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class SelectTests : BlazorComponentTestBase
+public class SelectTests : ComponentWithContractTestBase<IgbSelect>
 {
+    /// <summary>Static arrange for contract tests adding two select items.</summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbSelect>> arrangeItems =
+        ps => ps.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IgbSelectItem>(0);
+            builder.AddAttribute(1, "Value", "us");
+            builder.CloseComponent();
+            builder.OpenComponent<IgbSelectItem>(2);
+            builder.AddAttribute(3, "Value", "ca");
+            builder.CloseComponent();
+        });
+
+    /// <summary>Static arrange for contract tests adding a select group.</summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbSelect>> arrangeGroups =
+        ps => ps.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IgbSelectGroup>(0);
+            builder.CloseComponent();
+        });
+
+    protected override ComponentContract<IgbSelect> InteropContract { get; } = new ComponentContract<IgbSelect>()
+        .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: "us")
+        .Getter(c => c.GetItemsAsync(), c => c.GetItems(), "Items",
+            arrangeItems,
+            returns: (interop, cut) => InteropReturn.Array($$$"""[{"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-select-item:nth-of-type(1)")}}}"}, {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-select-item:nth-of-type(2)")}}}"}]"""),
+            assert: (cut, result) =>
+            {
+                Assert.Equal(2, result.Length);
+                Assert.Same(cut.FindComponents<IgbSelectItem>()[0].Instance, result[0]);
+                Assert.Same(cut.FindComponents<IgbSelectItem>()[1].Instance, result[1]);
+            })
+        .Getter(c => c.GetGroupsAsync(), c => c.GetGroups(), "Groups",
+            arrangeGroups,
+            returns: (interop, cut) => InteropReturn.Array($$$"""[{"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-select-group:nth-of-type(1)")}}}"}]"""),
+            assert: (cut, result) =>
+            {
+                Assert.Single(result);
+                // TODO: IgbSelectGroup never registers with Select's FindByName (no cascading-value
+                // partial the way SelectItem has one), so the ref currently resolves to a null
+                // Assert.Same(cut.FindComponents<IgbSelectGroup>()[0].Instance, result[0]);
+            })
+        .Getter(c => c.GetSelectedItemAsync(), c => c.GetSelectedItem(), "SelectedItem",
+            arrangeItems,
+            returns: (interop, cut) => InteropReturn.Ref($$"""{"refType": "name", "id": "{{interop.ContainerIdOf(cut, "igc-select-item:nth-of-type(1)")}}"}"""),
+            assert: (cut, result) => Assert.Same(cut.FindComponents<IgbSelectItem>()[0].Instance, result))
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }), "focus",
+            args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity", returns: true)
+        .Method(c => c.ClearSelectionAsync(), c => c.ClearSelection(), "clearSelection")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("Please choose an option"), c => c.SetCustomValidity("Please choose an option"), "setCustomValidity",
+            args: ["Please choose an option"], types: ["String"])
+        .Event(c => c.Focus)
+        .Event(c => c.Blur)
+        .Event(c => c.Opening)
+        .Event(c => c.Opened)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed)
+        .Event(c => c.Change,
+            arrangeItems,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-select-item:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) =>
+            {
+                Assert.Same(cut.FindComponents<IgbSelectItem>()[1].Instance, args.Detail);
+                Assert.Equal("ca", args.Detail.Value); // Change propagates Detail.Value into Select.Value
+            });
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Select_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/SliderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SliderTests.cs
@@ -1,10 +1,33 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class SliderTests : BlazorComponentTestBase
+public class SliderTests : ComponentWithContractTestBase<IgbSlider>
 {
+    // TODO: ValueFormatOptions/ValueFormat — Slider is direct-render BUG 35189
+    protected override ComponentContract<IgbSlider> InteropContract { get; } = new ComponentContract<IgbSlider>()
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: 42.0)
+        .Method(c => c.StepUpAsync(2), c => c.StepUp(2), "stepUp", args: [2.0], types: ["Number"])
+        .Method(c => c.StepDownAsync(2), c => c.StepDown(2), "stepDown", args: [2.0], types: ["Number"])
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("custom message"), c => c.SetCustomValidity("custom message"),
+            "setCustomValidity", args: ["custom message"], types: ["String"])
+        .Event(c => c.Input,
+            argsJson: """{"detail": 3}""",
+            assert: args => Assert.Equal(3, args.Detail))
+        .Event(c => c.Change,
+            argsJson: """{"detail": 5}""",
+            assert: args => Assert.Equal(5, args.Detail));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Slider_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/SplitterTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SplitterTests.cs
@@ -1,10 +1,45 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class SplitterTests : BlazorComponentTestBase
+public class SplitterTests : ComponentWithContractTestBase<IgbSplitter>
 {
+    protected override ComponentContract<IgbSplitter> InteropContract { get; } = new ComponentContract<IgbSplitter>()
+        .Method(c => c.ToggleAsync(PanePosition.Start), c => c.Toggle(PanePosition.Start),
+            "toggle", args: ["start"], types: ["Json"])
+        .Event(c => c.ResizeStart,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"startPanelSize": 120, "endPanelSize": 80, "delta": 0}}}""",
+            assert: args =>
+            {
+                Assert.Equal(120, args.Detail.StartPanelSize);
+                Assert.Equal(80, args.Detail.EndPanelSize);
+                Assert.Equal(0, args.Detail.Delta);
+            })
+        .Event(c => c.Resizing,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"startPanelSize": 130, "endPanelSize": 70, "delta": 10}}}""",
+            assert: args =>
+            {
+                Assert.Equal(130, args.Detail.StartPanelSize);
+                Assert.Equal(70, args.Detail.EndPanelSize);
+                Assert.Equal(10, args.Detail.Delta);
+            })
+        .Event(c => c.ResizeEnd,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"startPanelSize": 150, "endPanelSize": 50, "delta": 30}}}""",
+            assert: args =>
+            {
+                Assert.Equal(150, args.Detail.StartPanelSize);
+                Assert.Equal(50, args.Detail.EndPanelSize);
+                Assert.Equal(30, args.Detail.Delta);
+            });
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Splitter_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/StepperTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/StepperTests.cs
@@ -1,10 +1,54 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class StepperTests : BlazorComponentTestBase
+public class StepperTests : ComponentWithContractTestBase<IgbStepper>
 {
+    /// <summary> Static arrange for the GetSteps contract test adding two child steps. </summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbStepper>> arrange =
+        ps => ps.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IgbStep>(0);
+            builder.AddAttribute(1, "id", "step-1");
+            builder.CloseComponent();
+            builder.OpenComponent<IgbStep>(2);
+            builder.AddAttribute(3, "id", "step-2");
+            builder.CloseComponent();
+        });
+
+    protected override ComponentContract<IgbStepper> InteropContract { get; } = new ComponentContract<IgbStepper>()
+        .Method(c => c.NavigateToAsync(1), c => c.NavigateTo(1), "navigateTo", args: [1.0], types: ["Number"])
+        .Method(c => c.NextAsync(), c => c.Next(), "next")
+        .Method(c => c.PrevAsync(), c => c.Prev(), "prev")
+        .Method(c => c.ResetAsync(), c => c.Reset(), "reset")
+        .Getter(c => c.GetStepsAsync(), c => c.GetSteps(), "Steps",
+            arrange,
+            returns: (interop, cut) => InteropReturn.Array($$$"""[{"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-step:nth-of-type(1)")}}}"}, {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-step:nth-of-type(2)")}}}"}]"""),
+            assert: (cut, result) =>
+            {
+                Assert.Equal(2, result.Length);
+                // TODO: IgbStep has no CascadingParameter registration and no FindByNameStepper impl
+                // so the refs currently resolve to null elements
+            })
+        .Event(c => c.ActiveStepChanging,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"oldIndex": 0, "newIndex": 1}}}""",
+            assert: args =>
+            {
+                Assert.Equal(0, args.Detail.OldIndex);
+                Assert.Equal(1, args.Detail.NewIndex);
+            })
+        .Event(c => c.ActiveStepChanged,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"index": 1}}}""",
+            assert: args => Assert.Equal(1, args.Detail.Index));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Stepper_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/SwitchTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SwitchTests.cs
@@ -1,10 +1,37 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class SwitchTests : BlazorComponentTestBase
+public class SwitchTests : ComponentWithContractTestBase<IgbSwitch>
 {
+    protected override ComponentContract<IgbSwitch> InteropContract { get; } = new ComponentContract<IgbSwitch>()
+        .Getter(c => c.GetCurrentCheckedAsync(), c => c.GetCurrentChecked(), "Checked", returns: true)
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }),
+            "focus", args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.ClickAsync(), c => c.Click(), "click")
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("Please enable this setting"), c => c.SetCustomValidity("Please enable this setting"),
+            "setCustomValidity", args: ["Please enable this setting"], types: ["String"])
+        .Event(c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"checked": true, "value": "switch-value"}}}""",
+            assert: args =>
+            {
+                Assert.True(args.Detail.Checked);
+                Assert.Equal("switch-value", args.Detail.Value);
+            })
+        .Event(c => c.Focus)
+        .Event(c => c.Blur);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Switch_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/TabsTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TabsTests.cs
@@ -1,10 +1,37 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class TabsTests : BlazorComponentTestBase
+public class TabsTests : ComponentWithContractTestBase<IgbTabs>
 {
+    protected override ComponentContract<IgbTabs> InteropContract { get; } = new ComponentContract<IgbTabs>()
+        .Event(c => c.Change,
+            arrange: ps => ps.AddChildContent(builder =>
+            {
+                builder.OpenComponent<IgbTab>(0);
+                builder.AddAttribute(1, "id", "tab-1");
+                builder.CloseComponent();
+                builder.OpenComponent<IgbTab>(2);
+                builder.AddAttribute(3, "id", "tab-2");
+                builder.CloseComponent();
+            }),
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tab:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) =>
+            {
+                Assert.Same(cut.Instance.ActualTabsCollection[1], args.Detail);
+                Assert.True(args.Detail.Selected); // OnHandlingChange propagates selection
+            })
+        .Method(c => c.SelectAsync("tab-1"), c => c.Select("tab-1"), "select", args: ["tab-1"], types: ["String"])
+        .Getter(c => c.GetSelectedAsync(), c => c.GetSelected(), "Selected", returns: "tab-1");
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Tabs_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/TextInputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TextInputTests.cs
@@ -1,10 +1,33 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class TextareaTests : BlazorComponentTestBase
+public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
 {
+    protected override ComponentContract<IgbTextarea> InteropContract { get; } = new ComponentContract<IgbTextarea>()
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: "hello")
+        .Method(c => c.SelectAsync(), c => c.Select(), "select")
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("custom message"), c => c.SetCustomValidity("custom message"),
+            "setCustomValidity", args: ["custom message"], types: ["String"])
+        .Event(c => c.Input,
+            argsJson: """{"detail": "typed text"}""",
+            assert: args => Assert.Equal("typed text", args.Detail))
+        .Event(c => c.Change,
+            argsJson: """{"detail": "new value"}""",
+            assert: args => Assert.Equal("new value", args.Detail))
+        .Event(c => c.Focus)
+        .Event(c => c.Blur);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Textarea_RendersCorrectElement()
     {
@@ -106,8 +129,53 @@ public class TextareaTests : BlazorComponentTestBase
     }
 }
 
-public class MaskInputTests : BlazorComponentTestBase
+public class MaskInputTests : ComponentWithContractTestBase<IgbMaskInput>
 {
+    // Interop contract — source: src/components/Blazor/MaskInput.cs, src/components/Blazor/InputBase.cs.
+    // Skipped: none (SetNativeElementAsync/SetNativeElement are globally excluded).
+    // IgbMaskInput does not override UseDirectRender, so — like IgbDateTimeInput — it renders
+    // through the component-renderer-container and all its scalar props travel as .Prop updates.
+    protected override ComponentContract<IgbMaskInput> InteropContract { get; } = new ComponentContract<IgbMaskInput>()
+        .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: "hello")
+        .Method(c => c.SetSelectionRangeAsync(1, 3, "forward"), c => c.SetSelectionRange(1, 3, "forward"),
+            "setSelectionRange", args: [1.0, 3.0, "forward"], types: ["Number", "Number", "String"])
+        .Method(c => c.SetRangeTextAsync("abc", 1, 3, "end"), c => c.SetRangeText("abc", 1, 3, "end"),
+            "setRangeText", args: ["abc", 1.0, 3.0, "end"], types: ["String", "Number", "Number", "String"])
+        .Method(c => c.SelectAsync(), c => c.Select(), "select")
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }),
+            "focus", args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.ReportValidityAsync(), c => c.ReportValidity(), "reportValidity")
+        .Method(c => c.CheckValidityAsync(), c => c.CheckValidity(), "checkValidity")
+        .Method(c => c.SetCustomValidityAsync("custom message"), c => c.SetCustomValidity("custom message"),
+            "setCustomValidity", args: ["custom message"], types: ["String"])
+        .Event(c => c.Change,
+            argsJson: """{"detail": "new value"}""", assert: args => Assert.Equal("new value", args.Detail))
+        .Event(c => c.InputOcurred,
+            argsJson: """{"detail": "typed text"}""", assert: args => Assert.Equal("typed text", args.Detail))
+        .Event(c => c.Focus)
+        .Event(c => c.Blur)
+        .Prop(c => c.ValueMode, MaskInputValueMode.WithFormatting, wire: "withFormatting")
+        .Prop(c => c.Value, "555-1234")
+        .Prop(c => c.Mask, "000-0000")
+        .Prop(c => c.Prompt, "*")
+        .Prop(c => c.ReadOnly, true)
+        .Prop(c => c.Outlined, true)
+        .Prop(c => c.Placeholder, "Enter value")
+        .Prop(c => c.Label, "Phone")
+        .Prop(c => c.Disabled, true)
+        .Prop(c => c.Required, true)
+        .Prop(c => c.Invalid, true);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Props_FollowContract() => VerifyPropContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/TileManagerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TileManagerTests.cs
@@ -1,10 +1,83 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class TileManagerTests : BlazorComponentTestBase
+public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
 {
+    /// <summary> Static arrange for contract tests adding two tiles </summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbTileManager>> arrange =
+        ps => ps.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IgbTile>(0);
+            builder.AddAttribute(1, "id", "tile-1");
+            builder.CloseComponent();
+            builder.OpenComponent<IgbTile>(2);
+            builder.AddAttribute(3, "id", "tile-2");
+            builder.CloseComponent();
+        });
+
+    protected override ComponentContract<IgbTileManager> InteropContract { get; } = new ComponentContract<IgbTileManager>()
+        .Method(c => c.SaveLayoutAsync(), c => c.SaveLayout(), "saveLayout", returns: "{\"tiles\":[]}")
+        .Method(c => c.LoadLayoutAsync("{\"tiles\":[]}"), c => c.LoadLayout("{\"tiles\":[]}"), "loadLayout",
+            args: ["{\"tiles\":[]}"], types: ["String"])
+        .Getter(c => c.GetTilesAsync(), c => c.GetTiles(), "Tiles",
+            arrange,
+            returns: (interop, cut) => InteropReturn.Array($$$"""[{"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(1)")}}}"}, {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}"}]"""),
+            assert: (cut, result) =>
+            {
+                Assert.Equal(2, result.Length);
+                Assert.Same(cut.FindComponents<IgbTile>()[0].Instance, result[0]);
+                Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, result[1]);
+            })
+        .Event(c => c.TileDragStart,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, args.Detail))
+        .Event(c => c.TileDragEnd,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, args.Detail))
+        .Event(c => c.TileDragCancel,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, args.Detail))
+        .Event(c => c.TileResizeStart,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, args.Detail))
+        .Event(c => c.TileResizeEnd,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, args.Detail))
+        .Event(c => c.TileResizeCancel,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, args.Detail))
+        .Event(c => c.TileFullscreen,
+            arrange,
+            argsJson: (interop, cut) => $$$$"""{"detail": {"retType": "object", "type": "", "value": {"tile": {"refType": "name", "id": "{{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}}"}, "state": true}}}""",
+            assert: (cut, args) =>
+            {
+                Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, args.Detail.Tile);
+                Assert.True(args.Detail.State);
+            })
+        .Event(c => c.TileMaximize,
+            arrange,
+            argsJson: (interop, cut) => $$$$"""{"detail": {"retType": "object", "type": "", "value": {"tile": {"refType": "name", "id": "{{{{interop.ContainerIdOf(cut, "igc-tile:nth-of-type(2)")}}}}"}, "state": false}}}""",
+            assert: (cut, args) =>
+            {
+                Assert.Same(cut.FindComponents<IgbTile>()[1].Instance, args.Detail.Tile);
+                Assert.False(args.Detail.State);
+            });
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void TileManager_RendersCorrectElement()
     {
@@ -126,4 +199,51 @@ public class TileManagerTests : BlazorComponentTestBase
 
         Assert.Contains("Tile content", cut.Find("igc-tile").InnerHtml);
     }
+}
+
+public class TileTests : ComponentWithContractTestBase<IgbTile>
+{
+    // The tile's own events carry a self-reference ({"refType": "name", "id": "mainControl"})
+    // that must resolve back to the .NET instance; TileFullscreen/TileMaximize wrap it in a
+    // composite detail ({tile, state}).
+    protected override ComponentContract<IgbTile> InteropContract { get; } = new ComponentContract<IgbTile>()
+        .Getter(c => c.GetFullscreenAsync(), c => c.GetFullscreen(), "Fullscreen", returns: true)
+        .Event(c => c.TileDragStart,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (tile, args) => Assert.Same(tile, args.Detail))
+        .Event(c => c.TileDragEnd,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (tile, args) => Assert.Same(tile, args.Detail))
+        .Event(c => c.TileDragCancel,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (tile, args) => Assert.Same(tile, args.Detail))
+        .Event(c => c.TileResizeStart,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (tile, args) => Assert.Same(tile, args.Detail))
+        .Event(c => c.TileResizeEnd,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (tile, args) => Assert.Same(tile, args.Detail))
+        .Event(c => c.TileResizeCancel,
+            """{"detail": {"refType": "name", "id": "mainControl"}}""",
+            assert: (tile, args) => Assert.Same(tile, args.Detail))
+        .Event(c => c.TileFullscreen,
+            """{"detail": {"retType": "object", "type": "", "value": {"tile": {"refType": "name", "id": "mainControl"}, "state": true}}}""",
+            assert: (tile, args) =>
+            {
+                Assert.Same(tile, args.Detail.Tile);
+                Assert.True(args.Detail.State);
+            })
+        .Event(c => c.TileMaximize,
+            """{"detail": {"retType": "object", "type": "", "value": {"tile": {"refType": "name", "id": "mainControl"}, "state": false}}}""",
+            assert: (tile, args) =>
+            {
+                Assert.Same(tile, args.Detail.Tile);
+                Assert.False(args.Detail.State);
+            });
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
 }

--- a/tests/IgniteUI.Blazor.Tests/ToggleButtonTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ToggleButtonTests.cs
@@ -1,10 +1,20 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class ToggleButtonTests : BlazorComponentTestBase
+public class ToggleButtonTests : ComponentWithContractTestBase<IgbToggleButton>
 {
+    protected override ComponentContract<IgbToggleButton> InteropContract { get; } = new ComponentContract<IgbToggleButton>()
+        .Method(c => c.FocusComponentAsync(new IgbFocusOptions { PreventScroll = true }), c => c.FocusComponent(new IgbFocusOptions { PreventScroll = true }),
+            "focus", args: [new JsonSubset("""{"preventScroll": true}""")], types: ["Json"])
+        .Method(c => c.BlurComponentAsync(), c => c.BlurComponent(), "blur")
+        .Method(c => c.ClickAsync(), c => c.Click(), "click");
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
     [Fact]
     public void ToggleButton_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/TooltipTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TooltipTests.cs
@@ -1,10 +1,27 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class TooltipTests : BlazorComponentTestBase
+public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
 {
+    protected override ComponentContract<IgbTooltip> InteropContract { get; } = new ComponentContract<IgbTooltip>()
+        .Method(c => c.ShowAsync("target-1"), c => c.Show("target-1"), "show", returns: true,
+            args: ["target-1"], types: ["String"])
+        .Method(c => c.HideAsync(), c => c.Hide(), "hide", returns: false)
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle", returns: true)
+        .Event(c => c.Opening)
+        .Event(c => c.Opened)
+        .Event(c => c.Closing)
+        .Event(c => c.Closed);
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Tooltip_RendersCorrectElement()
     {

--- a/tests/IgniteUI.Blazor.Tests/TreeTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TreeTests.cs
@@ -1,10 +1,56 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Tests.Interop;
+using Microsoft.AspNetCore.Components;
 
 namespace IgniteUI.Blazor.Tests;
 
-public class TreeTests : BlazorComponentTestBase
+public class TreeTests : ComponentWithContractTestBase<IgbTree>
 {
+    /// <summary> Static arrange for contract tests adding two tree items </summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbTree>> arrange =
+        ps => ps.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IgbTreeItem>(0);
+            builder.AddAttribute(1, "id", "tree-item-1");
+            builder.CloseComponent();
+            builder.OpenComponent<IgbTreeItem>(2);
+            builder.AddAttribute(3, "id", "tree-item-2");
+            builder.CloseComponent();
+        });
+
+    protected override ComponentContract<IgbTree> InteropContract { get; } = new ComponentContract<IgbTree>()
+        .Event(c => c.ItemExpanding,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tree-item:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.Instance.ContentItems[1], args.Detail))
+        .Event(c => c.ItemExpanded,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tree-item:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.Instance.ContentItems[1], args.Detail))
+        .Event(c => c.ItemCollapsing,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tree-item:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.Instance.ContentItems[1], args.Detail))
+        .Event(c => c.ItemCollapsed,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tree-item:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.Instance.ContentItems[1], args.Detail))
+        .Event(c => c.ActiveItem,
+            arrange,
+            argsJson: (interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tree-item:nth-of-type(2)")}}}"}}""",
+            assert: (cut, args) => Assert.Same(cut.Instance.ContentItems[1], args.Detail))
+        .Event(c => c.SelectionChanged,
+            arrange,
+            argsJson: (interop, cut) => $$$$$"""{"detail": {"retType": "object", "type": "", "value": {"newSelection": {"retType": "Array", "type": "", "value": [{"refType": "name", "id": "{{{{{interop.ContainerIdOf(cut, "igc-tree-item:nth-of-type(2)")}}}}}"}]}}}}""",
+            assert: (cut, args) => Assert.Same(cut.Instance.ContentItems[1], args.Detail.NewSelection[0]));
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
+
+    [Fact]
+    public void Events_FollowContract() => VerifyEventContract();
+
     [Fact]
     public void Tree_RendersCorrectElement()
     {
@@ -109,4 +155,50 @@ public class TreeTests : BlazorComponentTestBase
 
         Assert.Contains("Child", cut.Find("igc-tree-item").InnerHtml);
     }
+}
+
+public class TreeItemTests : ComponentWithContractTestBase<IgbTreeItem>
+{
+    /// <summary>Real-usage host: IgbTree > "Node 1" > "Child 1.1" (the component under test).</summary>
+    static readonly RenderFragment treeHost = ContractHost.Of<IgbTree>(ps => ps.AddChildContent(b =>
+    {
+        b.OpenComponent<IgbTreeItem>(0);
+        b.AddAttribute(1, "Label", "Node 1");
+        b.AddAttribute(2, "ChildContent", (RenderFragment)(b2 =>
+        {
+            b2.OpenComponent<IgbTreeItem>(0);
+            b2.AddAttribute(1, "Label", "Child 1.1");
+            b2.CloseComponent();
+        }));
+        b.CloseComponent();
+    }));
+
+    protected override ComponentContract<IgbTreeItem> InteropContract { get; } = new ComponentContract<IgbTreeItem>()
+        .Method(c => c.ToggleAsync(), c => c.Toggle(), "toggle")
+        .Method(c => c.ExpandAsync(), c => c.Expand(), "expand")
+        .Method(c => c.CollapseAsync(), c => c.Collapse(), "collapse")
+        .Getter(c => c.GetPathAsync(), c => c.GetPath(), "Path",
+            arrange: ps => { },
+            returns: (interop, cut) => InteropReturn.Array("""[{"refType": "name", "id": "mainControl"}]"""),
+            assert: (cut, result) =>
+            {
+                Assert.Single(result);
+                Assert.Same(cut.Instance, result[0]);
+            })
+        .Getter(c => c.GetPathAsync(), c => c.GetPath(), "Path",
+            host: treeHost,
+            target: h => h.FindComponents<IgbTreeItem>()[1], // Child 1.1
+            returns: (interop, h) => InteropReturn.Array($$$"""[{"refType": "name", "id": "{{{interop.ContainerIdOf(h, "igc-tree-item")}}}"}, {"refType": "name", "id": "mainControl"}]"""),
+            assert: (h, result) =>
+            {
+                Assert.Equal(2, result.Length);
+                Assert.Same(h.FindComponents<IgbTreeItem>()[1].Instance, result[1]);
+                // TODO: the ancestor ref only resolves through FindByName on the item
+                // itself, which matches nothing but "mainControl" — the parent element
+                // currently decodes to null (observed: path = [self, null])
+                // Assert.Same(h.FindComponents<IgbTreeItem>()[0].Instance, result[0]);
+            });
+
+    [Fact]
+    public Task Methods_FollowContract() => VerifyMethodContract();
 }


### PR DESCRIPTION
_Interop migration plan: Phase 0 — contract tests._

## Summary

Adds unit-level interop coverage for the whole Lite component set. Every component with an interop surface now carries a **declarative interop contract** (`ComponentContract<TComponent>`) pinning how its public API maps onto the wire: method identifiers, argument serialization and type tags, return decoding (including component/data-item references), event-handler registration/removal transmissions plus JS→.NET event dispatch, and interop-borne props/data-source transfers. Plus shared semantics packs for readiness, event plumbing, the deferred return path, and message-borne serialization shapes.

**Zero product-source changes** — everything is driven through already-public surface (`WebCallback` JSInvokables, rendered `data-ig-id` markers, recorded `igSendMessage` payloads). The previous Moq swallow-everything `IJSRuntime` setup (which never verified an invocation) is replaced by bUnit's recording runtime; Moq is removed.

## Design: the `InteropHarness` seam

The interop infrastructure is slated for a rewrite, with components migrating one at a time. Contracts therefore avoid the wire format directly:

```
tests/IgniteUI.Blazor.Tests/Interop/
├── InteropHarness.cs                 # abstract seam + normalized models (InteropMethodCall,
│                                     #   InteropReturn incl. Object/Array/Ref/Deferred)
├── RendererMessageInteropHarness.cs  # THE place that knows the current wire format
├── InteropHarnessRegistry.cs         # component type → harness factory (default: legacy)
└── ComponentContract.cs              # declarative contract DSL + ContractHost
```

- Tests speak implementation-neutral terms: `SetupMethodResult`/`SetupPropertyRead`, `RaiseEvent`, `FindPropertyUpdate`, `PrimeReady`/`MakeReady`, `CompleteDeferred`, `ContainerIdOf`.
- The legacy adapter concentrates every wire detail: `igSendMessage`/`igCheckReady`/`igWaitForLoaded`, `RendererMessage` envelopes (`invokeMethod`/`description`/`descriptionDelta`/`refChanged` + `dataRef` indirection), `retType` return encoding, bare `refType` reference returns, `"p:"` property reads, `WebCallback` entry points, `data-ig-id` discovery.
- When a component moves to the new stack: implement a new harness, `Register<IgbX>(...)` — its contract runs unchanged and becomes the migration acceptance gate.

## The contract DSL (per-suite)

```csharp
protected override ComponentContract<IgbCombo<Item>> Contract { get; } = new ComponentContract<IgbCombo<Item>>()
    .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)        // wire id, args/types, return round-trip — sync twin held to the same expectations
    .Getter(c => c.GetSelectionAsync(), "Selection", arrange, returns, assert) // "p:" reads, ref-array decoding
    .Event(c => c.Change, arrange, argsJson, assert)                          // JS payload → typed args → handler
    .Prop(c => c.Open, true)                                                  // interop-borne props (wire name derived)
    .Prop(c => c.Data, items, wire: new JsonSubset("""[...]"""));             // data-source transfers via dataRef
```

- Arranged overloads cover reference semantics: child components resolved back to .NET instances (`Assert.Same`), data items as uuid refs, single bound-object returns (`InteropReturn.Ref` — bare, no envelope), and **hosted getters** (`ContractHost.Of<IgbTree>` + `target:`) for child components that only exist inside a parent (TreeItem's `GetPathAsync`).
- **Sync/async twins**: every `X()`/`XAsync()` pair is declared together (async selector, sync twin selector); the runner re-invokes the sync twin against the same wire/decode expectations, so manually-maintained twins can't drift apart silently. Sync variants have no other coverage anywhere — the Server-hosted integration TestBed only runs `*Async` methods.
- **Drift is a build break, not a green run**: poisoned `[Obsolete(error: true)]` overloads catch a void method growing a return (either twin), and the bare `.Event(c => c.Closing)` form only compiles for `EventCallback<IgbVoidEventArgs>` — a void event growing data demands a payload.
- Failures name the violated member and carry the declaring contract line as the top stack frame — test UIs navigate to the spec, not the shared runner. Per-suite one-liner facts (`Methods_/Props_/Events_FollowContract`) keep navigation in the suite; an inherited guard fact (`Contract_SectionsHaveFacts`) fails if a non-empty contract section has no runner fact.
- **`<Member>Script` parameters** (140 across the library, previously uncovered anywhere) are swept generically (`ScriptPropTests`): one reflection-enumerated theory per component asserts each script prop transmits a script reference for its target member — uniform generated surface, so no per-contract entries.
- Authoring guide: [`skills/igniteui-blazor-lite-testing/references/interop-contracts.md`](skills/igniteui-blazor-lite-testing/references/interop-contracts.md) (part of the new `igniteui-blazor-lite-testing` repo skill, which also documents the Playwright/TestBed integration setup).

## Relation to the integration suite (TestBed)

Overlap is intentional but the axes differ:

- **Integration** proves end-to-end behavior in a real browser — real client code, real DOM effects. It cannot attribute a failure to a side of the boundary, is slow, and skips everything listed in `componentsConfig.json` (`ExcludedProps`/`DependantMethods`/`ExcludedEvents`).
- **Contracts** pin the .NET side of the wire protocol at unit speed (ms, no browser): exact identifiers, serialized shapes, type tags, decode behavior — per instance, per member. They cover the config-excluded members (which previously had *no* coverage at all), and they survive the interop rewrite via the seam, turning migration into a per-component green-bar exercise.
- What contracts deliberately do NOT cover: client-side logic and rendering effects (integration/e2e), attribute rendering (existing bUnit facts).

## Product gaps found and pinned (not skipped)

Contracting the whole surface surfaced real defects; each is covered pinning current behavior with the *correct* assertion commented out under a `// TODO:` (grep `TODO` in the test project), ready to uncomment when fixed:

- `IgbStep`, `IgbSelectGroup`, `IgbDropdownGroup` have no parent-registration wiring — `GetSteps`/`GetGroups` refs always decode to null elements.
- `IgbTreeItem` path refs resolve only the self-reference — a nested item's `GetPathAsync` yields `[null, self]` (reproduced in-app).
- Combo `ChangeType` never decodes (wire key `type` vs `changeType`); numeric-key combos need `T=double`/`object` (boxed-double unbox).
- `MarshalByValueFactory` lacks a `WebDateRangeValue` entry — `DateRangePicker.GetCurrentValueAsync` throws on any non-null reply; `SelectAsync(range)` sends a meaningless element ref instead of `{start, end}`.
- `RendererSerializer.AddArrayProp` `values as object[]` cast breaks struct-element arrays (`int[]`, `double[]`).
- Unbinding an event callback crashes on both construction paths: a Razor-bound `default` arrives `Factory.Create`-wrapped (Receiver set, Delegate null), fails the setter's `Empty` check, and NREs in `CompareEventCallbacks` on `leftDelegate.Equals(...)`; a raw `Empty` (programmatic `SetParameters`) reaches the generated unset branch and NREs in `OnRefChanged` on `newValue.ToString()`.

## Verification

`dotnet test tests/IgniteUI.Blazor.Tests` — green on all TFMs (net8.0/net9.0/net10.0): 924 passed, 22 skipped (pre-existing), 0 failed per TFM. Contract runs are stub-driven and deterministic; the recording-concurrency path is snapshot-with-retry hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
