### PR TITLE
test(integration): Enable back Calendar and Rating Change events

### DIFF
--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
@@ -109,7 +109,7 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
             return result;
         }
 
-        public static Type? GetOriginEventDetailType(Type eventArgsType)
+        public static Type? GetOriginEventDetailType(Type eventArgsType, Type componentType)
         {
             var detailProp = eventArgsType.GetProperty("Detail", BindingFlags.Public | BindingFlags.Instance);
             if (detailProp == null)
@@ -121,6 +121,12 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
             if (detailType == typeof(string) || detailType.IsPrimitive || detailType == typeof(DateTime))
             {
                 return detailType;
+            }
+
+            // Calendar detail type is Object, but it actually casts to DateTime, so we need to handle that case specifically.
+            if (detailType == typeof(object) && componentType == typeof(IgbCalendar))
+            {
+                return typeof(DateTime);
             }
 
             return null;
@@ -200,7 +206,7 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
             }
             else if (type == typeof(double))
             {
-                value = 100.0;
+                value = 1.0;
             }
             else if (type == typeof(DateTime))
             {

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
@@ -123,7 +123,7 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
                 return detailType;
             }
 
-            // Calendar detail type is Object, but it actually casts to DateTime, so we need to handle that case specifically.
+            // TODO: Calendar detail type is Object, but it actually casts to DateTime, so we need to handle that case specifically.
             if (detailType == typeof(object) && componentType == typeof(IgbCalendar))
             {
                 return typeof(DateTime);

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
@@ -314,7 +314,7 @@
         {
             // hook events
             var arg = evt.PropertyType.GenericTypeArguments[0];
-            var detailType = ReflectionUtils.GetOriginEventDetailType(arg);
+            var detailType = ReflectionUtils.GetOriginEventDetailType(arg, selectedType);
             object? argDetailToSend = null;
             if (detailType != null)
             {
@@ -344,7 +344,7 @@
             }
 
             eventMessage = "";
-            var res = await JS.InvokeAsync<object>("triggerEvent", evtName, argDetailToSend);
+            var res = await JS.InvokeAsync<object>("triggerEvent", evtName, argDetailToSend, detailType == typeof(DateTime));
             await Task.Delay(100);
 
             if (eventMessage != $"Event fired.")

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
@@ -344,7 +344,7 @@
             }
 
             eventMessage = "";
-            var res = await JS.InvokeAsync<object>("triggerEvent", evtName, argDetailToSend, detailType == typeof(DateTime));
+            await JS.InvokeAsync<object>("triggerEvent", evtName, argDetailToSend, detailType == typeof(DateTime));
             await Task.Delay(100);
 
             if (eventMessage != $"Event fired.")

--- a/tests/IgniteUI.Blazor.Lite.TestBed/componentsConfig.json
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/componentsConfig.json
@@ -5,11 +5,7 @@
       "FormatOptions",
       "ResourceStrings"
     ],
-    "ExcludedEvents": [
-      // Does not fire from a synthetic igcChange event. Previously untested:
-      // the old source-scan two-way detection accidentally excluded it.
-      "Change"
-    ]
+    "ExcludedEvents": []
   },
   "IgbDatePicker": {
     "ExcludedProps": ["ResourceStrings"],
@@ -41,8 +37,7 @@
       "EmitEvent"
     ],
     "ExcludedEvents": [
-      // Does not fire from a synthetic igcChange event. Previously untested:
-      // the old source-scan two-way detection accidentally excluded it.
+      // Emits complex object, instance of igc-select-item, which we cannot easily mock.
       "Change"
     ],
     "DependantMethods": [
@@ -68,12 +63,7 @@
       "ReportValidityAsync",
       "CheckValidityAsync"
     ],
-    "ExcludedEvents": [
-      // Triggering igcChange resets client state and breaks the subsequent
-      // Value property check. Previously untested: the old source-scan
-      // two-way detection accidentally excluded it.
-      "Change"
-    ]
+    "ExcludedEvents": []
   },
   "IgbSlider": {
     "DependantMethods": [

--- a/tests/IgniteUI.Blazor.Lite.TestBed/wwwroot/app.js
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/wwwroot/app.js
@@ -91,7 +91,7 @@ function checkProp(propName) {
   return val;
 }
 
-function triggerEvent(eventName, arg) {
+function triggerEvent(eventName, arg, isDate) {
   var container = document.getElementById('container');
   var target = container.querySelectorAll(window.targetName)[0];
   console.log('Trigger event: ' + eventName);
@@ -103,7 +103,7 @@ function triggerEvent(eventName, arg) {
           bubbles: true,
           cancelable: false,
           composed: true,
-          detail: arg || {},
+          detail: isDate ? new Date(arg) : arg || {},
         },
         {},
       ),


### PR DESCRIPTION
Enable back Calendar and Rating Change events. Add more details on why Select Change cannot be mocked ATM.
Closes #262