### PR TITLE
test: bUnit update from 1.40.0 → 2.8.6 (latest stable)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <!-- Testing -->
-    <PackageVersion Include="bunit" Version="1.40.0" />
+    <PackageVersion Include="bunit" Version="2.8.6" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />

--- a/skills/igniteui-blazor-lite-testing/SKILL.md
+++ b/skills/igniteui-blazor-lite-testing/SKILL.md
@@ -32,7 +32,7 @@ The two suites overlap on purpose but answer different questions: integration pr
 
 ### Base classes
 
-- **`BlazorComponentTestBase`** — bUnit `TestContext` with setup `IIgniteUIBlazor` service, a recording JS runtime (`JSRuntimeMode.Loose`; every invocation recorded) and an `Interop` harness property (an `InteropHarness`, resolved per component type via `InteropFor<TComponent>()`). Default base for suites without an interop contract.
+- **`BlazorComponentTestBase`** — bUnit `BunitContext` with setup `IIgniteUIBlazor` service, a recording JS runtime (`JSRuntimeMode.Loose`; every invocation recorded) and an `Interop` harness property (an `InteropHarness`, resolved per component type via `InteropFor<TComponent>()`). Default base for suites without an interop contract.
 - **`ComponentWithContractTestBase<TComponent>`** — adds a declarative `ComponentContract<TComponent>`, `protected` runners (`VerifyMethodContract`/`VerifyPropContract`/`VerifyEventContract`) that the suite exposes as one-liner `[Fact]`s, and an inherited `Contract_SectionsHaveFacts` guard that fails if a non-empty contract section has no runner fact. Exactly one suite per component carries the contract; sync/async method pairs are declared together via the twin overloads.
 
 ### Running

--- a/tests/IgniteUI.Blazor.Tests/AlertTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/AlertTests.cs
@@ -21,7 +21,7 @@ public class SnackbarTests : ComponentWithContractTestBase<IgbSnackbar>
     [Fact]
     public void Snackbar_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSnackbar>();
+        var cut = Render<IgbSnackbar>();
         Assert.NotNull(cut.Find("igc-snackbar"));
     }
 
@@ -41,7 +41,7 @@ public class SnackbarTests : ComponentWithContractTestBase<IgbSnackbar>
     [Fact]
     public void Snackbar_ActionText_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSnackbar>(parameters =>
+        var cut = Render<IgbSnackbar>(parameters =>
             parameters.Add(p => p.ActionText, "UNDO"));
 
         var element = cut.Find("igc-snackbar");
@@ -51,7 +51,7 @@ public class SnackbarTests : ComponentWithContractTestBase<IgbSnackbar>
     [Fact]
     public void Snackbar_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSnackbar>(parameters =>
+        var cut = Render<IgbSnackbar>(parameters =>
             parameters.Add(p => p.Open, true));
 
         var element = cut.Find("igc-snackbar");
@@ -61,7 +61,7 @@ public class SnackbarTests : ComponentWithContractTestBase<IgbSnackbar>
     [Fact]
     public void Snackbar_DisplayTime_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSnackbar>(parameters =>
+        var cut = Render<IgbSnackbar>(parameters =>
             parameters.Add(p => p.DisplayTime, 5000.0));
 
         var element = cut.Find("igc-snackbar");
@@ -71,7 +71,7 @@ public class SnackbarTests : ComponentWithContractTestBase<IgbSnackbar>
     [Fact]
     public void Snackbar_KeepOpen_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSnackbar>(parameters =>
+        var cut = Render<IgbSnackbar>(parameters =>
             parameters.Add(p => p.KeepOpen, true));
 
         var element = cut.Find("igc-snackbar");
@@ -81,7 +81,7 @@ public class SnackbarTests : ComponentWithContractTestBase<IgbSnackbar>
     [Fact]
     public void Snackbar_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbSnackbar>(parameters =>
+        var cut = Render<IgbSnackbar>(parameters =>
             parameters.AddChildContent("Item deleted"));
 
         Assert.Contains("Item deleted", cut.Markup);
@@ -101,7 +101,7 @@ public class ToastTests : ComponentWithContractTestBase<IgbToast>
     [Fact]
     public void Toast_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbToast>();
+        var cut = Render<IgbToast>();
         Assert.NotNull(cut.Find("igc-toast"));
     }
 
@@ -121,7 +121,7 @@ public class ToastTests : ComponentWithContractTestBase<IgbToast>
     [Fact]
     public void Toast_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToast>(parameters =>
+        var cut = Render<IgbToast>(parameters =>
             parameters.Add(p => p.Open, true));
 
         var element = cut.Find("igc-toast");
@@ -131,7 +131,7 @@ public class ToastTests : ComponentWithContractTestBase<IgbToast>
     [Fact]
     public void Toast_DisplayTime_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToast>(parameters =>
+        var cut = Render<IgbToast>(parameters =>
             parameters.Add(p => p.DisplayTime, 3000.0));
 
         var element = cut.Find("igc-toast");
@@ -141,7 +141,7 @@ public class ToastTests : ComponentWithContractTestBase<IgbToast>
     [Fact]
     public void Toast_KeepOpen_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToast>(parameters =>
+        var cut = Render<IgbToast>(parameters =>
             parameters.Add(p => p.KeepOpen, true));
 
         var element = cut.Find("igc-toast");
@@ -151,7 +151,7 @@ public class ToastTests : ComponentWithContractTestBase<IgbToast>
     [Fact]
     public void Toast_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbToast>(parameters =>
+        var cut = Render<IgbToast>(parameters =>
             parameters.AddChildContent("Operation successful"));
 
         Assert.Contains("Operation successful", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/AvatarTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/AvatarTests.cs
@@ -8,7 +8,7 @@ public class AvatarTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbAvatar>();
+        var cut = Render<IgbAvatar>();
         Assert.NotNull(cut.Find("igc-avatar"));
     }
 
@@ -22,7 +22,7 @@ public class AvatarTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_Src_RendersAttribute()
     {
-        var cut = RenderComponent<IgbAvatar>(parameters =>
+        var cut = Render<IgbAvatar>(parameters =>
             parameters.Add(p => p.Src, "https://example.com/avatar.png"));
 
         var element = cut.Find("igc-avatar");
@@ -32,7 +32,7 @@ public class AvatarTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_Alt_RendersAttribute()
     {
-        var cut = RenderComponent<IgbAvatar>(parameters =>
+        var cut = Render<IgbAvatar>(parameters =>
             parameters.Add(p => p.Alt, "User avatar"));
 
         var element = cut.Find("igc-avatar");
@@ -42,7 +42,7 @@ public class AvatarTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_Initials_RendersAttribute()
     {
-        var cut = RenderComponent<IgbAvatar>(parameters =>
+        var cut = Render<IgbAvatar>(parameters =>
             parameters.Add(p => p.Initials, "JD"));
 
         var element = cut.Find("igc-avatar");
@@ -52,7 +52,7 @@ public class AvatarTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_Shape_Circle()
     {
-        var cut = RenderComponent<IgbAvatar>(parameters =>
+        var cut = Render<IgbAvatar>(parameters =>
             parameters.Add(p => p.Shape, AvatarShape.Circle));
 
         var element = cut.Find("igc-avatar");
@@ -62,7 +62,7 @@ public class AvatarTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_Shape_Rounded()
     {
-        var cut = RenderComponent<IgbAvatar>(parameters =>
+        var cut = Render<IgbAvatar>(parameters =>
             parameters.Add(p => p.Shape, AvatarShape.Rounded));
 
         var element = cut.Find("igc-avatar");

--- a/tests/IgniteUI.Blazor.Tests/BadgeExtendedTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/BadgeExtendedTests.cs
@@ -12,7 +12,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Variant_Info()
     {
-        var cut = RenderComponent<IgbBadge>(p =>
+        var cut = Render<IgbBadge>(p =>
             p.Add(x => x.Variant, StyleVariant.Info));
 
         Assert.Equal("info", cut.Find("igc-badge").GetAttribute("variant"));
@@ -21,7 +21,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Variant_Success()
     {
-        var cut = RenderComponent<IgbBadge>(p =>
+        var cut = Render<IgbBadge>(p =>
             p.Add(x => x.Variant, StyleVariant.Success));
 
         Assert.Equal("success", cut.Find("igc-badge").GetAttribute("variant"));
@@ -30,7 +30,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Variant_Warning()
     {
-        var cut = RenderComponent<IgbBadge>(p =>
+        var cut = Render<IgbBadge>(p =>
             p.Add(x => x.Variant, StyleVariant.Warning));
 
         Assert.Equal("warning", cut.Find("igc-badge").GetAttribute("variant"));
@@ -39,7 +39,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Variant_Danger()
     {
-        var cut = RenderComponent<IgbBadge>(p =>
+        var cut = Render<IgbBadge>(p =>
             p.Add(x => x.Variant, StyleVariant.Danger));
 
         Assert.Equal("danger", cut.Find("igc-badge").GetAttribute("variant"));
@@ -48,7 +48,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Badge_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbBadge>(p =>
+        var cut = Render<IgbBadge>(p =>
             p.AddChildContent("99+"));
 
         Assert.Contains("99+", cut.Find("igc-badge").InnerHtml);
@@ -58,7 +58,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_Shape_Circle()
     {
-        var cut = RenderComponent<IgbAvatar>(p =>
+        var cut = Render<IgbAvatar>(p =>
             p.Add(x => x.Shape, AvatarShape.Circle));
 
         Assert.Equal("circle", cut.Find("igc-avatar").GetAttribute("shape"));
@@ -67,7 +67,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_Shape_Rounded()
     {
-        var cut = RenderComponent<IgbAvatar>(p =>
+        var cut = Render<IgbAvatar>(p =>
             p.Add(x => x.Shape, AvatarShape.Rounded));
 
         Assert.Equal("rounded", cut.Find("igc-avatar").GetAttribute("shape"));
@@ -76,7 +76,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_Shape_Square()
     {
-        var cut = RenderComponent<IgbAvatar>(p =>
+        var cut = Render<IgbAvatar>(p =>
             p.Add(x => x.Shape, AvatarShape.Square));
 
         Assert.Equal("square", cut.Find("igc-avatar").GetAttribute("shape"));
@@ -85,7 +85,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbAvatar>(p =>
+        var cut = Render<IgbAvatar>(p =>
             p.AddChildContent("<img src=\"avatar.png\" />"));
 
         Assert.Contains("img", cut.Find("igc-avatar").InnerHtml);
@@ -95,7 +95,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Chip_Variant_Primary()
     {
-        var cut = RenderComponent<IgbChip>(p =>
+        var cut = Render<IgbChip>(p =>
             p.Add(x => x.Variant, StyleVariant.Primary));
 
         Assert.Equal("primary", cut.Find("igc-chip").GetAttribute("variant"));
@@ -104,7 +104,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Chip_Variant_Info()
     {
-        var cut = RenderComponent<IgbChip>(p =>
+        var cut = Render<IgbChip>(p =>
             p.Add(x => x.Variant, StyleVariant.Info));
 
         Assert.Equal("info", cut.Find("igc-chip").GetAttribute("variant"));
@@ -113,7 +113,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Chip_Variant_Success()
     {
-        var cut = RenderComponent<IgbChip>(p =>
+        var cut = Render<IgbChip>(p =>
             p.Add(x => x.Variant, StyleVariant.Success));
 
         Assert.Equal("success", cut.Find("igc-chip").GetAttribute("variant"));
@@ -122,7 +122,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Chip_Variant_Warning()
     {
-        var cut = RenderComponent<IgbChip>(p =>
+        var cut = Render<IgbChip>(p =>
             p.Add(x => x.Variant, StyleVariant.Warning));
 
         Assert.Equal("warning", cut.Find("igc-chip").GetAttribute("variant"));
@@ -131,7 +131,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Chip_Variant_Danger()
     {
-        var cut = RenderComponent<IgbChip>(p =>
+        var cut = Render<IgbChip>(p =>
             p.Add(x => x.Variant, StyleVariant.Danger));
 
         Assert.Equal("danger", cut.Find("igc-chip").GetAttribute("variant"));
@@ -140,7 +140,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Chip_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbChip>(p =>
+        var cut = Render<IgbChip>(p =>
             p.AddChildContent("Technology"));
 
         Assert.Contains("Technology", cut.Find("igc-chip").InnerHtml);
@@ -150,7 +150,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Icon_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbIcon>(p =>
+        var cut = Render<IgbIcon>(p =>
             p.AddChildContent("<svg></svg>"));
 
         Assert.Contains("svg", cut.Find("igc-icon").InnerHtml);
@@ -160,7 +160,7 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Ripple_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbRipple>();
+        var cut = Render<IgbRipple>();
         cut.Find("igc-ripple").Should_Exist();
     }
 
@@ -168,14 +168,14 @@ public class BadgeExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Divider_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbDivider>();
+        var cut = Render<IgbDivider>();
         cut.Find("igc-divider").Should_Exist();
     }
 
     [Fact]
     public void Divider_LineType_Dashed()
     {
-        var cut = RenderComponent<IgbDivider>(p =>
+        var cut = Render<IgbDivider>(p =>
             p.Add(x => x.LineType, DividerType.Dashed));
 
         Assert.Equal("dashed", cut.Find("igc-divider").GetAttribute("type"));

--- a/tests/IgniteUI.Blazor.Tests/BadgeTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/BadgeTests.cs
@@ -8,7 +8,7 @@ public class BadgeTests : BlazorComponentTestBase
     [Fact]
     public void Badge_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbBadge>();
+        var cut = Render<IgbBadge>();
         Assert.NotNull(cut.Find("igc-badge"));
     }
 
@@ -22,7 +22,7 @@ public class BadgeTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Outlined_RendersAttribute()
     {
-        var cut = RenderComponent<IgbBadge>(parameters =>
+        var cut = Render<IgbBadge>(parameters =>
             parameters.Add(p => p.Outlined, true));
 
         var element = cut.Find("igc-badge");
@@ -32,7 +32,7 @@ public class BadgeTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Dot_RendersAttribute()
     {
-        var cut = RenderComponent<IgbBadge>(parameters =>
+        var cut = Render<IgbBadge>(parameters =>
             parameters.Add(p => p.Dot, true));
 
         var element = cut.Find("igc-badge");
@@ -42,7 +42,7 @@ public class BadgeTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Shape_Rounded()
     {
-        var cut = RenderComponent<IgbBadge>(parameters =>
+        var cut = Render<IgbBadge>(parameters =>
             parameters.Add(p => p.Shape, BadgeShape.Rounded));
 
         var element = cut.Find("igc-badge");
@@ -52,7 +52,7 @@ public class BadgeTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Shape_Square()
     {
-        var cut = RenderComponent<IgbBadge>(parameters =>
+        var cut = Render<IgbBadge>(parameters =>
             parameters.Add(p => p.Shape, BadgeShape.Square));
 
         var element = cut.Find("igc-badge");
@@ -62,7 +62,7 @@ public class BadgeTests : BlazorComponentTestBase
     [Fact]
     public void Badge_Variant_RendersAttribute()
     {
-        var cut = RenderComponent<IgbBadge>(parameters =>
+        var cut = Render<IgbBadge>(parameters =>
             parameters.Add(p => p.Variant, StyleVariant.Danger));
 
         var element = cut.Find("igc-badge");

--- a/tests/IgniteUI.Blazor.Tests/BaseControlTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/BaseControlTests.cs
@@ -11,7 +11,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_ClassParameter_OverridesDefault()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.Add(p => p.Class, "custom-class"));
 
         var element = cut.Find("igc-button");
@@ -21,7 +21,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_AdditionalAttributes_AreRendered()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.Add(p => p.AdditionalAttributes,
                 new Dictionary<string, object> { { "data-testid", "btn-1" } }));
 
@@ -32,7 +32,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DataIgId_IsPresent()
     {
-        var cut = RenderComponent<IgbButton>();
+        var cut = Render<IgbButton>();
         var element = cut.Find("igc-button");
         Assert.NotNull(element.GetAttribute("data-ig-id"));
     }
@@ -40,7 +40,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DefaultClass_FollowsNaming()
     {
-        var cut = RenderComponent<IgbBadge>();
+        var cut = Render<IgbBadge>();
         var element = cut.Find("igc-badge");
         Assert.Equal("igb-web-badge", element.GetAttribute("class"));
     }
@@ -48,7 +48,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DefaultClass_Button()
     {
-        var cut = RenderComponent<IgbButton>();
+        var cut = Render<IgbButton>();
         var element = cut.Find("igc-button");
         Assert.Equal("igb-web-button", element.GetAttribute("class"));
     }
@@ -56,7 +56,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DefaultClass_Checkbox()
     {
-        var cut = RenderComponent<IgbCheckbox>();
+        var cut = Render<IgbCheckbox>();
         var element = cut.Find("igc-checkbox");
         Assert.Equal("igb-web-checkbox", element.GetAttribute("class"));
     }
@@ -64,7 +64,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DefaultClass_Switch()
     {
-        var cut = RenderComponent<IgbSwitch>();
+        var cut = Render<IgbSwitch>();
         var element = cut.Find("igc-switch");
         Assert.Equal("igb-web-switch", element.GetAttribute("class"));
     }
@@ -72,7 +72,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DefaultClass_Avatar()
     {
-        var cut = RenderComponent<IgbAvatar>();
+        var cut = Render<IgbAvatar>();
         var element = cut.Find("igc-avatar");
         Assert.Equal("igb-web-avatar", element.GetAttribute("class"));
     }
@@ -80,7 +80,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DefaultClass_Icon()
     {
-        var cut = RenderComponent<IgbIcon>();
+        var cut = Render<IgbIcon>();
         var element = cut.Find("igc-icon");
         Assert.Equal("igb-web-icon", element.GetAttribute("class"));
     }
@@ -88,7 +88,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DefaultClass_Dialog()
     {
-        var cut = RenderComponent<IgbDialog>();
+        var cut = Render<IgbDialog>();
         var element = cut.Find("igc-dialog");
         Assert.Equal("igb-web-dialog", element.GetAttribute("class"));
     }
@@ -96,7 +96,7 @@ public class BaseControlTests : BlazorComponentTestBase
     [Fact]
     public void Component_DefaultClass_Slider()
     {
-        var cut = RenderComponent<IgbSlider>();
+        var cut = Render<IgbSlider>();
         var element = cut.Find("igc-slider");
         Assert.Equal("igb-web-slider", element.GetAttribute("class"));
     }

--- a/tests/IgniteUI.Blazor.Tests/BlazorComponentTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/BlazorComponentTestBase.cs
@@ -12,7 +12,7 @@ namespace IgniteUI.Blazor.Tests;
 /// invocation is recorded). Interop traffic is observed and driven through the
 /// <see cref="InteropHarness"/> seam rather than against the wire format directly.
 /// </summary>
-public abstract class BlazorComponentTestBase : TestContext
+public abstract class BlazorComponentTestBase : BunitContext
 {
     protected IIgniteUIBlazor IgniteUIBlazor { get; }
 

--- a/tests/IgniteUI.Blazor.Tests/ButtonGroupTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ButtonGroupTests.cs
@@ -20,14 +20,14 @@ public class ButtonGroupTests : ComponentWithContractTestBase<IgbButtonGroup>
     [Fact]
     public void ButtonGroup_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbButtonGroup>();
+        var cut = Render<IgbButtonGroup>();
         cut.Find("igc-button-group").Should_Exist();
     }
 
     [Fact]
     public void ButtonGroup_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbButtonGroup>(p =>
+        var cut = Render<IgbButtonGroup>(p =>
             p.Add(x => x.Disabled, true));
 
         Assert.NotNull(cut.Find("igc-button-group").GetAttribute("disabled"));
@@ -36,7 +36,7 @@ public class ButtonGroupTests : ComponentWithContractTestBase<IgbButtonGroup>
     [Fact]
     public void ButtonGroup_Selection_Single()
     {
-        var cut = RenderComponent<IgbButtonGroup>(p =>
+        var cut = Render<IgbButtonGroup>(p =>
             p.Add(x => x.Selection, ButtonGroupSelection.Single));
 
         Assert.Equal("single", cut.Find("igc-button-group").GetAttribute("selection"));
@@ -45,7 +45,7 @@ public class ButtonGroupTests : ComponentWithContractTestBase<IgbButtonGroup>
     [Fact]
     public void ButtonGroup_Selection_Multiple()
     {
-        var cut = RenderComponent<IgbButtonGroup>(p =>
+        var cut = Render<IgbButtonGroup>(p =>
             p.Add(x => x.Selection, ButtonGroupSelection.Multiple));
 
         Assert.Equal("multiple", cut.Find("igc-button-group").GetAttribute("selection"));
@@ -54,7 +54,7 @@ public class ButtonGroupTests : ComponentWithContractTestBase<IgbButtonGroup>
     [Fact]
     public void ButtonGroup_Selection_SingleRequired()
     {
-        var cut = RenderComponent<IgbButtonGroup>(p =>
+        var cut = Render<IgbButtonGroup>(p =>
             p.Add(x => x.Selection, ButtonGroupSelection.SingleRequired));
 
         Assert.Equal("single-required", cut.Find("igc-button-group").GetAttribute("selection"));
@@ -63,7 +63,7 @@ public class ButtonGroupTests : ComponentWithContractTestBase<IgbButtonGroup>
     [Fact]
     public void ButtonGroup_Alignment_Vertical()
     {
-        var cut = RenderComponent<IgbButtonGroup>(p =>
+        var cut = Render<IgbButtonGroup>(p =>
             p.Add(x => x.Alignment, ContentOrientation.Vertical));
 
         Assert.Equal("vertical", cut.Find("igc-button-group").GetAttribute("alignment"));
@@ -72,7 +72,7 @@ public class ButtonGroupTests : ComponentWithContractTestBase<IgbButtonGroup>
     [Fact]
     public void ButtonGroup_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbButtonGroup>(p =>
+        var cut = Render<IgbButtonGroup>(p =>
             p.AddChildContent("<igc-toggle-button>A</igc-toggle-button>"));
 
         Assert.Contains("A", cut.Find("igc-button-group").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/ButtonTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ButtonTests.cs
@@ -24,14 +24,14 @@ public class ButtonTests : ComponentWithContractTestBase<IgbButton>
     [Fact]
     public void Button_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbButton>();
+        var cut = Render<IgbButton>();
         cut.Find("igc-button").Should_Exist();
     }
 
     [Fact]
     public void Button_DefaultVariant_IsContained()
     {
-        var cut = RenderComponent<IgbButton>();
+        var cut = Render<IgbButton>();
         var element = cut.Find("igc-button");
         // Default variant should not emit attribute (only dirty props are serialized)
         Assert.NotNull(element);
@@ -40,7 +40,7 @@ public class ButtonTests : ComponentWithContractTestBase<IgbButton>
     [Fact]
     public void Button_SetVariant_Flat()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.Add(p => p.Variant, ButtonVariant.Flat));
 
         var element = cut.Find("igc-button");
@@ -50,7 +50,7 @@ public class ButtonTests : ComponentWithContractTestBase<IgbButton>
     [Fact]
     public void Button_SetVariant_Outlined()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.Add(p => p.Variant, ButtonVariant.Outlined));
 
         var element = cut.Find("igc-button");
@@ -60,7 +60,7 @@ public class ButtonTests : ComponentWithContractTestBase<IgbButton>
     [Fact]
     public void Button_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-button");
@@ -70,7 +70,7 @@ public class ButtonTests : ComponentWithContractTestBase<IgbButton>
     [Fact]
     public void Button_NotDisabled_NoAttribute()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.Add(p => p.Disabled, false));
 
         var element = cut.Find("igc-button");
@@ -81,7 +81,7 @@ public class ButtonTests : ComponentWithContractTestBase<IgbButton>
     [Fact]
     public void Button_Href_RendersAttribute()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.Add(p => p.Href, "https://example.com"));
 
         var element = cut.Find("igc-button");
@@ -91,7 +91,7 @@ public class ButtonTests : ComponentWithContractTestBase<IgbButton>
     [Fact]
     public void Button_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.AddChildContent("Click Me"));
 
         cut.Find("igc-button").MarkupMatches(@"<igc-button class=""igb-web-button"" data-ig-id:ignore>Click Me</igc-button>");
@@ -113,7 +113,7 @@ public class ButtonTests : ComponentWithContractTestBase<IgbButton>
     [Fact]
     public void Button_DisplayType_RendersCorrectly()
     {
-        var cut = RenderComponent<IgbButton>(parameters =>
+        var cut = Render<IgbButton>(parameters =>
             parameters.Add(p => p.DisplayType, ButtonBaseType.Submit));
 
         var element = cut.Find("igc-button");

--- a/tests/IgniteUI.Blazor.Tests/CardTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CardTests.cs
@@ -8,7 +8,7 @@ public class CardTests : BlazorComponentTestBase
     [Fact]
     public void Card_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCard>();
+        var cut = Render<IgbCard>();
         Assert.NotNull(cut.Find("igc-card"));
     }
 
@@ -22,7 +22,7 @@ public class CardTests : BlazorComponentTestBase
     [Fact]
     public void Card_Elevated_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCard>(parameters =>
+        var cut = Render<IgbCard>(parameters =>
             parameters.Add(p => p.Elevated, true));
 
         var element = cut.Find("igc-card");
@@ -32,7 +32,7 @@ public class CardTests : BlazorComponentTestBase
     [Fact]
     public void Card_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCard>(parameters =>
+        var cut = Render<IgbCard>(parameters =>
             parameters.AddChildContent("<p>Card content</p>"));
 
         Assert.Contains("Card content", cut.Markup);
@@ -50,7 +50,7 @@ public class CardHeaderTests : BlazorComponentTestBase
     [Fact]
     public void CardHeader_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCardHeader>();
+        var cut = Render<IgbCardHeader>();
         Assert.NotNull(cut.Find("igc-card-header"));
     }
 
@@ -67,7 +67,7 @@ public class CardContentTests : BlazorComponentTestBase
     [Fact]
     public void CardContent_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCardContent>();
+        var cut = Render<IgbCardContent>();
         Assert.NotNull(cut.Find("igc-card-content"));
     }
 
@@ -84,7 +84,7 @@ public class CardActionsTests : BlazorComponentTestBase
     [Fact]
     public void CardActions_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCardActions>();
+        var cut = Render<IgbCardActions>();
         Assert.NotNull(cut.Find("igc-card-actions"));
     }
 
@@ -101,7 +101,7 @@ public class CardMediaTests : BlazorComponentTestBase
     [Fact]
     public void CardMedia_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCardMedia>();
+        var cut = Render<IgbCardMedia>();
         Assert.NotNull(cut.Find("igc-card-media"));
     }
 

--- a/tests/IgniteUI.Blazor.Tests/CarouselTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CarouselTests.cs
@@ -33,14 +33,14 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCarousel>();
+        var cut = Render<IgbCarousel>();
         cut.Find("igc-carousel").Should_Exist();
     }
 
     [Fact]
     public void Carousel_DisableLoop_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.DisableLoop, true));
 
         Assert.NotNull(cut.Find("igc-carousel").GetAttribute("disable-loop"));
@@ -49,7 +49,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_HideNavigation_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.HideNavigation, true));
 
         Assert.NotNull(cut.Find("igc-carousel").GetAttribute("hide-navigation"));
@@ -58,7 +58,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_HideIndicators_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.HideIndicators, true));
 
         Assert.NotNull(cut.Find("igc-carousel").GetAttribute("hide-indicators"));
@@ -67,7 +67,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_Vertical_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.Vertical, true));
 
         Assert.NotNull(cut.Find("igc-carousel").GetAttribute("vertical"));
@@ -76,7 +76,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_DisablePauseOnInteraction_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.DisablePauseOnInteraction, true));
 
         Assert.NotNull(cut.Find("igc-carousel").GetAttribute("disable-pause-on-interaction"));
@@ -85,7 +85,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_IndicatorsOrientation_Start()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.IndicatorsOrientation, CarouselIndicatorsOrientation.Start));
 
         Assert.Equal("start", cut.Find("igc-carousel").GetAttribute("indicators-orientation"));
@@ -94,7 +94,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_AnimationType_Fade()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.AnimationType, HorizontalTransitionAnimation.Fade));
 
         Assert.Equal("fade", cut.Find("igc-carousel").GetAttribute("animation-type"));
@@ -103,7 +103,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_AnimationType_None()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.AnimationType, HorizontalTransitionAnimation.None));
 
         Assert.Equal("none", cut.Find("igc-carousel").GetAttribute("animation-type"));
@@ -112,7 +112,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_Interval_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.Interval, 5000));
 
         Assert.Equal("5000", cut.Find("igc-carousel").GetAttribute("interval"));
@@ -121,7 +121,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_MaximumIndicatorsCount_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.Add(x => x.MaximumIndicatorsCount, 10));
 
         Assert.Equal("10", cut.Find("igc-carousel").GetAttribute("maximum-indicators-count"));
@@ -130,7 +130,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void Carousel_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCarousel>(p =>
+        var cut = Render<IgbCarousel>(p =>
             p.AddChildContent("<div>Slide Content</div>"));
 
         cut.Find("igc-carousel").InnerHtml.Contains("Slide Content");
@@ -139,14 +139,14 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void CarouselSlide_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCarouselSlide>();
+        var cut = Render<IgbCarouselSlide>();
         cut.Find("igc-carousel-slide").Should_Exist();
     }
 
     [Fact]
     public void CarouselSlide_Active_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCarouselSlide>(p =>
+        var cut = Render<IgbCarouselSlide>(p =>
             p.Add(x => x.Active, true));
 
         Assert.NotNull(cut.Find("igc-carousel-slide").GetAttribute("active"));
@@ -155,7 +155,7 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
     [Fact]
     public void CarouselIndicator_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCarouselIndicator>();
+        var cut = Render<IgbCarouselIndicator>();
         cut.Find("igc-carousel-indicator").Should_Exist();
     }
 }

--- a/tests/IgniteUI.Blazor.Tests/ChatTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ChatTests.cs
@@ -82,7 +82,7 @@ public class ChatTests : ComponentWithContractTestBase<IgbChat>
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void Chat_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbChat>();
+        var cut = Render<IgbChat>();
         Assert.NotNull(cut.Find("igc-chat"));
     }
 

--- a/tests/IgniteUI.Blazor.Tests/CheckboxTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CheckboxTests.cs
@@ -35,7 +35,7 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
     [Fact]
     public void Checkbox_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCheckbox>();
+        var cut = Render<IgbCheckbox>();
         Assert.NotNull(cut.Find("igc-checkbox"));
     }
 
@@ -55,7 +55,7 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
     [Fact]
     public void Checkbox_Checked_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCheckbox>(parameters =>
+        var cut = Render<IgbCheckbox>(parameters =>
             parameters.Add(p => p.Checked, true));
 
         var element = cut.Find("igc-checkbox");
@@ -65,7 +65,7 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
     [Fact]
     public void Checkbox_Indeterminate_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCheckbox>(parameters =>
+        var cut = Render<IgbCheckbox>(parameters =>
             parameters.Add(p => p.Indeterminate, true));
 
         var element = cut.Find("igc-checkbox");
@@ -75,7 +75,7 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
     [Fact]
     public void Checkbox_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCheckbox>(parameters =>
+        var cut = Render<IgbCheckbox>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-checkbox");
@@ -85,7 +85,7 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
     [Fact]
     public void Checkbox_Required_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCheckbox>(parameters =>
+        var cut = Render<IgbCheckbox>(parameters =>
             parameters.Add(p => p.Required, true));
 
         var element = cut.Find("igc-checkbox");
@@ -95,7 +95,7 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
     [Fact]
     public void Checkbox_LabelPosition_Before()
     {
-        var cut = RenderComponent<IgbCheckbox>(parameters =>
+        var cut = Render<IgbCheckbox>(parameters =>
             parameters.Add(p => p.LabelPosition, ToggleLabelPosition.Before));
 
         var element = cut.Find("igc-checkbox");
@@ -105,7 +105,7 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
     [Fact]
     public void Checkbox_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCheckbox>(parameters =>
+        var cut = Render<IgbCheckbox>(parameters =>
             parameters.Add(p => p.Value, "test-value"));
 
         var element = cut.Find("igc-checkbox");
@@ -115,7 +115,7 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
     [Fact]
     public void Checkbox_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCheckbox>(parameters =>
+        var cut = Render<IgbCheckbox>(parameters =>
             parameters.AddChildContent("Accept terms"));
 
         Assert.Contains("Accept terms", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/ChipTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ChipTests.cs
@@ -24,7 +24,7 @@ public class ChipTests : ComponentWithContractTestBase<IgbChip>
     [Fact]
     public void Chip_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbChip>();
+        var cut = Render<IgbChip>();
         Assert.NotNull(cut.Find("igc-chip"));
     }
 
@@ -38,7 +38,7 @@ public class ChipTests : ComponentWithContractTestBase<IgbChip>
     [Fact]
     public void Chip_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbChip>(parameters =>
+        var cut = Render<IgbChip>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-chip");
@@ -48,7 +48,7 @@ public class ChipTests : ComponentWithContractTestBase<IgbChip>
     [Fact]
     public void Chip_Removable_RendersAttribute()
     {
-        var cut = RenderComponent<IgbChip>(parameters =>
+        var cut = Render<IgbChip>(parameters =>
             parameters.Add(p => p.Removable, true));
 
         var element = cut.Find("igc-chip");
@@ -58,7 +58,7 @@ public class ChipTests : ComponentWithContractTestBase<IgbChip>
     [Fact]
     public void Chip_Selectable_RendersAttribute()
     {
-        var cut = RenderComponent<IgbChip>(parameters =>
+        var cut = Render<IgbChip>(parameters =>
             parameters.Add(p => p.Selectable, true));
 
         var element = cut.Find("igc-chip");
@@ -68,7 +68,7 @@ public class ChipTests : ComponentWithContractTestBase<IgbChip>
     [Fact]
     public void Chip_Selected_RendersAttribute()
     {
-        var cut = RenderComponent<IgbChip>(parameters =>
+        var cut = Render<IgbChip>(parameters =>
             parameters.Add(p => p.Selected, true));
 
         var element = cut.Find("igc-chip");
@@ -78,7 +78,7 @@ public class ChipTests : ComponentWithContractTestBase<IgbChip>
     [Fact]
     public void Chip_Variant_RendersAttribute()
     {
-        var cut = RenderComponent<IgbChip>(parameters =>
+        var cut = Render<IgbChip>(parameters =>
             parameters.Add(p => p.Variant, StyleVariant.Info));
 
         var element = cut.Find("igc-chip");
@@ -88,7 +88,7 @@ public class ChipTests : ComponentWithContractTestBase<IgbChip>
     [Fact]
     public void Chip_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbChip>(parameters =>
+        var cut = Render<IgbChip>(parameters =>
             parameters.AddChildContent("Tag Label"));
 
         Assert.Contains("Tag Label", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/CircularGradientTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CircularGradientTests.cs
@@ -8,14 +8,14 @@ public class CircularGradientTests : BlazorComponentTestBase
     [Fact]
     public void CircularGradient_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCircularGradient>();
+        var cut = Render<IgbCircularGradient>();
         cut.Find("igc-circular-gradient").Should_Exist();
     }
 
     [Fact]
     public void CircularGradient_Offset_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularGradient>(p =>
+        var cut = Render<IgbCircularGradient>(p =>
             p.Add(x => x.Offset, "0%"));
 
         Assert.Equal("0%", cut.Find("igc-circular-gradient").GetAttribute("offset"));
@@ -24,7 +24,7 @@ public class CircularGradientTests : BlazorComponentTestBase
     [Fact]
     public void CircularGradient_Color_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularGradient>(p =>
+        var cut = Render<IgbCircularGradient>(p =>
             p.Add(x => x.Color, "#ff0000"));
 
         Assert.Equal("#ff0000", cut.Find("igc-circular-gradient").GetAttribute("color"));
@@ -33,7 +33,7 @@ public class CircularGradientTests : BlazorComponentTestBase
     [Fact]
     public void CircularGradient_Opacity_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularGradient>(p =>
+        var cut = Render<IgbCircularGradient>(p =>
             p.Add(x => x.Opacity, 0.5));
 
         Assert.Equal("0.5", cut.Find("igc-circular-gradient").GetAttribute("opacity"));
@@ -42,7 +42,7 @@ public class CircularGradientTests : BlazorComponentTestBase
     [Fact]
     public void CircularGradient_AllProperties()
     {
-        var cut = RenderComponent<IgbCircularGradient>(p =>
+        var cut = Render<IgbCircularGradient>(p =>
             p.Add(x => x.Offset, "50%")
              .Add(x => x.Color, "blue")
              .Add(x => x.Opacity, 1));

--- a/tests/IgniteUI.Blazor.Tests/ComboTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComboTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
 using IgniteUI.Blazor.Tests.Interop;
+using Microsoft.AspNetCore.Components;
 
 namespace IgniteUI.Blazor.Tests;
 
@@ -17,13 +18,13 @@ public class ComboTests : ComponentWithContractTestBase<IgbCombo<ComboItem>>
 
     // Data items cross as {"refType": "uuid", "id": "<guid>"} references (see
     // JsonDataSourceItem.ToJson's "___id" marker), assigned once item is added to DS.
-    internal static string DataItemId(InteropHarness interop, IRenderedFragment cut, int index)
+    internal static string DataItemId(InteropHarness interop, IRenderedComponent<IComponent> cut, int index)
     {
         var items = interop.FindPropertyUpdate(interop.ContainerIdOf(cut), "data")!.Value.EnumerateArray().ToArray();
         return items[index].GetProperty("___id").GetString()!;
     }
 
-    internal static string UuidRef(InteropHarness interop, IRenderedFragment cut, int index) =>
+    internal static string UuidRef(InteropHarness interop, IRenderedComponent<IComponent> cut, int index) =>
         $$"""{"refType": "uuid", "id": "{{DataItemId(interop, cut, index)}}"}""";
 
     internal static string ChangeDetail(string newValues, string items, string type = "selection") =>

--- a/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
@@ -43,7 +43,7 @@ public sealed class ContractViolationException : XunitException
 /// interop (e.g. Badge) stay on <see cref="BlazorComponentTestBase"/>.
 /// </summary>
 public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponentTestBase
-    where TComponent : IComponent
+    where TComponent : class, IComponent
 {
     /// <summary>
     /// The component's interop contract to exercise against a harness.
@@ -114,17 +114,17 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
                 // Hosted specs render the parent structure and pick the cut out of it;
                 // specs with an arrangement render their own instance.
                 IRenderedComponent<TComponent> cut;
-                IRenderedFragment scope;
+                IRenderedComponent<IComponent> scope;
                 if (method.Host is not null)
                 {
-                    scope = Render(method.Host);
+                    scope = method.Host(this);
                     cut = method.Target!(scope);
                 }
                 else
                 {
                     cut = method.Arrange is null
-                        ? sharedCut ??= RenderComponent<TComponent>()
-                        : RenderComponent<TComponent>(ps => method.Arrange(ps));
+                        ? sharedCut ??= Render<TComponent>()
+                        : Render<TComponent>(ps => method.Arrange(ps));
                     scope = cut;
                 }
 
@@ -149,7 +149,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
 
     /// <summary>Stub → invoke → assert the recorded call's identifier, args, and type tags, then the decoded return.</summary>
     private static async Task RunMethodSpec(
-        InteropHarness harness, IRenderedComponent<TComponent> cut, IRenderedFragment scope, MethodContractSpec<TComponent> method)
+        InteropHarness harness, IRenderedComponent<TComponent> cut, IRenderedComponent<IComponent> scope, MethodContractSpec<TComponent> method)
     {
         // Stub immediately before invoking so specs may reuse a method name
         // with different stubbed results.
@@ -218,7 +218,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
 
     /// <summary>Stub the property's JS-side value → invoke → assert a current-state read was issued and the return decoded.</summary>
     private static async Task RunGetterSpec(
-        InteropHarness harness, IRenderedComponent<TComponent> cut, IRenderedFragment scope, MethodContractSpec<TComponent> method)
+        InteropHarness harness, IRenderedComponent<TComponent> cut, IRenderedComponent<IComponent> scope, MethodContractSpec<TComponent> method)
     {
         var stub = method.StubFactory?.Invoke(harness, scope) ?? method.Stub;
         harness.SetupPropertyRead(method.ReadsProperty!, stub!);
@@ -270,7 +270,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
         {
             try
             {
-                var cut = RenderComponent<TComponent>(ps =>
+                var cut = Render<TComponent>(ps =>
                 {
                     prop.Arrange?.Invoke(ps);
                     prop.Set(ps);
@@ -324,7 +324,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
             {
                 object? received = null;
                 object bound = null!;
-                var cut = RenderComponent<TComponent>(ps =>
+                var cut = Render<TComponent>(ps =>
                 {
                     evt.Arrange?.Invoke(ps);
                     bound = evt.Bind(ps, args => received = args);

--- a/tests/IgniteUI.Blazor.Tests/DateTimeInputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DateTimeInputTests.cs
@@ -63,14 +63,14 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbDateTimeInput>();
+        var cut = Render<IgbDateTimeInput>();
         cut.Find("igc-date-time-input").Should_Exist();
     }
 
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_InputFormat_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p =>
+        var cut = Render<IgbDateTimeInput>(p =>
             p.Add(x => x.InputFormat, "dd/MM/yyyy"));
 
         Assert.Equal("dd/MM/yyyy", cut.Find("igc-date-time-input").GetAttribute("input-format"));
@@ -79,7 +79,7 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_DisplayFormat_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p =>
+        var cut = Render<IgbDateTimeInput>(p =>
             p.Add(x => x.DisplayFormat, "MMMM dd, yyyy"));
 
         Assert.Equal("MMMM dd, yyyy", cut.Find("igc-date-time-input").GetAttribute("display-format"));
@@ -88,7 +88,7 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p =>
+        var cut = Render<IgbDateTimeInput>(p =>
             p.Add(x => x.Disabled, true));
 
         Assert.NotNull(cut.Find("igc-date-time-input").GetAttribute("disabled"));
@@ -97,7 +97,7 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_ReadOnly_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p =>
+        var cut = Render<IgbDateTimeInput>(p =>
             p.Add(x => x.ReadOnly, true));
 
         Assert.NotNull(cut.Find("igc-date-time-input").GetAttribute("readonly"));
@@ -106,7 +106,7 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p =>
+        var cut = Render<IgbDateTimeInput>(p =>
             p.Add(x => x.Label, "Select Date"));
 
         Assert.Equal("Select Date", cut.Find("igc-date-time-input").GetAttribute("label"));
@@ -115,7 +115,7 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_Placeholder_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p =>
+        var cut = Render<IgbDateTimeInput>(p =>
             p.Add(x => x.Placeholder, "Enter date..."));
 
         Assert.Equal("Enter date...", cut.Find("igc-date-time-input").GetAttribute("placeholder"));
@@ -124,7 +124,7 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_Required_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p =>
+        var cut = Render<IgbDateTimeInput>(p =>
             p.Add(x => x.Required, true));
 
         Assert.NotNull(cut.Find("igc-date-time-input").GetAttribute("required"));
@@ -133,7 +133,7 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_Outlined_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p =>
+        var cut = Render<IgbDateTimeInput>(p =>
             p.Add(x => x.Outlined, true));
 
         Assert.NotNull(cut.Find("igc-date-time-input").GetAttribute("outlined"));

--- a/tests/IgniteUI.Blazor.Tests/DialogExtendedTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DialogExtendedTests.cs
@@ -12,7 +12,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Dialog_HideDefaultAction_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(p =>
+        var cut = Render<IgbDialog>(p =>
             p.Add(x => x.HideDefaultAction, true));
 
         Assert.NotNull(cut.Find("igc-dialog").GetAttribute("hide-default-action"));
@@ -21,7 +21,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Dialog_Title_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(p =>
+        var cut = Render<IgbDialog>(p =>
             p.Add(x => x.Title, "Confirm Action"));
 
         Assert.Equal("Confirm Action", cut.Find("igc-dialog").GetAttribute("title"));
@@ -30,7 +30,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Dialog_ReturnValue_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(p =>
+        var cut = Render<IgbDialog>(p =>
             p.Add(x => x.ReturnValue, "ok"));
 
         Assert.Equal("ok", cut.Find("igc-dialog").GetAttribute("return-value"));
@@ -39,7 +39,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Dialog_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbDialog>(p =>
+        var cut = Render<IgbDialog>(p =>
             p.AddChildContent("<p>Are you sure?</p>"));
 
         Assert.Contains("Are you sure?", cut.Find("igc-dialog").InnerHtml);
@@ -48,7 +48,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Accordion_SingleExpand_RendersAttribute()
     {
-        var cut = RenderComponent<IgbAccordion>(p =>
+        var cut = Render<IgbAccordion>(p =>
             p.Add(x => x.SingleExpand, true));
 
         Assert.NotNull(cut.Find("igc-accordion").GetAttribute("single-expand"));
@@ -57,7 +57,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Accordion_SingleExpand_False_NoAttribute()
     {
-        var cut = RenderComponent<IgbAccordion>(p =>
+        var cut = Render<IgbAccordion>(p =>
             p.Add(x => x.SingleExpand, false));
 
         Assert.Null(cut.Find("igc-accordion").GetAttribute("single-expand"));
@@ -66,7 +66,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Accordion_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbAccordion>(p =>
+        var cut = Render<IgbAccordion>(p =>
             p.AddChildContent("<div>Panel content</div>"));
 
         Assert.Contains("Panel content", cut.Find("igc-accordion").InnerHtml);
@@ -75,7 +75,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Banner_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbBanner>(p =>
+        var cut = Render<IgbBanner>(p =>
             p.Add(x => x.Open, true));
 
         Assert.NotNull(cut.Find("igc-banner").GetAttribute("open"));
@@ -84,7 +84,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Banner_Open_False_NoAttribute()
     {
-        var cut = RenderComponent<IgbBanner>(p =>
+        var cut = Render<IgbBanner>(p =>
             p.Add(x => x.Open, false));
 
         Assert.Null(cut.Find("igc-banner").GetAttribute("open"));
@@ -93,7 +93,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Banner_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbBanner>(p =>
+        var cut = Render<IgbBanner>(p =>
             p.AddChildContent("Important notice"));
 
         Assert.Contains("Important notice", cut.Find("igc-banner").InnerHtml);
@@ -102,7 +102,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void ExpansionPanel_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbExpansionPanel>(p =>
+        var cut = Render<IgbExpansionPanel>(p =>
             p.Add(x => x.Open, true)
              .AddChildContent("<p>Panel body</p>"));
 
@@ -112,7 +112,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Snackbar_ActionText_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSnackbar>(p =>
+        var cut = Render<IgbSnackbar>(p =>
             p.Add(x => x.ActionText, "Undo"));
 
         Assert.Equal("Undo", cut.Find("igc-snackbar").GetAttribute("action-text"));
@@ -121,7 +121,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Snackbar_DisplayTime_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSnackbar>(p =>
+        var cut = Render<IgbSnackbar>(p =>
             p.Add(x => x.DisplayTime, 5000));
 
         Assert.Equal("5000", cut.Find("igc-snackbar").GetAttribute("display-time"));
@@ -130,7 +130,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Snackbar_KeepOpen_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSnackbar>(p =>
+        var cut = Render<IgbSnackbar>(p =>
             p.Add(x => x.KeepOpen, true));
 
         Assert.NotNull(cut.Find("igc-snackbar").GetAttribute("keep-open"));
@@ -139,7 +139,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Toast_DisplayTime_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToast>(p =>
+        var cut = Render<IgbToast>(p =>
             p.Add(x => x.DisplayTime, 3000));
 
         Assert.Equal("3000", cut.Find("igc-toast").GetAttribute("display-time"));
@@ -148,7 +148,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Toast_KeepOpen_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToast>(p =>
+        var cut = Render<IgbToast>(p =>
             p.Add(x => x.KeepOpen, true));
 
         Assert.NotNull(cut.Find("igc-toast").GetAttribute("keep-open"));
@@ -157,7 +157,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Toast_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToast>(p =>
+        var cut = Render<IgbToast>(p =>
             p.Add(x => x.Open, true));
 
         Assert.NotNull(cut.Find("igc-toast").GetAttribute("open"));
@@ -166,7 +166,7 @@ public class DialogExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Toast_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbToast>(p =>
+        var cut = Render<IgbToast>(p =>
             p.AddChildContent("File saved"));
 
         Assert.Contains("File saved", cut.Find("igc-toast").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/DialogTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DialogTests.cs
@@ -22,7 +22,7 @@ public class DialogTests : ComponentWithContractTestBase<IgbDialog>
     [Fact]
     public void Dialog_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbDialog>();
+        var cut = Render<IgbDialog>();
         Assert.NotNull(cut.Find("igc-dialog"));
     }
 
@@ -36,7 +36,7 @@ public class DialogTests : ComponentWithContractTestBase<IgbDialog>
     [Fact]
     public void Dialog_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(parameters =>
+        var cut = Render<IgbDialog>(parameters =>
             parameters.Add(p => p.Open, true));
 
         var element = cut.Find("igc-dialog");
@@ -46,7 +46,7 @@ public class DialogTests : ComponentWithContractTestBase<IgbDialog>
     [Fact]
     public void Dialog_Title_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(parameters =>
+        var cut = Render<IgbDialog>(parameters =>
             parameters.Add(p => p.Title, "Confirm Action"));
 
         var element = cut.Find("igc-dialog");
@@ -56,7 +56,7 @@ public class DialogTests : ComponentWithContractTestBase<IgbDialog>
     [Fact]
     public void Dialog_KeepOpenOnEscape_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(parameters =>
+        var cut = Render<IgbDialog>(parameters =>
             parameters.Add(p => p.KeepOpenOnEscape, true));
 
         var element = cut.Find("igc-dialog");
@@ -66,7 +66,7 @@ public class DialogTests : ComponentWithContractTestBase<IgbDialog>
     [Fact]
     public void Dialog_CloseOnOutsideClick_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(parameters =>
+        var cut = Render<IgbDialog>(parameters =>
             parameters.Add(p => p.CloseOnOutsideClick, true));
 
         var element = cut.Find("igc-dialog");
@@ -76,7 +76,7 @@ public class DialogTests : ComponentWithContractTestBase<IgbDialog>
     [Fact]
     public void Dialog_HideDefaultAction_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(parameters =>
+        var cut = Render<IgbDialog>(parameters =>
             parameters.Add(p => p.HideDefaultAction, true));
 
         var element = cut.Find("igc-dialog");
@@ -86,7 +86,7 @@ public class DialogTests : ComponentWithContractTestBase<IgbDialog>
     [Fact]
     public void Dialog_ReturnValue_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDialog>(parameters =>
+        var cut = Render<IgbDialog>(parameters =>
             parameters.Add(p => p.ReturnValue, "confirmed"));
 
         var element = cut.Find("igc-dialog");
@@ -96,7 +96,7 @@ public class DialogTests : ComponentWithContractTestBase<IgbDialog>
     [Fact]
     public void Dialog_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbDialog>(parameters =>
+        var cut = Render<IgbDialog>(parameters =>
             parameters.AddChildContent("Dialog content here"));
 
         Assert.Contains("Dialog content here", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/DropdownExtendedTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DropdownExtendedTests.cs
@@ -11,7 +11,7 @@ public class DropdownExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Dropdown_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbDropdown>(p =>
+        var cut = Render<IgbDropdown>(p =>
             p.AddChildContent("<igc-dropdown-item>Item</igc-dropdown-item>"));
 
         Assert.Contains("Item", cut.Find("igc-dropdown").InnerHtml);
@@ -20,14 +20,14 @@ public class DropdownExtendedTests : BlazorComponentTestBase
     [Fact]
     public void DropdownGroup_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbDropdownGroup>();
+        var cut = Render<IgbDropdownGroup>();
         cut.Find("igc-dropdown-group").Should_Exist();
     }
 
     [Fact]
     public void DropdownGroup_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbDropdownGroup>(p =>
+        var cut = Render<IgbDropdownGroup>(p =>
             p.AddChildContent("<igc-dropdown-item>Grouped</igc-dropdown-item>"));
 
         Assert.Contains("Grouped", cut.Find("igc-dropdown-group").InnerHtml);
@@ -36,14 +36,14 @@ public class DropdownExtendedTests : BlazorComponentTestBase
     [Fact]
     public void DropdownHeader_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbDropdownHeader>();
+        var cut = Render<IgbDropdownHeader>();
         cut.Find("igc-dropdown-header").Should_Exist();
     }
 
     [Fact]
     public void DropdownHeader_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbDropdownHeader>(p =>
+        var cut = Render<IgbDropdownHeader>(p =>
             p.AddChildContent("Category"));
 
         Assert.Contains("Category", cut.Find("igc-dropdown-header").InnerHtml);
@@ -52,7 +52,7 @@ public class DropdownExtendedTests : BlazorComponentTestBase
     [Fact]
     public void DropdownItem_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDropdownItem>(p =>
+        var cut = Render<IgbDropdownItem>(p =>
             p.Add(x => x.Value, "item-1"));
 
         Assert.Equal("item-1", cut.Find("igc-dropdown-item").GetAttribute("value"));
@@ -61,7 +61,7 @@ public class DropdownExtendedTests : BlazorComponentTestBase
     [Fact]
     public void DropdownItem_Active_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDropdownItem>(p =>
+        var cut = Render<IgbDropdownItem>(p =>
             p.Add(x => x.Active, true));
 
         Assert.NotNull(cut.Find("igc-dropdown-item").GetAttribute("active"));
@@ -70,7 +70,7 @@ public class DropdownExtendedTests : BlazorComponentTestBase
     [Fact]
     public void DropdownItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbDropdownItem>(p =>
+        var cut = Render<IgbDropdownItem>(p =>
             p.AddChildContent("Option A"));
 
         Assert.Contains("Option A", cut.Find("igc-dropdown-item").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/DropdownTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DropdownTests.cs
@@ -83,7 +83,7 @@ public class DropdownTests : ComponentWithContractTestBase<IgbDropdown>
     [Fact]
     public void Dropdown_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbDropdown>();
+        var cut = Render<IgbDropdown>();
         Assert.NotNull(cut.Find("igc-dropdown"));
     }
 
@@ -97,7 +97,7 @@ public class DropdownTests : ComponentWithContractTestBase<IgbDropdown>
     [Fact]
     public void Dropdown_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDropdown>(parameters =>
+        var cut = Render<IgbDropdown>(parameters =>
             parameters.Add(p => p.Open, true));
 
         var element = cut.Find("igc-dropdown");
@@ -107,7 +107,7 @@ public class DropdownTests : ComponentWithContractTestBase<IgbDropdown>
     [Fact]
     public void Dropdown_KeepOpenOnSelect_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDropdown>(parameters =>
+        var cut = Render<IgbDropdown>(parameters =>
             parameters.Add(p => p.KeepOpenOnSelect, true));
 
         var element = cut.Find("igc-dropdown");
@@ -126,7 +126,7 @@ public class DropdownItemTests : BlazorComponentTestBase
     [Fact]
     public void DropdownItem_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbDropdownItem>();
+        var cut = Render<IgbDropdownItem>();
         Assert.NotNull(cut.Find("igc-dropdown-item"));
     }
 
@@ -140,7 +140,7 @@ public class DropdownItemTests : BlazorComponentTestBase
     [Fact]
     public void DropdownItem_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDropdownItem>(parameters =>
+        var cut = Render<IgbDropdownItem>(parameters =>
             parameters.Add(p => p.Value, "item-1"));
 
         var element = cut.Find("igc-dropdown-item");
@@ -150,7 +150,7 @@ public class DropdownItemTests : BlazorComponentTestBase
     [Fact]
     public void DropdownItem_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDropdownItem>(parameters =>
+        var cut = Render<IgbDropdownItem>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-dropdown-item");
@@ -160,7 +160,7 @@ public class DropdownItemTests : BlazorComponentTestBase
     [Fact]
     public void DropdownItem_Selected_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDropdownItem>(parameters =>
+        var cut = Render<IgbDropdownItem>(parameters =>
             parameters.Add(p => p.Selected, true));
 
         var element = cut.Find("igc-dropdown-item");
@@ -170,7 +170,7 @@ public class DropdownItemTests : BlazorComponentTestBase
     [Fact]
     public void DropdownItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbDropdownItem>(parameters =>
+        var cut = Render<IgbDropdownItem>(parameters =>
             parameters.AddChildContent("Option 1"));
 
         Assert.Contains("Option 1", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/EnumSerializationTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/EnumSerializationTests.cs
@@ -19,7 +19,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(ButtonVariant.Fab, "fab")]
     public void ButtonVariant_Serialization(ButtonVariant variant, string expected)
     {
-        var cut = RenderComponent<IgbButton>(p => p.Add(x => x.Variant, variant));
+        var cut = Render<IgbButton>(p => p.Add(x => x.Variant, variant));
         Assert.Equal(expected, cut.Find("igc-button").GetAttribute("variant"));
     }
 
@@ -30,7 +30,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(ButtonBaseType.Submit, "submit")]
     public void ButtonBaseType_Serialization(ButtonBaseType type, string expected)
     {
-        var cut = RenderComponent<IgbButton>(p => p.Add(x => x.DisplayType, type));
+        var cut = Render<IgbButton>(p => p.Add(x => x.DisplayType, type));
         Assert.Equal(expected, cut.Find("igc-button").GetAttribute("type"));
     }
 
@@ -45,7 +45,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(InputType.Url, "url")]
     public void InputType_Serialization(InputType type, string expected)
     {
-        var cut = RenderComponent<IgbInput>(p => p.Add(x => x.DisplayType, type));
+        var cut = Render<IgbInput>(p => p.Add(x => x.DisplayType, type));
         Assert.Equal(expected, cut.Find("igc-input").GetAttribute("type"));
     }
 
@@ -55,7 +55,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(ToggleLabelPosition.Before, "before")]
     public void ToggleLabelPosition_Serialization(ToggleLabelPosition pos, string expected)
     {
-        var cut = RenderComponent<IgbCheckbox>(p => p.Add(x => x.LabelPosition, pos));
+        var cut = Render<IgbCheckbox>(p => p.Add(x => x.LabelPosition, pos));
         Assert.Equal(expected, cut.Find("igc-checkbox").GetAttribute("label-position"));
     }
 
@@ -65,7 +65,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(BadgeShape.Square, "square")]
     public void BadgeShape_Serialization(BadgeShape shape, string expected)
     {
-        var cut = RenderComponent<IgbBadge>(p => p.Add(x => x.Shape, shape));
+        var cut = Render<IgbBadge>(p => p.Add(x => x.Shape, shape));
         Assert.Equal(expected, cut.Find("igc-badge").GetAttribute("shape"));
     }
 
@@ -76,7 +76,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(AvatarShape.Square, "square")]
     public void AvatarShape_Serialization(AvatarShape shape, string expected)
     {
-        var cut = RenderComponent<IgbAvatar>(p => p.Add(x => x.Shape, shape));
+        var cut = Render<IgbAvatar>(p => p.Add(x => x.Shape, shape));
         Assert.Equal(expected, cut.Find("igc-avatar").GetAttribute("shape"));
     }
 
@@ -89,7 +89,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(StyleVariant.Danger, "danger")]
     public void StyleVariant_Serialization(StyleVariant variant, string expected)
     {
-        var cut = RenderComponent<IgbLinearProgress>(p => p.Add(x => x.Variant, variant));
+        var cut = Render<IgbLinearProgress>(p => p.Add(x => x.Variant, variant));
         Assert.Equal(expected, cut.Find("igc-linear-progress").GetAttribute("variant"));
     }
 
@@ -102,7 +102,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(NavDrawerPosition.Relative, "relative")]
     public void NavDrawerPosition_Serialization(NavDrawerPosition pos, string expected)
     {
-        var cut = RenderComponent<IgbNavDrawer>(p => p.Add(x => x.Position, pos));
+        var cut = Render<IgbNavDrawer>(p => p.Add(x => x.Position, pos));
         Assert.Equal(expected, cut.Find("igc-nav-drawer").GetAttribute("position"));
     }
 
@@ -113,7 +113,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(TextareaResize.Auto, "auto")]
     public void TextareaResize_Serialization(TextareaResize resize, string expected)
     {
-        var cut = RenderComponent<IgbTextarea>(p => p.Add(x => x.Resize, resize));
+        var cut = Render<IgbTextarea>(p => p.Add(x => x.Resize, resize));
         Assert.Equal(expected, cut.Find("igc-textarea").GetAttribute("resize"));
     }
 
@@ -124,7 +124,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(TextareaWrap.Off, "off")]
     public void TextareaWrap_Serialization(TextareaWrap wrap, string expected)
     {
-        var cut = RenderComponent<IgbTextarea>(p => p.Add(x => x.Wrap, wrap));
+        var cut = Render<IgbTextarea>(p => p.Add(x => x.Wrap, wrap));
         Assert.Equal(expected, cut.Find("igc-textarea").GetAttribute("wrap"));
     }
 
@@ -135,7 +135,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(TreeSelection.Cascade, "cascade")]
     public void TreeSelection_Serialization(TreeSelection sel, string expected)
     {
-        var cut = RenderComponent<IgbTree>(p => p.Add(x => x.Selection, sel));
+        var cut = Render<IgbTree>(p => p.Add(x => x.Selection, sel));
         Assert.Equal(expected, cut.Find("igc-tree").GetAttribute("selection"));
     }
 
@@ -146,7 +146,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(ButtonGroupSelection.Multiple, "multiple")]
     public void ButtonGroupSelection_Serialization(ButtonGroupSelection sel, string expected)
     {
-        var cut = RenderComponent<IgbButtonGroup>(p => p.Add(x => x.Selection, sel));
+        var cut = Render<IgbButtonGroup>(p => p.Add(x => x.Selection, sel));
         Assert.Equal(expected, cut.Find("igc-button-group").GetAttribute("selection"));
     }
 
@@ -158,7 +158,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(TabsAlignment.Justify, "justify")]
     public void TabsAlignment_Serialization(TabsAlignment alignment, string expected)
     {
-        var cut = RenderComponent<IgbTabs>(p => p.Add(x => x.Alignment, alignment));
+        var cut = Render<IgbTabs>(p => p.Add(x => x.Alignment, alignment));
         Assert.Equal(expected, cut.Find("igc-tabs").GetAttribute("alignment"));
     }
 
@@ -168,7 +168,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(TabsActivation.Manual, "manual")]
     public void TabsActivation_Serialization(TabsActivation activation, string expected)
     {
-        var cut = RenderComponent<IgbTabs>(p => p.Add(x => x.Activation, activation));
+        var cut = Render<IgbTabs>(p => p.Add(x => x.Activation, activation));
         Assert.Equal(expected, cut.Find("igc-tabs").GetAttribute("activation"));
     }
 
@@ -179,7 +179,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(SliderTickOrientation.Mirror, "mirror")]
     public void SliderTickOrientation_Serialization(SliderTickOrientation orient, string expected)
     {
-        var cut = RenderComponent<IgbSlider>(p => p.Add(x => x.TickOrientation, orient));
+        var cut = Render<IgbSlider>(p => p.Add(x => x.TickOrientation, orient));
         Assert.Equal(expected, cut.Find("igc-slider").GetAttribute("tick-orientation"));
     }
 
@@ -189,7 +189,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(StepperOrientation.Vertical, "vertical")]
     public void StepperOrientation_Serialization(StepperOrientation orient, string expected)
     {
-        var cut = RenderComponent<IgbStepper>(p => p.Add(x => x.Orientation, orient));
+        var cut = Render<IgbStepper>(p => p.Add(x => x.Orientation, orient));
         Assert.Equal(expected, cut.Find("igc-stepper").GetAttribute("orientation"));
     }
 
@@ -200,7 +200,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(StepperStepType.Full, "full")]
     public void StepperStepType_Serialization(StepperStepType type, string expected)
     {
-        var cut = RenderComponent<IgbStepper>(p => p.Add(x => x.StepType, type));
+        var cut = Render<IgbStepper>(p => p.Add(x => x.StepType, type));
         Assert.Equal(expected, cut.Find("igc-stepper").GetAttribute("step-type"));
     }
 
@@ -212,7 +212,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(StepperTitlePosition.Start, "start")]
     public void StepperTitlePosition_Serialization(StepperTitlePosition pos, string expected)
     {
-        var cut = RenderComponent<IgbStepper>(p => p.Add(x => x.TitlePosition, pos));
+        var cut = Render<IgbStepper>(p => p.Add(x => x.TitlePosition, pos));
         Assert.Equal(expected, cut.Find("igc-stepper").GetAttribute("title-position"));
     }
 
@@ -223,7 +223,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(ExpansionPanelIndicatorPosition.None, "none")]
     public void ExpansionPanelIndicatorPosition_Serialization(ExpansionPanelIndicatorPosition pos, string expected)
     {
-        var cut = RenderComponent<IgbExpansionPanel>(p => p.Add(x => x.IndicatorPosition, pos));
+        var cut = Render<IgbExpansionPanel>(p => p.Add(x => x.IndicatorPosition, pos));
         Assert.Equal(expected, cut.Find("igc-expansion-panel").GetAttribute("indicator-position"));
     }
 
@@ -234,7 +234,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(IconButtonVariant.Flat, "flat")]
     public void IconButtonVariant_Serialization(IconButtonVariant variant, string expected)
     {
-        var cut = RenderComponent<IgbIconButton>(p => p.Add(x => x.Variant, variant));
+        var cut = Render<IgbIconButton>(p => p.Add(x => x.Variant, variant));
         Assert.Equal(expected, cut.Find("igc-icon-button").GetAttribute("variant"));
     }
 
@@ -244,7 +244,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(MaskInputValueMode.WithFormatting, "withFormatting")]
     public void MaskInputValueMode_Serialization(MaskInputValueMode mode, string expected)
     {
-        var cut = RenderComponent<IgbMaskInput>(p => p.Add(x => x.ValueMode, mode));
+        var cut = Render<IgbMaskInput>(p => p.Add(x => x.ValueMode, mode));
         Assert.Equal(expected, cut.Find("igc-mask-input").GetAttribute("value-mode"));
     }
 
@@ -255,7 +255,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(TileManagerResizeMode.Hover, "hover")]
     public void TileManagerResizeMode_Serialization(TileManagerResizeMode mode, string expected)
     {
-        var cut = RenderComponent<IgbTileManager>(p => p.Add(x => x.ResizeMode, mode));
+        var cut = Render<IgbTileManager>(p => p.Add(x => x.ResizeMode, mode));
         Assert.Equal(expected, cut.Find("igc-tile-manager").GetAttribute("resize-mode"));
     }
 
@@ -266,7 +266,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(TileManagerDragMode.TileHeader, "tile-header")]
     public void TileManagerDragMode_Serialization(TileManagerDragMode mode, string expected)
     {
-        var cut = RenderComponent<IgbTileManager>(p => p.Add(x => x.DragMode, mode));
+        var cut = Render<IgbTileManager>(p => p.Add(x => x.DragMode, mode));
         Assert.Equal(expected, cut.Find("igc-tile-manager").GetAttribute("drag-mode"));
     }
 
@@ -277,7 +277,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(HorizontalTransitionAnimation.Fade, "fade")]
     public void CarouselAnimationType_Serialization(HorizontalTransitionAnimation anim, string expected)
     {
-        var cut = RenderComponent<IgbCarousel>(p => p.Add(x => x.AnimationType, anim));
+        var cut = Render<IgbCarousel>(p => p.Add(x => x.AnimationType, anim));
         Assert.Equal(expected, cut.Find("igc-carousel").GetAttribute("animation-type"));
     }
 
@@ -287,7 +287,7 @@ public class EnumSerializationTests : BlazorComponentTestBase
     [InlineData(CarouselIndicatorsOrientation.End, "end")]
     public void CarouselIndicatorsOrientation_Serialization(CarouselIndicatorsOrientation orient, string expected)
     {
-        var cut = RenderComponent<IgbCarousel>(p => p.Add(x => x.IndicatorsOrientation, orient));
+        var cut = Render<IgbCarousel>(p => p.Add(x => x.IndicatorsOrientation, orient));
         Assert.Equal(expected, cut.Find("igc-carousel").GetAttribute("indicators-orientation"));
     }
 }

--- a/tests/IgniteUI.Blazor.Tests/ExpansionPanelTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ExpansionPanelTests.cs
@@ -34,7 +34,7 @@ public class ExpansionPanelTests : ComponentWithContractTestBase<IgbExpansionPan
     [Fact]
     public void ExpansionPanel_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbExpansionPanel>();
+        var cut = Render<IgbExpansionPanel>();
         Assert.NotNull(cut.Find("igc-expansion-panel"));
     }
 
@@ -48,7 +48,7 @@ public class ExpansionPanelTests : ComponentWithContractTestBase<IgbExpansionPan
     [Fact]
     public void ExpansionPanel_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbExpansionPanel>(parameters =>
+        var cut = Render<IgbExpansionPanel>(parameters =>
             parameters.Add(p => p.Open, true));
 
         var element = cut.Find("igc-expansion-panel");
@@ -58,7 +58,7 @@ public class ExpansionPanelTests : ComponentWithContractTestBase<IgbExpansionPan
     [Fact]
     public void ExpansionPanel_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbExpansionPanel>(parameters =>
+        var cut = Render<IgbExpansionPanel>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-expansion-panel");
@@ -68,7 +68,7 @@ public class ExpansionPanelTests : ComponentWithContractTestBase<IgbExpansionPan
     [Fact]
     public void ExpansionPanel_IndicatorPosition_End()
     {
-        var cut = RenderComponent<IgbExpansionPanel>(parameters =>
+        var cut = Render<IgbExpansionPanel>(parameters =>
             parameters.Add(p => p.IndicatorPosition, ExpansionPanelIndicatorPosition.End));
 
         var element = cut.Find("igc-expansion-panel");
@@ -78,7 +78,7 @@ public class ExpansionPanelTests : ComponentWithContractTestBase<IgbExpansionPan
     [Fact]
     public void ExpansionPanel_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbExpansionPanel>(parameters =>
+        var cut = Render<IgbExpansionPanel>(parameters =>
             parameters.AddChildContent("Panel content"));
 
         Assert.Contains("Panel content", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/HighlightTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/HighlightTests.cs
@@ -23,7 +23,7 @@ public class HighlightTests : ComponentWithContractTestBase<IgbHighlight>
     [Fact]
     public void Highlight_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbHighlight>();
+        var cut = Render<IgbHighlight>();
         Assert.NotNull(cut.Find("igc-highlight"));
     }
 
@@ -39,7 +39,7 @@ public class HighlightTests : ComponentWithContractTestBase<IgbHighlight>
     [Fact]
     public void Highlight_CaseSensitive_True_RendersAttribute()
     {
-        var cut = RenderComponent<IgbHighlight>(parameters =>
+        var cut = Render<IgbHighlight>(parameters =>
             parameters.Add(p => p.CaseSensitive, true));
 
         Assert.NotNull(cut.Find("igc-highlight").GetAttribute("case-sensitive"));
@@ -48,7 +48,7 @@ public class HighlightTests : ComponentWithContractTestBase<IgbHighlight>
     [Fact]
     public void Highlight_SearchText_RendersAttribute()
     {
-        var cut = RenderComponent<IgbHighlight>(parameters =>
+        var cut = Render<IgbHighlight>(parameters =>
             parameters.Add(p => p.SearchText, "lorem"));
 
         Assert.Equal("lorem", cut.Find("igc-highlight").GetAttribute("search-text"));
@@ -57,7 +57,7 @@ public class HighlightTests : ComponentWithContractTestBase<IgbHighlight>
     [Fact]
     public void Highlight_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbHighlight>(parameters =>
+        var cut = Render<IgbHighlight>(parameters =>
             parameters.AddChildContent("<p>Body text to search.</p>"));
 
         Assert.Contains("Body text to search.", cut.Find("igc-highlight").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/IconButtonTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/IconButtonTests.cs
@@ -27,7 +27,7 @@ public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
     [Fact]
     public void IconButton_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbIconButton>();
+        var cut = Render<IgbIconButton>();
         cut.Find("igc-icon-button").Should_Exist();
     }
 
@@ -35,7 +35,7 @@ public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
     public void IconButton_IconName_RendersAsNameAttribute()
     {
         // IconName has WCWidgetMemberName("Name") → serialized key "iconName" → remapped to "name"
-        var cut = RenderComponent<IgbIconButton>(p =>
+        var cut = Render<IgbIconButton>(p =>
             p.Add(x => x.IconName, "home"));
 
         Assert.Equal("home", cut.Find("igc-icon-button").GetAttribute("name"));
@@ -44,7 +44,7 @@ public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
     [Fact]
     public void IconButton_Collection_RendersAttribute()
     {
-        var cut = RenderComponent<IgbIconButton>(p =>
+        var cut = Render<IgbIconButton>(p =>
             p.Add(x => x.Collection, "material"));
 
         Assert.Equal("material", cut.Find("igc-icon-button").GetAttribute("collection"));
@@ -53,7 +53,7 @@ public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
     [Fact]
     public void IconButton_Mirrored_RendersAttribute()
     {
-        var cut = RenderComponent<IgbIconButton>(p =>
+        var cut = Render<IgbIconButton>(p =>
             p.Add(x => x.Mirrored, true));
 
         Assert.NotNull(cut.Find("igc-icon-button").GetAttribute("mirrored"));
@@ -62,7 +62,7 @@ public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
     [Fact]
     public void IconButton_Variant_Flat()
     {
-        var cut = RenderComponent<IgbIconButton>(p =>
+        var cut = Render<IgbIconButton>(p =>
             p.Add(x => x.Variant, IconButtonVariant.Flat));
 
         Assert.Equal("flat", cut.Find("igc-icon-button").GetAttribute("variant"));
@@ -71,7 +71,7 @@ public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
     [Fact]
     public void IconButton_Variant_Outlined()
     {
-        var cut = RenderComponent<IgbIconButton>(p =>
+        var cut = Render<IgbIconButton>(p =>
             p.Add(x => x.Variant, IconButtonVariant.Outlined));
 
         Assert.Equal("outlined", cut.Find("igc-icon-button").GetAttribute("variant"));
@@ -80,7 +80,7 @@ public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
     [Fact]
     public void IconButton_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbIconButton>(p =>
+        var cut = Render<IgbIconButton>(p =>
             p.Add(x => x.Disabled, true));
 
         Assert.NotNull(cut.Find("igc-icon-button").GetAttribute("disabled"));
@@ -89,7 +89,7 @@ public class IconButtonTests : ComponentWithContractTestBase<IgbIconButton>
     [Fact]
     public void IconButton_Href_RendersAttribute()
     {
-        var cut = RenderComponent<IgbIconButton>(p =>
+        var cut = Render<IgbIconButton>(p =>
             p.Add(x => x.Href, "https://example.com"));
 
         Assert.Equal("https://example.com", cut.Find("igc-icon-button").GetAttribute("href"));

--- a/tests/IgniteUI.Blazor.Tests/IconTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/IconTests.cs
@@ -24,7 +24,7 @@ public class IconTests : ComponentWithContractTestBase<IgbIcon>
     [Fact]
     public void Icon_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbIcon>();
+        var cut = Render<IgbIcon>();
         Assert.NotNull(cut.Find("igc-icon"));
     }
 
@@ -38,7 +38,7 @@ public class IconTests : ComponentWithContractTestBase<IgbIcon>
     [Fact]
     public void Icon_Name_RendersAttribute()
     {
-        var cut = RenderComponent<IgbIcon>(parameters =>
+        var cut = Render<IgbIcon>(parameters =>
             parameters.Add(p => p.IconName, "home"));
 
         var element = cut.Find("igc-icon");
@@ -48,7 +48,7 @@ public class IconTests : ComponentWithContractTestBase<IgbIcon>
     [Fact]
     public void Icon_Collection_RendersAttribute()
     {
-        var cut = RenderComponent<IgbIcon>(parameters =>
+        var cut = Render<IgbIcon>(parameters =>
             parameters.Add(p => p.Collection, "material"));
 
         var element = cut.Find("igc-icon");
@@ -58,7 +58,7 @@ public class IconTests : ComponentWithContractTestBase<IgbIcon>
     [Fact]
     public void Icon_Mirrored_RendersAttribute()
     {
-        var cut = RenderComponent<IgbIcon>(parameters =>
+        var cut = Render<IgbIcon>(parameters =>
             parameters.Add(p => p.Mirrored, true));
 
         var element = cut.Find("igc-icon");

--- a/tests/IgniteUI.Blazor.Tests/InputExtendedTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InputExtendedTests.cs
@@ -12,7 +12,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.Label, "Username"));
 
         Assert.Equal("Username", cut.Find("igc-input").GetAttribute("label"));
@@ -21,7 +21,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_Outlined_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.Outlined, true));
 
         Assert.NotNull(cut.Find("igc-input").GetAttribute("outlined"));
@@ -30,7 +30,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_Invalid_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.Invalid, true));
 
         Assert.NotNull(cut.Find("igc-input").GetAttribute("invalid"));
@@ -39,7 +39,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_Min_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.Min, 0));
 
         Assert.Equal("0", cut.Find("igc-input").GetAttribute("min"));
@@ -48,7 +48,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_Max_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.Max, 100));
 
         Assert.Equal("100", cut.Find("igc-input").GetAttribute("max"));
@@ -57,7 +57,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_Step_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.Step, 5));
 
         Assert.Equal("5", cut.Find("igc-input").GetAttribute("step"));
@@ -66,7 +66,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_Autocomplete_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.Autocomplete, "email"));
 
         Assert.Equal("email", cut.Find("igc-input").GetAttribute("autocomplete"));
@@ -75,7 +75,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_InputMode_RendersAsAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.InputMode, "numeric"));
 
         Assert.Equal("numeric", cut.Find("igc-input").GetAttribute("inputmode"));
@@ -84,7 +84,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Input_ValidateOnly_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(p =>
+        var cut = Render<IgbInput>(p =>
             p.Add(x => x.ValidateOnly, true));
 
         Assert.NotNull(cut.Find("igc-input").GetAttribute("validate-only"));
@@ -94,7 +94,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.Label, "Comments"));
 
         Assert.Equal("Comments", cut.Find("igc-textarea").GetAttribute("label"));
@@ -103,7 +103,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_Outlined_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.Outlined, true));
 
         Assert.NotNull(cut.Find("igc-textarea").GetAttribute("outlined"));
@@ -112,7 +112,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_MaxLength_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.MaxLength, 500));
 
         Assert.Equal("500", cut.Find("igc-textarea").GetAttribute("maxlength"));
@@ -121,7 +121,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_MinLength_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.MinLength, 10));
 
         Assert.Equal("10", cut.Find("igc-textarea").GetAttribute("minlength"));
@@ -130,7 +130,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_ReadOnly_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.ReadOnly, true));
 
         Assert.NotNull(cut.Find("igc-textarea").GetAttribute("readonly"));
@@ -139,7 +139,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_Spellcheck_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.Spellcheck, true));
 
         Assert.NotNull(cut.Find("igc-textarea").GetAttribute("spellcheck"));
@@ -148,7 +148,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_InputMode_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.InputMode, "text"));
 
         Assert.Equal("text", cut.Find("igc-textarea").GetAttribute("inputmode"));
@@ -157,7 +157,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_Wrap_Hard()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.Wrap, TextareaWrap.Hard));
 
         Assert.Equal("hard", cut.Find("igc-textarea").GetAttribute("wrap"));
@@ -166,7 +166,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_ValidateOnly_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.ValidateOnly, true));
 
         Assert.NotNull(cut.Find("igc-textarea").GetAttribute("validate-only"));
@@ -175,7 +175,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_Autocomplete_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(p =>
+        var cut = Render<IgbTextarea>(p =>
             p.Add(x => x.Autocomplete, "on"));
 
         Assert.Equal("on", cut.Find("igc-textarea").GetAttribute("autocomplete"));
@@ -185,7 +185,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_ValueMode_RendersAttribute()
     {
-        var cut = RenderComponent<IgbMaskInput>(p =>
+        var cut = Render<IgbMaskInput>(p =>
             p.Add(x => x.ValueMode, MaskInputValueMode.WithFormatting));
 
         Assert.Equal("withFormatting", cut.Find("igc-mask-input").GetAttribute("value-mode"));
@@ -194,7 +194,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_Prompt_RendersAttribute()
     {
-        var cut = RenderComponent<IgbMaskInput>(p =>
+        var cut = Render<IgbMaskInput>(p =>
             p.Add(x => x.Prompt, "#"));
 
         Assert.Equal("#", cut.Find("igc-mask-input").GetAttribute("prompt"));
@@ -203,7 +203,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbMaskInput>(p =>
+        var cut = Render<IgbMaskInput>(p =>
             p.Add(x => x.Label, "Phone"));
 
         Assert.Equal("Phone", cut.Find("igc-mask-input").GetAttribute("label"));
@@ -212,7 +212,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_Required_RendersAttribute()
     {
-        var cut = RenderComponent<IgbMaskInput>(p =>
+        var cut = Render<IgbMaskInput>(p =>
             p.Add(x => x.Required, true));
 
         Assert.NotNull(cut.Find("igc-mask-input").GetAttribute("required"));
@@ -221,7 +221,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_Outlined_RendersAttribute()
     {
-        var cut = RenderComponent<IgbMaskInput>(p =>
+        var cut = Render<IgbMaskInput>(p =>
             p.Add(x => x.Outlined, true));
 
         Assert.NotNull(cut.Find("igc-mask-input").GetAttribute("outlined"));
@@ -231,7 +231,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Checkbox_Invalid_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCheckbox>(p =>
+        var cut = Render<IgbCheckbox>(p =>
             p.Add(x => x.Invalid, true));
 
         Assert.NotNull(cut.Find("igc-checkbox").GetAttribute("invalid"));
@@ -240,7 +240,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Checkbox_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCheckbox>(p =>
+        var cut = Render<IgbCheckbox>(p =>
             p.AddChildContent("Accept terms"));
 
         Assert.Contains("Accept terms", cut.Find("igc-checkbox").InnerHtml);
@@ -249,7 +249,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Switch_Invalid_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSwitch>(p =>
+        var cut = Render<IgbSwitch>(p =>
             p.Add(x => x.Invalid, true));
 
         Assert.NotNull(cut.Find("igc-switch").GetAttribute("invalid"));
@@ -258,7 +258,7 @@ public class InputExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Switch_Required_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSwitch>(p =>
+        var cut = Render<IgbSwitch>(p =>
             p.Add(x => x.Required, true));
 
         Assert.NotNull(cut.Find("igc-switch").GetAttribute("required"));

--- a/tests/IgniteUI.Blazor.Tests/InputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InputTests.cs
@@ -36,7 +36,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbInput>();
+        var cut = Render<IgbInput>();
         Assert.NotNull(cut.Find("igc-input"));
     }
 
@@ -50,7 +50,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.Value, "hello"));
 
         var element = cut.Find("igc-input");
@@ -60,7 +60,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_DisplayType_Email()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.DisplayType, InputType.Email));
 
         var element = cut.Find("igc-input");
@@ -70,7 +70,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_DisplayType_Password()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.DisplayType, InputType.Password));
 
         var element = cut.Find("igc-input");
@@ -80,7 +80,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_Placeholder_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.Placeholder, "Enter text..."));
 
         var element = cut.Find("igc-input");
@@ -90,7 +90,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-input");
@@ -100,7 +100,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_Required_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.Required, true));
 
         var element = cut.Find("igc-input");
@@ -110,7 +110,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_ReadOnly_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.ReadOnly, true));
 
         var element = cut.Find("igc-input");
@@ -120,7 +120,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_MinLength_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.MinLength, 3.0));
 
         var element = cut.Find("igc-input");
@@ -130,7 +130,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_MaxLength_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.MaxLength, 100.0));
 
         var element = cut.Find("igc-input");
@@ -140,7 +140,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_Autofocus_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.Autofocus, true));
 
         var element = cut.Find("igc-input");
@@ -150,7 +150,7 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
     [Fact]
     public void Input_Pattern_RendersAttribute()
     {
-        var cut = RenderComponent<IgbInput>(parameters =>
+        var cut = Render<IgbInput>(parameters =>
             parameters.Add(p => p.Pattern, "[A-Za-z]+"));
 
         var element = cut.Find("igc-input");

--- a/tests/IgniteUI.Blazor.Tests/Interop/ComponentContract.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/ComponentContract.cs
@@ -17,13 +17,17 @@ public sealed record SpecSource(string File, int Line);
 /// </summary>
 public static class ContractHost
 {
-    public static RenderFragment Of<THost>(Action<ComponentParameterCollectionBuilder<THost>> arrange)
-        where THost : IComponent
-    {
-        var ps = new ComponentParameterCollectionBuilder<THost>();
-        arrange(ps);
-        return ps.Build().ToRenderFragment<THost>();
-    }
+    /// <summary>
+    /// Produces a thunk that renders the host through the test context. bUnit v2 dropped the
+    /// public way to materialize an arranged builder into a detached <see cref="RenderFragment"/>
+    /// (<c>ComponentParameterCollection</c> is now internal), so the host defers to
+    /// <see cref="BunitContext.Render{TComponent}(Action{ComponentParameterCollectionBuilder{TComponent}})"/>
+    /// at run time instead. The rendered host is exposed as <see cref="IRenderedComponent{IComponent}"/>
+    /// via the interface's covariance.
+    /// </summary>
+    public static Func<BunitContext, IRenderedComponent<IComponent>> Of<THost>(Action<ComponentParameterCollectionBuilder<THost>> arrange)
+        where THost : class, IComponent
+        => ctx => ctx.Render<THost>(arrange);
 }
 
 /// <summary>Expected wire value that is itself JSON (object/array arguments); compared structurally and exactly.</summary>
@@ -58,10 +62,10 @@ public sealed class MethodContractSpec<TComponent> where TComponent : IComponent
     /// Hosted specs: the full render, parent included (see <see cref="ContractHost.Of{THost}"/>);
     /// the component under test is picked out of it by <see cref="Target"/>.
     /// </summary>
-    public RenderFragment? Host { get; init; }
+    public Func<BunitContext, IRenderedComponent<IComponent>>? Host { get; init; }
 
     /// <summary>Selects which rendered <typeparamref name="TComponent"/> inside <see cref="Host"/> is the component under test.</summary>
-    public Func<IRenderedFragment, IRenderedComponent<TComponent>>? Target { get; init; }
+    public Func<IRenderedComponent<IComponent>, IRenderedComponent<TComponent>>? Target { get; init; }
 
     /// <summary>
     /// The member's sync twin (<c>Show()</c> for <c>ShowAsync()</c>), when declared: the
@@ -74,10 +78,10 @@ public sealed class MethodContractSpec<TComponent> where TComponent : IComponent
     /// wins over <see cref="Stub"/>. The fragment is the render scope: the cut itself for
     /// arranged specs, the whole host for hosted ones (so ancestors are reachable).
     /// </summary>
-    public Func<InteropHarness, IRenderedFragment, InteropReturn>? StubFactory { get; init; }
+    public Func<InteropHarness, IRenderedComponent<IComponent>, InteropReturn>? StubFactory { get; init; }
 
     /// <summary>Dynamic return assert receiving the render scope (see <see cref="StubFactory"/>) to compare against arranged instances.</summary>
-    public Action<IRenderedFragment, object?>? AssertReturnWithCut { get; init; }
+    public Action<IRenderedComponent<IComponent>, object?>? AssertReturnWithCut { get; init; }
 
     public SpecSource? Source { get; init; }
 }
@@ -393,10 +397,10 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
     public ComponentContract<TComponent> Getter<TResult>(
         Func<TComponent, Task<TResult>> invoke,
         string propertyName,
-        RenderFragment host,
-        Func<IRenderedFragment, IRenderedComponent<TComponent>> target,
-        Func<InteropHarness, IRenderedFragment, InteropReturn> returns,
-        Action<IRenderedFragment, TResult> assert,
+        Func<BunitContext, IRenderedComponent<IComponent>> host,
+        Func<IRenderedComponent<IComponent>, IRenderedComponent<TComponent>> target,
+        Func<InteropHarness, IRenderedComponent<IComponent>, InteropReturn> returns,
+        Action<IRenderedComponent<IComponent>, TResult> assert,
         [CallerFilePath] string atFile = "",
         [CallerLineNumber] int atLine = 0)
     {
@@ -475,10 +479,10 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
         Func<TComponent, Task<TResult>> invoke,
         Func<TComponent, TResult> sync,
         string propertyName,
-        RenderFragment host,
-        Func<IRenderedFragment, IRenderedComponent<TComponent>> target,
-        Func<InteropHarness, IRenderedFragment, InteropReturn> returns,
-        Action<IRenderedFragment, TResult> assert,
+        Func<BunitContext, IRenderedComponent<IComponent>> host,
+        Func<IRenderedComponent<IComponent>, IRenderedComponent<TComponent>> target,
+        Func<InteropHarness, IRenderedComponent<IComponent>, InteropReturn> returns,
+        Action<IRenderedComponent<IComponent>, TResult> assert,
         [CallerFilePath] string atFile = "",
         [CallerLineNumber] int atLine = 0)
     {

--- a/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace IgniteUI.Blazor.Tests.Interop;
@@ -110,10 +111,10 @@ public abstract class InteropHarness
     public abstract void MakeReady();
 
     /// <summary>Resolves the interop instance id of a rendered component.</summary>
-    public abstract string ContainerIdOf(IRenderedFragment cut);
+    public abstract string ContainerIdOf(IRenderedComponent<IComponent> cut);
 
     /// <summary>Resolves the interop instance id of a child component inside a rendered fragment.</summary>
-    public abstract string ContainerIdOf(IRenderedFragment cut, string childSelector);
+    public abstract string ContainerIdOf(IRenderedComponent<IComponent> cut, string childSelector);
 
     /// <summary>All API method invocations sent to JS so far, in order.</summary>
     public abstract IReadOnlyList<InteropMethodCall> MethodCalls { get; }

--- a/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Bunit;
 using IgniteUI.Blazor.Controls;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace IgniteUI.Blazor.Tests.Interop;
@@ -63,11 +64,11 @@ public sealed class RendererMessageInteropHarness : InteropHarness
 
     public override void MakeReady() => _service.WebCallback.OnReady();
 
-    public override string ContainerIdOf(IRenderedFragment cut) =>
+    public override string ContainerIdOf(IRenderedComponent<IComponent> cut) =>
         cut.Find("[data-ig-id]").GetAttribute("data-ig-id")
         ?? throw new InvalidOperationException("Rendered component has no data-ig-id container marker.");
 
-    public override string ContainerIdOf(IRenderedFragment cut, string childSelector) =>
+    public override string ContainerIdOf(IRenderedComponent<IComponent> cut, string childSelector) =>
         cut.Find(childSelector).GetAttribute("data-ig-id")
         ?? throw new InvalidOperationException($"Element \"{childSelector}\" has no data-ig-id container marker.");
 

--- a/tests/IgniteUI.Blazor.Tests/InteropEventTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropEventTests.cs
@@ -15,7 +15,7 @@ public class InteropEventTests : BlazorComponentTestBase
     public void BoolDetailEvent_FromJs_PropagatesTwoWayBinding()
     {
         var selected = false;
-        var cut = RenderComponent<IgbChip>(parameters => parameters
+        var cut = Render<IgbChip>(parameters => parameters
             .Add(c => c.Select, _ => { })
             .Add(c => c.SelectedChanged, value => selected = value));
 
@@ -28,7 +28,7 @@ public class InteropEventTests : BlazorComponentTestBase
     [Fact]
     public void BoolDetailEvent_FromJs_SendsDeltaStateSyncBack()
     {
-        var cut = RenderComponent<IgbChip>(parameters =>
+        var cut = Render<IgbChip>(parameters =>
             parameters.Add(c => c.Select, _ => { }));
         var containerId = Interop.ContainerIdOf(cut);
 
@@ -43,7 +43,7 @@ public class InteropEventTests : BlazorComponentTestBase
     [Fact]
     public void Event_WithoutBoundHandler_IsIgnored()
     {
-        var cut = RenderComponent<IgbBanner>();
+        var cut = Render<IgbBanner>();
 
         // No handler bound — dispatch must be a no-op rather than an error.
         Interop.RaiseEvent(Interop.ContainerIdOf(cut), "Closing");

--- a/tests/IgniteUI.Blazor.Tests/InteropReadinessTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropReadinessTests.cs
@@ -13,7 +13,7 @@ public class InteropReadinessTests : BlazorComponentTestBase
     [Fact]
     public async Task MethodInvocation_BeforeReady_Throws()
     {
-        var cut = RenderComponent<IgbBanner>();
+        var cut = Render<IgbBanner>();
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => cut.Instance.ShowAsync());
         Assert.Null(Interop.FindCall("show"));
@@ -24,7 +24,7 @@ public class InteropReadinessTests : BlazorComponentTestBase
     {
         Interop.PrimeReady();
         Interop.SetupMethodResult("show", InteropReturn.Bool(true));
-        var cut = RenderComponent<IgbBanner>();
+        var cut = Render<IgbBanner>();
 
         var shown = await cut.Instance.ShowAsync();
 
@@ -35,7 +35,7 @@ public class InteropReadinessTests : BlazorComponentTestBase
     [Fact]
     public async Task MakeReady_ReadiesComponents_RenderedBeforeTheLoadedSignal()
     {
-        var cut = RenderComponent<IgbBanner>();
+        var cut = Render<IgbBanner>();
         Interop.SetupMethodResult("hide", InteropReturn.Bool(false));
 
         Interop.MakeReady();

--- a/tests/IgniteUI.Blazor.Tests/ListTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ListTests.cs
@@ -8,7 +8,7 @@ public class ListTests : BlazorComponentTestBase
     [Fact]
     public void List_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbList>();
+        var cut = Render<IgbList>();
         Assert.NotNull(cut.Find("igc-list"));
     }
 
@@ -22,7 +22,7 @@ public class ListTests : BlazorComponentTestBase
     [Fact]
     public void List_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbList>(parameters =>
+        var cut = Render<IgbList>(parameters =>
             parameters.AddChildContent("List items"));
 
         Assert.Contains("List items", cut.Markup);
@@ -40,7 +40,7 @@ public class ListItemTests : BlazorComponentTestBase
     [Fact]
     public void ListItem_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbListItem>();
+        var cut = Render<IgbListItem>();
         Assert.NotNull(cut.Find("igc-list-item"));
     }
 
@@ -54,7 +54,7 @@ public class ListItemTests : BlazorComponentTestBase
     [Fact]
     public void ListItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbListItem>(parameters =>
+        var cut = Render<IgbListItem>(parameters =>
             parameters.AddChildContent("Item text"));
 
         Assert.Contains("Item text", cut.Markup);
@@ -66,7 +66,7 @@ public class ListHeaderTests : BlazorComponentTestBase
     [Fact]
     public void ListHeader_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbListHeader>();
+        var cut = Render<IgbListHeader>();
         Assert.NotNull(cut.Find("igc-list-header"));
     }
 

--- a/tests/IgniteUI.Blazor.Tests/MethodInteropTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/MethodInteropTests.cs
@@ -18,7 +18,7 @@ public class MethodInteropTests : BlazorComponentTestBase
     {
         Interop.PrimeReady();
         Interop.SetupMethodResult("toggle", InteropReturn.Deferred);
-        var cut = RenderComponent<IgbBanner>();
+        var cut = Render<IgbBanner>();
 
         var pending = cut.Instance.ToggleAsync();
         Assert.False(pending.IsCompleted);

--- a/tests/IgniteUI.Blazor.Tests/MiscComponentTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/MiscComponentTests.cs
@@ -47,7 +47,7 @@ public class AccordionTests : ComponentWithContractTestBase<IgbAccordion>
     [Fact]
     public void Accordion_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbAccordion>();
+        var cut = Render<IgbAccordion>();
         Assert.NotNull(cut.Find("igc-accordion"));
     }
 
@@ -61,7 +61,7 @@ public class AccordionTests : ComponentWithContractTestBase<IgbAccordion>
     [Fact]
     public void Accordion_SingleExpand_RendersAttribute()
     {
-        var cut = RenderComponent<IgbAccordion>(parameters =>
+        var cut = Render<IgbAccordion>(parameters =>
             parameters.Add(p => p.SingleExpand, true));
 
         var element = cut.Find("igc-accordion");
@@ -71,7 +71,7 @@ public class AccordionTests : ComponentWithContractTestBase<IgbAccordion>
     [Fact]
     public void Accordion_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbAccordion>(parameters =>
+        var cut = Render<IgbAccordion>(parameters =>
             parameters.AddChildContent("Accordion content"));
 
         Assert.Contains("Accordion content", cut.Markup);
@@ -102,7 +102,7 @@ public class BannerTests : ComponentWithContractTestBase<IgbBanner>
     [Fact]
     public void Banner_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbBanner>();
+        var cut = Render<IgbBanner>();
         Assert.NotNull(cut.Find("igc-banner"));
     }
 
@@ -116,7 +116,7 @@ public class BannerTests : ComponentWithContractTestBase<IgbBanner>
     [Fact]
     public void Banner_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbBanner>(parameters =>
+        var cut = Render<IgbBanner>(parameters =>
             parameters.Add(p => p.Open, true));
 
         var element = cut.Find("igc-banner");
@@ -135,7 +135,7 @@ public class DividerTests : BlazorComponentTestBase
     [Fact]
     public void Divider_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbDivider>();
+        var cut = Render<IgbDivider>();
         Assert.NotNull(cut.Find("igc-divider"));
     }
 
@@ -149,7 +149,7 @@ public class DividerTests : BlazorComponentTestBase
     [Fact]
     public void Divider_Type_Dashed()
     {
-        var cut = RenderComponent<IgbDivider>(parameters =>
+        var cut = Render<IgbDivider>(parameters =>
             parameters.Add(p => p.LineType, DividerType.Dashed));
 
         var element = cut.Find("igc-divider");
@@ -159,7 +159,7 @@ public class DividerTests : BlazorComponentTestBase
     [Fact]
     public void Divider_Middle_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDivider>(parameters =>
+        var cut = Render<IgbDivider>(parameters =>
             parameters.Add(p => p.Middle, true));
 
         var element = cut.Find("igc-divider");
@@ -169,7 +169,7 @@ public class DividerTests : BlazorComponentTestBase
     [Fact]
     public void Divider_Vertical_RendersAttribute()
     {
-        var cut = RenderComponent<IgbDivider>(parameters =>
+        var cut = Render<IgbDivider>(parameters =>
             parameters.Add(p => p.Vertical, true));
 
         var element = cut.Find("igc-divider");
@@ -182,7 +182,7 @@ public class RippleTests : BlazorComponentTestBase
     [Fact]
     public void Ripple_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbRipple>();
+        var cut = Render<IgbRipple>();
         Assert.NotNull(cut.Find("igc-ripple"));
     }
 

--- a/tests/IgniteUI.Blazor.Tests/NavDrawerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/NavDrawerTests.cs
@@ -8,7 +8,7 @@ public class NavDrawerExtendedTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawer_Position_End()
     {
-        var cut = RenderComponent<IgbNavDrawer>(p =>
+        var cut = Render<IgbNavDrawer>(p =>
             p.Add(x => x.Position, NavDrawerPosition.End));
 
         Assert.Equal("end", cut.Find("igc-nav-drawer").GetAttribute("position"));
@@ -17,7 +17,7 @@ public class NavDrawerExtendedTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawer_Position_Top()
     {
-        var cut = RenderComponent<IgbNavDrawer>(p =>
+        var cut = Render<IgbNavDrawer>(p =>
             p.Add(x => x.Position, NavDrawerPosition.Top));
 
         Assert.Equal("top", cut.Find("igc-nav-drawer").GetAttribute("position"));
@@ -26,7 +26,7 @@ public class NavDrawerExtendedTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawer_Position_Bottom()
     {
-        var cut = RenderComponent<IgbNavDrawer>(p =>
+        var cut = Render<IgbNavDrawer>(p =>
             p.Add(x => x.Position, NavDrawerPosition.Bottom));
 
         Assert.Equal("bottom", cut.Find("igc-nav-drawer").GetAttribute("position"));
@@ -35,7 +35,7 @@ public class NavDrawerExtendedTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawer_Position_Relative()
     {
-        var cut = RenderComponent<IgbNavDrawer>(p =>
+        var cut = Render<IgbNavDrawer>(p =>
             p.Add(x => x.Position, NavDrawerPosition.Relative));
 
         Assert.Equal("relative", cut.Find("igc-nav-drawer").GetAttribute("position"));
@@ -44,14 +44,14 @@ public class NavDrawerExtendedTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawerItem_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbNavDrawerItem>();
+        var cut = Render<IgbNavDrawerItem>();
         cut.Find("igc-nav-drawer-item").Should_Exist();
     }
 
     [Fact]
     public void NavDrawerItem_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbNavDrawerItem>(p =>
+        var cut = Render<IgbNavDrawerItem>(p =>
             p.Add(x => x.Disabled, true));
 
         Assert.NotNull(cut.Find("igc-nav-drawer-item").GetAttribute("disabled"));
@@ -60,7 +60,7 @@ public class NavDrawerExtendedTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawerItem_Active_RendersAttribute()
     {
-        var cut = RenderComponent<IgbNavDrawerItem>(p =>
+        var cut = Render<IgbNavDrawerItem>(p =>
             p.Add(x => x.Active, true));
 
         Assert.NotNull(cut.Find("igc-nav-drawer-item").GetAttribute("active"));
@@ -69,7 +69,7 @@ public class NavDrawerExtendedTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawerItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbNavDrawerItem>(p =>
+        var cut = Render<IgbNavDrawerItem>(p =>
             p.AddChildContent("<span>Home</span>"));
 
         Assert.Contains("Home", cut.Find("igc-nav-drawer-item").InnerHtml);
@@ -78,14 +78,14 @@ public class NavDrawerExtendedTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawerHeaderItem_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbNavDrawerHeaderItem>();
+        var cut = Render<IgbNavDrawerHeaderItem>();
         cut.Find("igc-nav-drawer-header-item").Should_Exist();
     }
 
     [Fact]
     public void NavDrawerHeaderItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbNavDrawerHeaderItem>(p =>
+        var cut = Render<IgbNavDrawerHeaderItem>(p =>
             p.AddChildContent("Navigation"));
 
         Assert.Contains("Navigation", cut.Find("igc-nav-drawer-header-item").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/NavigationTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/NavigationTests.cs
@@ -9,7 +9,7 @@ public class NavbarTests : BlazorComponentTestBase
     [Fact]
     public void Navbar_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbNavbar>();
+        var cut = Render<IgbNavbar>();
         Assert.NotNull(cut.Find("igc-navbar"));
     }
 
@@ -23,7 +23,7 @@ public class NavbarTests : BlazorComponentTestBase
     [Fact]
     public void Navbar_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbNavbar>(parameters =>
+        var cut = Render<IgbNavbar>(parameters =>
             parameters.AddChildContent("Navigation Title"));
 
         Assert.Contains("Navigation Title", cut.Markup);
@@ -54,7 +54,7 @@ public class NavDrawerTests : ComponentWithContractTestBase<IgbNavDrawer>
     [Fact]
     public void NavDrawer_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbNavDrawer>();
+        var cut = Render<IgbNavDrawer>();
         Assert.NotNull(cut.Find("igc-nav-drawer"));
     }
 
@@ -68,7 +68,7 @@ public class NavDrawerTests : ComponentWithContractTestBase<IgbNavDrawer>
     [Fact]
     public void NavDrawer_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbNavDrawer>(parameters =>
+        var cut = Render<IgbNavDrawer>(parameters =>
             parameters.Add(p => p.Open, true));
 
         var element = cut.Find("igc-nav-drawer");

--- a/tests/IgniteUI.Blazor.Tests/ProgressExtendedTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ProgressExtendedTests.cs
@@ -12,7 +12,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_HideLabel_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(p =>
+        var cut = Render<IgbLinearProgress>(p =>
             p.Add(x => x.HideLabel, true));
 
         Assert.NotNull(cut.Find("igc-linear-progress").GetAttribute("hide-label"));
@@ -21,7 +21,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_LabelFormat_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(p =>
+        var cut = Render<IgbLinearProgress>(p =>
             p.Add(x => x.LabelFormat, "{0}%"));
 
         Assert.Equal("{0}%", cut.Find("igc-linear-progress").GetAttribute("label-format"));
@@ -30,7 +30,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_AnimationDuration_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(p =>
+        var cut = Render<IgbLinearProgress>(p =>
             p.Add(x => x.AnimationDuration, 500));
 
         Assert.Equal("500", cut.Find("igc-linear-progress").GetAttribute("animation-duration"));
@@ -40,7 +40,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_HideLabel_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularProgress>(p =>
+        var cut = Render<IgbCircularProgress>(p =>
             p.Add(x => x.HideLabel, true));
 
         Assert.NotNull(cut.Find("igc-circular-progress").GetAttribute("hide-label"));
@@ -49,7 +49,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_LabelFormat_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularProgress>(p =>
+        var cut = Render<IgbCircularProgress>(p =>
             p.Add(x => x.LabelFormat, "{0} of {1}"));
 
         Assert.Equal("{0} of {1}", cut.Find("igc-circular-progress").GetAttribute("label-format"));
@@ -58,7 +58,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_AnimationDuration_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularProgress>(p =>
+        var cut = Render<IgbCircularProgress>(p =>
             p.Add(x => x.AnimationDuration, 1000));
 
         Assert.Equal("1000", cut.Find("igc-circular-progress").GetAttribute("animation-duration"));
@@ -67,7 +67,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCircularProgress>(p =>
+        var cut = Render<IgbCircularProgress>(p =>
             p.AddChildContent("<igc-circular-gradient offset=\"0%\" color=\"blue\"></igc-circular-gradient>"));
 
         Assert.Contains("igc-circular-gradient", cut.Find("igc-circular-progress").InnerHtml);
@@ -77,7 +77,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Rating_ChildContent_RatingSymbol()
     {
-        var cut = RenderComponent<IgbRating>(p =>
+        var cut = Render<IgbRating>(p =>
             p.AddChildContent("<igc-rating-symbol></igc-rating-symbol>"));
 
         Assert.Contains("igc-rating-symbol", cut.Find("igc-rating").InnerHtml);
@@ -87,7 +87,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void List_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbList>(p =>
+        var cut = Render<IgbList>(p =>
             p.AddChildContent("<igc-list-item>First</igc-list-item>"));
 
         Assert.Contains("First", cut.Find("igc-list").InnerHtml);
@@ -96,7 +96,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void ListItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbListItem>(p =>
+        var cut = Render<IgbListItem>(p =>
             p.AddChildContent("List content"));
 
         Assert.Contains("List content", cut.Find("igc-list-item").InnerHtml);
@@ -105,7 +105,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void ListHeader_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbListHeader>(p =>
+        var cut = Render<IgbListHeader>(p =>
             p.AddChildContent("Section A"));
 
         Assert.Contains("Section A", cut.Find("igc-list-header").InnerHtml);
@@ -115,7 +115,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Tab_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbTab>(p =>
+        var cut = Render<IgbTab>(p =>
             p.AddChildContent("Tab Content"));
 
         Assert.Contains("Tab Content", cut.Find("igc-tab").InnerHtml);
@@ -124,7 +124,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Tabs_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbTabs>(p =>
+        var cut = Render<IgbTabs>(p =>
             p.AddChildContent("<igc-tab>First</igc-tab>"));
 
         Assert.Contains("First", cut.Find("igc-tabs").InnerHtml);
@@ -134,7 +134,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Card_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCard>(p =>
+        var cut = Render<IgbCard>(p =>
             p.AddChildContent("<igc-card-header></igc-card-header>"));
 
         Assert.Contains("igc-card-header", cut.Find("igc-card").InnerHtml);
@@ -143,7 +143,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void CardHeader_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCardHeader>(p =>
+        var cut = Render<IgbCardHeader>(p =>
             p.AddChildContent("<h3>Title</h3>"));
 
         Assert.Contains("Title", cut.Find("igc-card-header").InnerHtml);
@@ -152,7 +152,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void CardContent_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCardContent>(p =>
+        var cut = Render<IgbCardContent>(p =>
             p.AddChildContent("<p>Body text</p>"));
 
         Assert.Contains("Body text", cut.Find("igc-card-content").InnerHtml);
@@ -161,7 +161,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void CardActions_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCardActions>(p =>
+        var cut = Render<IgbCardActions>(p =>
             p.AddChildContent("<button>Action</button>"));
 
         Assert.Contains("Action", cut.Find("igc-card-actions").InnerHtml);
@@ -170,7 +170,7 @@ public class ProgressExtendedTests : BlazorComponentTestBase
     [Fact]
     public void CardMedia_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbCardMedia>(p =>
+        var cut = Render<IgbCardMedia>(p =>
             p.AddChildContent("<img src=\"test.png\" />"));
 
         Assert.Contains("img", cut.Find("igc-card-media").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/ProgressTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ProgressTests.cs
@@ -8,7 +8,7 @@ public class LinearProgressTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbLinearProgress>();
+        var cut = Render<IgbLinearProgress>();
         Assert.NotNull(cut.Find("igc-linear-progress"));
     }
 
@@ -28,7 +28,7 @@ public class LinearProgressTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(parameters =>
+        var cut = Render<IgbLinearProgress>(parameters =>
             parameters.Add(p => p.Value, 75.0));
 
         var element = cut.Find("igc-linear-progress");
@@ -38,7 +38,7 @@ public class LinearProgressTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_Max_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(parameters =>
+        var cut = Render<IgbLinearProgress>(parameters =>
             parameters.Add(p => p.Max, 200.0));
 
         var element = cut.Find("igc-linear-progress");
@@ -48,7 +48,7 @@ public class LinearProgressTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_Striped_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(parameters =>
+        var cut = Render<IgbLinearProgress>(parameters =>
             parameters.Add(p => p.Striped, true));
 
         var element = cut.Find("igc-linear-progress");
@@ -58,7 +58,7 @@ public class LinearProgressTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_Indeterminate_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(parameters =>
+        var cut = Render<IgbLinearProgress>(parameters =>
             parameters.Add(p => p.Indeterminate, true));
 
         var element = cut.Find("igc-linear-progress");
@@ -68,7 +68,7 @@ public class LinearProgressTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_HideLabel_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(parameters =>
+        var cut = Render<IgbLinearProgress>(parameters =>
             parameters.Add(p => p.HideLabel, true));
 
         var element = cut.Find("igc-linear-progress");
@@ -78,7 +78,7 @@ public class LinearProgressTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_Variant_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(parameters =>
+        var cut = Render<IgbLinearProgress>(parameters =>
             parameters.Add(p => p.Variant, StyleVariant.Success));
 
         var element = cut.Find("igc-linear-progress");
@@ -88,7 +88,7 @@ public class LinearProgressTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_LabelFormat_RendersAttribute()
     {
-        var cut = RenderComponent<IgbLinearProgress>(parameters =>
+        var cut = Render<IgbLinearProgress>(parameters =>
             parameters.Add(p => p.LabelFormat, "{0}%"));
 
         var element = cut.Find("igc-linear-progress");
@@ -101,7 +101,7 @@ public class CircularProgressTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbCircularProgress>();
+        var cut = Render<IgbCircularProgress>();
         Assert.NotNull(cut.Find("igc-circular-progress"));
     }
 
@@ -121,7 +121,7 @@ public class CircularProgressTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularProgress>(parameters =>
+        var cut = Render<IgbCircularProgress>(parameters =>
             parameters.Add(p => p.Value, 60.0));
 
         var element = cut.Find("igc-circular-progress");
@@ -131,7 +131,7 @@ public class CircularProgressTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_Indeterminate_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularProgress>(parameters =>
+        var cut = Render<IgbCircularProgress>(parameters =>
             parameters.Add(p => p.Indeterminate, true));
 
         var element = cut.Find("igc-circular-progress");
@@ -141,7 +141,7 @@ public class CircularProgressTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_Max_RendersAttribute()
     {
-        var cut = RenderComponent<IgbCircularProgress>(parameters =>
+        var cut = Render<IgbCircularProgress>(parameters =>
             parameters.Add(p => p.Max, 150.0));
 
         var element = cut.Find("igc-circular-progress");

--- a/tests/IgniteUI.Blazor.Tests/RadioTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RadioTests.cs
@@ -35,7 +35,7 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
     [Fact]
     public void Radio_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbRadio>();
+        var cut = Render<IgbRadio>();
         Assert.NotNull(cut.Find("igc-radio"));
     }
 
@@ -49,7 +49,7 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
     [Fact]
     public void Radio_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRadio>(parameters =>
+        var cut = Render<IgbRadio>(parameters =>
             parameters.Add(p => p.Value, "option1"));
 
         var element = cut.Find("igc-radio");
@@ -59,7 +59,7 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
     [Fact]
     public void Radio_Checked_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRadio>(parameters =>
+        var cut = Render<IgbRadio>(parameters =>
             parameters.Add(p => p.Checked, true));
 
         var element = cut.Find("igc-radio");
@@ -69,7 +69,7 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
     [Fact]
     public void Radio_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRadio>(parameters =>
+        var cut = Render<IgbRadio>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-radio");
@@ -79,7 +79,7 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
     [Fact]
     public void Radio_Required_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRadio>(parameters =>
+        var cut = Render<IgbRadio>(parameters =>
             parameters.Add(p => p.Required, true));
 
         var element = cut.Find("igc-radio");
@@ -89,7 +89,7 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
     [Fact]
     public void Radio_LabelPosition_Before()
     {
-        var cut = RenderComponent<IgbRadio>(parameters =>
+        var cut = Render<IgbRadio>(parameters =>
             parameters.Add(p => p.LabelPosition, ToggleLabelPosition.Before));
 
         var element = cut.Find("igc-radio");
@@ -99,7 +99,7 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
     [Fact]
     public void Radio_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbRadio>(parameters =>
+        var cut = Render<IgbRadio>(parameters =>
             parameters.AddChildContent("Option A"));
 
         Assert.Contains("Option A", cut.Markup);
@@ -133,7 +133,7 @@ public class RadioGroupTests : ComponentWithContractTestBase<IgbRadioGroup>
     [Fact]
     public void RadioGroup_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbRadioGroup>();
+        var cut = Render<IgbRadioGroup>();
         Assert.NotNull(cut.Find("igc-radio-group"));
     }
 
@@ -147,7 +147,7 @@ public class RadioGroupTests : ComponentWithContractTestBase<IgbRadioGroup>
     [Fact]
     public void RadioGroup_Alignment_Vertical()
     {
-        var cut = RenderComponent<IgbRadioGroup>(parameters =>
+        var cut = Render<IgbRadioGroup>(parameters =>
             parameters.Add(p => p.Alignment, ContentOrientation.Vertical));
 
         var element = cut.Find("igc-radio-group");
@@ -157,7 +157,7 @@ public class RadioGroupTests : ComponentWithContractTestBase<IgbRadioGroup>
     [Fact]
     public void RadioGroup_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRadioGroup>(parameters =>
+        var cut = Render<IgbRadioGroup>(parameters =>
             parameters.Add(p => p.Value, "selected-option"));
 
         var element = cut.Find("igc-radio-group");

--- a/tests/IgniteUI.Blazor.Tests/RangeSliderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RangeSliderTests.cs
@@ -30,14 +30,14 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbRangeSlider>();
+        var cut = Render<IgbRangeSlider>();
         cut.Find("igc-range-slider").Should_Exist();
     }
 
     [Fact]
     public void RangeSlider_Lower_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.Lower, 20));
 
         Assert.Equal("20", cut.Find("igc-range-slider").GetAttribute("lower"));
@@ -46,7 +46,7 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_Upper_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.Upper, 80));
 
         Assert.Equal("80", cut.Find("igc-range-slider").GetAttribute("upper"));
@@ -55,7 +55,7 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_Min_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.Min, 10));
 
         Assert.Equal("10", cut.Find("igc-range-slider").GetAttribute("min"));
@@ -64,7 +64,7 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_Max_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.Max, 200));
 
         Assert.Equal("200", cut.Find("igc-range-slider").GetAttribute("max"));
@@ -73,7 +73,7 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_Step_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.Step, 5));
 
         Assert.Equal("5", cut.Find("igc-range-slider").GetAttribute("step"));
@@ -82,7 +82,7 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.Disabled, true));
 
         Assert.NotNull(cut.Find("igc-range-slider").GetAttribute("disabled"));
@@ -91,7 +91,7 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_DiscreteTrack_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.DiscreteTrack, true));
 
         Assert.NotNull(cut.Find("igc-range-slider").GetAttribute("discrete-track"));
@@ -100,7 +100,7 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_HideTooltip_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.HideTooltip, true));
 
         Assert.NotNull(cut.Find("igc-range-slider").GetAttribute("hide-tooltip"));
@@ -109,7 +109,7 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     [Fact]
     public void RangeSlider_PrimaryTicks_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p =>
+        var cut = Render<IgbRangeSlider>(p =>
             p.Add(x => x.PrimaryTicks, 5));
 
         Assert.Equal("5", cut.Find("igc-range-slider").GetAttribute("primary-ticks"));

--- a/tests/IgniteUI.Blazor.Tests/RatingTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RatingTests.cs
@@ -30,7 +30,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbRating>();
+        var cut = Render<IgbRating>();
         Assert.NotNull(cut.Find("igc-rating"));
     }
 
@@ -44,7 +44,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_Max_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.Max, 10.0));
 
         var element = cut.Find("igc-rating");
@@ -54,7 +54,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.Value, 3.5));
 
         var element = cut.Find("igc-rating");
@@ -64,7 +64,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_Step_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.Step, 0.5));
 
         var element = cut.Find("igc-rating");
@@ -74,7 +74,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.Label, "Product rating"));
 
         var element = cut.Find("igc-rating");
@@ -84,7 +84,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_ReadOnly_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.ReadOnly, true));
 
         var element = cut.Find("igc-rating");
@@ -94,7 +94,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-rating");
@@ -104,7 +104,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_Single_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.Single, true));
 
         var element = cut.Find("igc-rating");
@@ -114,7 +114,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_AllowReset_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.AllowReset, true));
 
         var element = cut.Find("igc-rating");
@@ -124,7 +124,7 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
     [Fact]
     public void Rating_HoverPreview_RendersAttribute()
     {
-        var cut = RenderComponent<IgbRating>(parameters =>
+        var cut = Render<IgbRating>(parameters =>
             parameters.Add(p => p.HoverPreview, true));
 
         var element = cut.Find("igc-rating");

--- a/tests/IgniteUI.Blazor.Tests/RenderingSerializationTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RenderingSerializationTests.cs
@@ -12,7 +12,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Button_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbButton>(p => p
+        var cut = Render<IgbButton>(p => p
             .Add(x => x.Variant, ButtonVariant.Outlined)
             .Add(x => x.DisplayType, ButtonBaseType.Submit)
             .Add(x => x.Disabled, true)
@@ -34,7 +34,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Input_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbInput>(p => p
+        var cut = Render<IgbInput>(p => p
             .Add(x => x.Value, "test")
             .Add(x => x.DisplayType, InputType.Password)
             .Add(x => x.Placeholder, "Enter value")
@@ -58,7 +58,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Textarea_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbTextarea>(p => p
+        var cut = Render<IgbTextarea>(p => p
             .Add(x => x.Value, "content")
             .Add(x => x.Placeholder, "Type here")
             .Add(x => x.Label, "Message")
@@ -80,7 +80,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Checkbox_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbCheckbox>(p => p
+        var cut = Render<IgbCheckbox>(p => p
             .Add(x => x.Checked, true)
             .Add(x => x.Disabled, true)
             .Add(x => x.Required, true)
@@ -100,7 +100,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Switch_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbSwitch>(p => p
+        var cut = Render<IgbSwitch>(p => p
             .Add(x => x.Checked, true)
             .Add(x => x.Disabled, true)
             .Add(x => x.Required, true)
@@ -118,7 +118,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Radio_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbRadio>(p => p
+        var cut = Render<IgbRadio>(p => p
             .Add(x => x.Value, "option-a")
             .Add(x => x.Checked, true)
             .Add(x => x.Disabled, true)
@@ -136,7 +136,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Slider_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbSlider>(p => p
+        var cut = Render<IgbSlider>(p => p
             .Add(x => x.Value, 50)
             .Add(x => x.Min, 0)
             .Add(x => x.Max, 100)
@@ -162,7 +162,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void RangeSlider_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbRangeSlider>(p => p
+        var cut = Render<IgbRangeSlider>(p => p
             .Add(x => x.Lower, 20)
             .Add(x => x.Upper, 80)
             .Add(x => x.Min, 0)
@@ -182,7 +182,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Rating_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbRating>(p => p
+        var cut = Render<IgbRating>(p => p
             .Add(x => x.Value, 4)
             .Add(x => x.Max, 10)
             .Add(x => x.ReadOnly, true)
@@ -206,7 +206,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Chip_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbChip>(p => p
+        var cut = Render<IgbChip>(p => p
             .Add(x => x.Disabled, true)
             .Add(x => x.Removable, true)
             .Add(x => x.Selectable, true)
@@ -224,7 +224,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void ExpansionPanel_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbExpansionPanel>(p => p
+        var cut = Render<IgbExpansionPanel>(p => p
             .Add(x => x.Open, true)
             .Add(x => x.Disabled, true)
             .Add(x => x.IndicatorPosition, ExpansionPanelIndicatorPosition.End));
@@ -238,7 +238,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Dialog_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbDialog>(p => p
+        var cut = Render<IgbDialog>(p => p
             .Add(x => x.Open, true)
             .Add(x => x.Title, "Test Title")
             .Add(x => x.KeepOpenOnEscape, true)
@@ -255,7 +255,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Snackbar_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbSnackbar>(p => p
+        var cut = Render<IgbSnackbar>(p => p
             .Add(x => x.Open, true)
             .Add(x => x.DisplayTime, 5000)
             .Add(x => x.KeepOpen, true)
@@ -271,7 +271,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Toast_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbToast>(p => p
+        var cut = Render<IgbToast>(p => p
             .Add(x => x.Open, true)
             .Add(x => x.DisplayTime, 3000)
             .Add(x => x.KeepOpen, true));
@@ -285,7 +285,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void LinearProgress_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbLinearProgress>(p => p
+        var cut = Render<IgbLinearProgress>(p => p
             .Add(x => x.Value, 75)
             .Add(x => x.Max, 100)
             .Add(x => x.Variant, StyleVariant.Success)
@@ -307,7 +307,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void CircularProgress_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbCircularProgress>(p => p
+        var cut = Render<IgbCircularProgress>(p => p
             .Add(x => x.Value, 60)
             .Add(x => x.Max, 100)
             .Add(x => x.Variant, StyleVariant.Danger)
@@ -327,7 +327,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawer_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbNavDrawer>(p => p
+        var cut = Render<IgbNavDrawer>(p => p
             .Add(x => x.Open, true)
             .Add(x => x.Position, NavDrawerPosition.End));
 
@@ -339,7 +339,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void NavDrawerItem_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbNavDrawerItem>(p => p
+        var cut = Render<IgbNavDrawerItem>(p => p
             .Add(x => x.Disabled, true)
             .Add(x => x.Active, true));
 
@@ -351,7 +351,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Carousel_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbCarousel>(p => p
+        var cut = Render<IgbCarousel>(p => p
             .Add(x => x.DisableLoop, true)
             .Add(x => x.DisablePauseOnInteraction, true)
             .Add(x => x.HideNavigation, true)
@@ -375,7 +375,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Tree_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbTree>(p => p
+        var cut = Render<IgbTree>(p => p
             .Add(x => x.SingleBranchExpand, true)
             .Add(x => x.ToggleNodeOnClick, true)
             .Add(x => x.Selection, TreeSelection.Cascade));
@@ -389,7 +389,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void TreeItem_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbTreeItem>(p => p
+        var cut = Render<IgbTreeItem>(p => p
             .Add(x => x.Label, "Item 1")
             .Add(x => x.Expanded, true)
             .Add(x => x.Active, true)
@@ -407,7 +407,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Tabs_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbTabs>(p => p
+        var cut = Render<IgbTabs>(p => p
             .Add(x => x.Alignment, TabsAlignment.Center)
             .Add(x => x.Activation, TabsActivation.Manual));
 
@@ -419,7 +419,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Tab_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbTab>(p => p
+        var cut = Render<IgbTab>(p => p
             .Add(x => x.Disabled, true)
             .Add(x => x.Selected, true));
 
@@ -431,7 +431,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Stepper_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbStepper>(p => p
+        var cut = Render<IgbStepper>(p => p
             .Add(x => x.Orientation, StepperOrientation.Vertical)
             .Add(x => x.StepType, StepperStepType.Full)
             .Add(x => x.TitlePosition, StepperTitlePosition.End)
@@ -447,7 +447,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Step_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbStep>(p => p
+        var cut = Render<IgbStep>(p => p
             .Add(x => x.Disabled, true));
 
         var el = cut.Find("igc-step");
@@ -457,7 +457,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void ToggleButton_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbToggleButton>(p => p
+        var cut = Render<IgbToggleButton>(p => p
             .Add(x => x.Value, "bold")
             .Add(x => x.Selected, true)
             .Add(x => x.Disabled, true));
@@ -471,7 +471,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void IconButton_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbIconButton>(p => p
+        var cut = Render<IgbIconButton>(p => p
             .Add(x => x.IconName, "search")
             .Add(x => x.Collection, "material")
             .Add(x => x.Variant, IconButtonVariant.Outlined)
@@ -489,7 +489,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Avatar_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbAvatar>(p => p
+        var cut = Render<IgbAvatar>(p => p
             .Add(x => x.Src, "img.png")
             .Add(x => x.Alt, "User")
             .Add(x => x.Initials, "AB")
@@ -505,7 +505,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Badge_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbBadge>(p => p
+        var cut = Render<IgbBadge>(p => p
             .Add(x => x.Variant, StyleVariant.Info)
             .Add(x => x.Outlined, true)
             .Add(x => x.Shape, BadgeShape.Square));
@@ -519,7 +519,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Icon_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbIcon>(p => p
+        var cut = Render<IgbIcon>(p => p
             .Add(x => x.IconName, "home")
             .Add(x => x.Collection, "material")
             .Add(x => x.Mirrored, true));
@@ -533,7 +533,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Accordion_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbAccordion>(p => p
+        var cut = Render<IgbAccordion>(p => p
             .Add(x => x.SingleExpand, true));
 
         var el = cut.Find("igc-accordion");
@@ -543,7 +543,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void ButtonGroup_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbButtonGroup>(p => p
+        var cut = Render<IgbButtonGroup>(p => p
             .Add(x => x.Disabled, true)
             .Add(x => x.Selection, ButtonGroupSelection.Multiple));
 
@@ -555,7 +555,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Select_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbSelect>(p => p
+        var cut = Render<IgbSelect>(p => p
             .Add(x => x.Label, "Choose")
             .Add(x => x.Placeholder, "Select...")
             .Add(x => x.Disabled, true)
@@ -575,7 +575,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbDateTimeInput>(p => p
+        var cut = Render<IgbDateTimeInput>(p => p
             .Add(x => x.InputFormat, "dd/MM/yyyy")
             .Add(x => x.Label, "Date")
             .Add(x => x.Placeholder, "Enter date")
@@ -595,7 +595,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbMaskInput>(p => p
+        var cut = Render<IgbMaskInput>(p => p
             .Add(x => x.Mask, "(000) 000-0000")
             .Add(x => x.Label, "Phone")
             .Add(x => x.Placeholder, "Enter phone")
@@ -617,7 +617,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Dropdown_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbDropdown>(p => p
+        var cut = Render<IgbDropdown>(p => p
             .Add(x => x.Open, true)
             .Add(x => x.KeepOpenOnSelect, true));
 
@@ -629,7 +629,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void TileManager_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbTileManager>(p => p
+        var cut = Render<IgbTileManager>(p => p
             .Add(x => x.ColumnCount, 4)
             .Add(x => x.ResizeMode, TileManagerResizeMode.Always)
             .Add(x => x.DragMode, TileManagerDragMode.TileHeader)
@@ -647,7 +647,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Tile_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbTile>(p => p
+        var cut = Render<IgbTile>(p => p
             .Add(x => x.ColSpan, 2)
             .Add(x => x.RowSpan, 3)
             .Add(x => x.ColStart, 1)
@@ -663,7 +663,7 @@ public class RenderingSerializationTests : BlazorComponentTestBase
     [Fact]
     public void Tooltip_RendersAllAttributes()
     {
-        var cut = RenderComponent<IgbTooltip>(p => p
+        var cut = Render<IgbTooltip>(p => p
             .Add(x => x.Open, true)
             .Add(x => x.WithArrow, true)
             .Add(x => x.Offset, 10)

--- a/tests/IgniteUI.Blazor.Tests/SelectExtendedTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SelectExtendedTests.cs
@@ -11,7 +11,7 @@ public class SelectExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Select_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(p =>
+        var cut = Render<IgbSelect>(p =>
             p.Add(x => x.Label, "Choose option"));
 
         Assert.Equal("Choose option", cut.Find("igc-select").GetAttribute("label"));
@@ -20,7 +20,7 @@ public class SelectExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Select_Outlined_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(p =>
+        var cut = Render<IgbSelect>(p =>
             p.Add(x => x.Outlined, true));
 
         Assert.NotNull(cut.Find("igc-select").GetAttribute("outlined"));
@@ -29,7 +29,7 @@ public class SelectExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Select_Autofocus_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(p =>
+        var cut = Render<IgbSelect>(p =>
             p.Add(x => x.Autofocus, true));
 
         Assert.NotNull(cut.Find("igc-select").GetAttribute("autofocus"));
@@ -38,7 +38,7 @@ public class SelectExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Select_Invalid_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(p =>
+        var cut = Render<IgbSelect>(p =>
             p.Add(x => x.Invalid, true));
 
         Assert.NotNull(cut.Find("igc-select").GetAttribute("invalid"));
@@ -47,7 +47,7 @@ public class SelectExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Select_Distance_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(p =>
+        var cut = Render<IgbSelect>(p =>
             p.Add(x => x.Distance, 8));
 
         Assert.Equal("8", cut.Find("igc-select").GetAttribute("distance"));
@@ -56,14 +56,14 @@ public class SelectExtendedTests : BlazorComponentTestBase
     [Fact]
     public void SelectGroup_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSelectGroup>();
+        var cut = Render<IgbSelectGroup>();
         cut.Find("igc-select-group").Should_Exist();
     }
 
     [Fact]
     public void SelectGroup_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelectGroup>(p =>
+        var cut = Render<IgbSelectGroup>(p =>
             p.Add(x => x.Disabled, true));
 
         Assert.NotNull(cut.Find("igc-select-group").GetAttribute("disabled"));
@@ -72,14 +72,14 @@ public class SelectExtendedTests : BlazorComponentTestBase
     [Fact]
     public void SelectHeader_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSelectHeader>();
+        var cut = Render<IgbSelectHeader>();
         cut.Find("igc-select-header").Should_Exist();
     }
 
     [Fact]
     public void SelectHeader_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbSelectHeader>(p =>
+        var cut = Render<IgbSelectHeader>(p =>
             p.AddChildContent("Group A"));
 
         Assert.Contains("Group A", cut.Find("igc-select-header").InnerHtml);
@@ -88,7 +88,7 @@ public class SelectExtendedTests : BlazorComponentTestBase
     [Fact]
     public void SelectItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbSelectItem>(p =>
+        var cut = Render<IgbSelectItem>(p =>
             p.Add(x => x.Value, "opt1")
              .AddChildContent("Option 1"));
 

--- a/tests/IgniteUI.Blazor.Tests/SelectTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SelectTests.cs
@@ -86,7 +86,7 @@ public class SelectTests : ComponentWithContractTestBase<IgbSelect>
     [Fact]
     public void Select_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSelect>();
+        var cut = Render<IgbSelect>();
         Assert.NotNull(cut.Find("igc-select"));
     }
 
@@ -100,7 +100,7 @@ public class SelectTests : ComponentWithContractTestBase<IgbSelect>
     [Fact]
     public void Select_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(parameters =>
+        var cut = Render<IgbSelect>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-select");
@@ -110,7 +110,7 @@ public class SelectTests : ComponentWithContractTestBase<IgbSelect>
     [Fact]
     public void Select_Required_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(parameters =>
+        var cut = Render<IgbSelect>(parameters =>
             parameters.Add(p => p.Required, true));
 
         var element = cut.Find("igc-select");
@@ -120,7 +120,7 @@ public class SelectTests : ComponentWithContractTestBase<IgbSelect>
     [Fact]
     public void Select_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(parameters =>
+        var cut = Render<IgbSelect>(parameters =>
             parameters.Add(p => p.Open, true));
 
         var element = cut.Find("igc-select");
@@ -130,7 +130,7 @@ public class SelectTests : ComponentWithContractTestBase<IgbSelect>
     [Fact]
     public void Select_Placeholder_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(parameters =>
+        var cut = Render<IgbSelect>(parameters =>
             parameters.Add(p => p.Placeholder, "Choose..."));
 
         var element = cut.Find("igc-select");
@@ -140,7 +140,7 @@ public class SelectTests : ComponentWithContractTestBase<IgbSelect>
     [Fact]
     public void Select_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelect>(parameters =>
+        var cut = Render<IgbSelect>(parameters =>
             parameters.Add(p => p.Label, "Country"));
 
         var element = cut.Find("igc-select");
@@ -159,7 +159,7 @@ public class SelectItemTests : BlazorComponentTestBase
     [Fact]
     public void SelectItem_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSelectItem>();
+        var cut = Render<IgbSelectItem>();
         Assert.NotNull(cut.Find("igc-select-item"));
     }
 
@@ -173,7 +173,7 @@ public class SelectItemTests : BlazorComponentTestBase
     [Fact]
     public void SelectItem_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelectItem>(parameters =>
+        var cut = Render<IgbSelectItem>(parameters =>
             parameters.Add(p => p.Value, "us"));
 
         var element = cut.Find("igc-select-item");
@@ -183,7 +183,7 @@ public class SelectItemTests : BlazorComponentTestBase
     [Fact]
     public void SelectItem_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelectItem>(parameters =>
+        var cut = Render<IgbSelectItem>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-select-item");
@@ -193,7 +193,7 @@ public class SelectItemTests : BlazorComponentTestBase
     [Fact]
     public void SelectItem_Selected_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSelectItem>(parameters =>
+        var cut = Render<IgbSelectItem>(parameters =>
             parameters.Add(p => p.Selected, true));
 
         var element = cut.Find("igc-select-item");
@@ -203,7 +203,7 @@ public class SelectItemTests : BlazorComponentTestBase
     [Fact]
     public void SelectItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbSelectItem>(parameters =>
+        var cut = Render<IgbSelectItem>(parameters =>
             parameters.AddChildContent("United States"));
 
         Assert.Contains("United States", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/SliderExtendedTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SliderExtendedTests.cs
@@ -11,7 +11,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_LowerBound_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.LowerBound, 10));
 
         Assert.Equal("10", cut.Find("igc-slider").GetAttribute("lower-bound"));
@@ -20,7 +20,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_UpperBound_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.UpperBound, 90));
 
         Assert.Equal("90", cut.Find("igc-slider").GetAttribute("upper-bound"));
@@ -29,7 +29,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_HideTooltip_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.HideTooltip, true));
 
         Assert.NotNull(cut.Find("igc-slider").GetAttribute("hide-tooltip"));
@@ -38,7 +38,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_PrimaryTicks_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.PrimaryTicks, 5));
 
         Assert.Equal("5", cut.Find("igc-slider").GetAttribute("primary-ticks"));
@@ -47,7 +47,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_SecondaryTicks_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.SecondaryTicks, 3));
 
         Assert.Equal("3", cut.Find("igc-slider").GetAttribute("secondary-ticks"));
@@ -56,7 +56,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_HidePrimaryLabels_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.HidePrimaryLabels, true));
 
         Assert.NotNull(cut.Find("igc-slider").GetAttribute("hide-primary-labels"));
@@ -65,7 +65,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_HideSecondaryLabels_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.HideSecondaryLabels, true));
 
         Assert.NotNull(cut.Find("igc-slider").GetAttribute("hide-secondary-labels"));
@@ -74,7 +74,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_TickOrientation_Mirror()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.TickOrientation, SliderTickOrientation.Mirror));
 
         Assert.Equal("mirror", cut.Find("igc-slider").GetAttribute("tick-orientation"));
@@ -83,7 +83,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_Locale_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.Locale, "en-US"));
 
         Assert.Equal("en-US", cut.Find("igc-slider").GetAttribute("locale"));
@@ -92,7 +92,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_ValueFormat_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.ValueFormat, "{0}%"));
 
         Assert.Equal("{0}%", cut.Find("igc-slider").GetAttribute("value-format"));
@@ -101,7 +101,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void Slider_Invalid_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(p =>
+        var cut = Render<IgbSlider>(p =>
             p.Add(x => x.Invalid, true));
 
         Assert.NotNull(cut.Find("igc-slider").GetAttribute("invalid"));
@@ -110,14 +110,14 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void SliderLabel_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSliderLabel>();
+        var cut = Render<IgbSliderLabel>();
         cut.Find("igc-slider-label").Should_Exist();
     }
 
     [Fact]
     public void SliderLabel_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbSliderLabel>(p =>
+        var cut = Render<IgbSliderLabel>(p =>
             p.AddChildContent("Low"));
 
         Assert.Contains("Low", cut.Find("igc-slider-label").InnerHtml);
@@ -126,7 +126,7 @@ public class SliderExtendedTests : BlazorComponentTestBase
     [Fact]
     public void RatingSymbol_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbRatingSymbol>();
+        var cut = Render<IgbRatingSymbol>();
         cut.Find("igc-rating-symbol").Should_Exist();
     }
 }

--- a/tests/IgniteUI.Blazor.Tests/SliderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SliderTests.cs
@@ -31,7 +31,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSlider>();
+        var cut = Render<IgbSlider>();
         Assert.NotNull(cut.Find("igc-slider"));
     }
 
@@ -51,7 +51,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.Value, 50.0));
 
         var element = cut.Find("igc-slider");
@@ -61,7 +61,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_Min_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.Min, 10.0));
 
         var element = cut.Find("igc-slider");
@@ -71,7 +71,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_Max_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.Max, 100.0));
 
         var element = cut.Find("igc-slider");
@@ -81,7 +81,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_Step_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.Step, 5.0));
 
         var element = cut.Find("igc-slider");
@@ -91,7 +91,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-slider");
@@ -101,7 +101,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_DiscreteTrack_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.DiscreteTrack, true));
 
         var element = cut.Find("igc-slider");
@@ -111,7 +111,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_HideTooltip_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.HideTooltip, true));
 
         var element = cut.Find("igc-slider");
@@ -121,7 +121,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_LowerBound_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.LowerBound, 20.0));
 
         var element = cut.Find("igc-slider");
@@ -131,7 +131,7 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
     [Fact]
     public void Slider_UpperBound_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSlider>(parameters =>
+        var cut = Render<IgbSlider>(parameters =>
             parameters.Add(p => p.UpperBound, 80.0));
 
         var element = cut.Find("igc-slider");

--- a/tests/IgniteUI.Blazor.Tests/SplitterTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SplitterTests.cs
@@ -43,7 +43,7 @@ public class SplitterTests : ComponentWithContractTestBase<IgbSplitter>
     [Fact]
     public void Splitter_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSplitter>();
+        var cut = Render<IgbSplitter>();
         Assert.NotNull(cut.Find("igc-splitter"));
     }
 
@@ -70,7 +70,7 @@ public class SplitterTests : ComponentWithContractTestBase<IgbSplitter>
     [InlineData(SplitterOrientation.Vertical, "vertical")]
     public void Splitter_Orientation_SerializesAsAttribute(SplitterOrientation orientation, string expected)
     {
-        var cut = RenderComponent<IgbSplitter>(parameters =>
+        var cut = Render<IgbSplitter>(parameters =>
             parameters.Add(p => p.Orientation, orientation));
 
         Assert.Equal(expected, cut.Find("igc-splitter").GetAttribute("orientation"));
@@ -79,7 +79,7 @@ public class SplitterTests : ComponentWithContractTestBase<IgbSplitter>
     [Fact]
     public void Splitter_DisableCollapse_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSplitter>(parameters =>
+        var cut = Render<IgbSplitter>(parameters =>
             parameters.Add(p => p.DisableCollapse, true));
 
         Assert.NotNull(cut.Find("igc-splitter").GetAttribute("disable-collapse"));
@@ -88,7 +88,7 @@ public class SplitterTests : ComponentWithContractTestBase<IgbSplitter>
     [Fact]
     public void Splitter_DisableResize_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSplitter>(parameters =>
+        var cut = Render<IgbSplitter>(parameters =>
             parameters.Add(p => p.DisableResize, true));
 
         Assert.NotNull(cut.Find("igc-splitter").GetAttribute("disable-resize"));
@@ -97,7 +97,7 @@ public class SplitterTests : ComponentWithContractTestBase<IgbSplitter>
     [Fact]
     public void Splitter_SizeConstraints_RendersAttributes()
     {
-        var cut = RenderComponent<IgbSplitter>(parameters =>
+        var cut = Render<IgbSplitter>(parameters =>
             parameters.Add(p => p.StartMinSize, "10%")
                 .Add(p => p.EndMaxSize, "400px")
                 .Add(p => p.StartSize, "30%")
@@ -113,7 +113,7 @@ public class SplitterTests : ComponentWithContractTestBase<IgbSplitter>
     [Fact]
     public void Splitter_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbSplitter>(parameters =>
+        var cut = Render<IgbSplitter>(parameters =>
             parameters.AddChildContent("<div slot=\"start\">Start</div><div slot=\"end\">End</div>"));
 
         var innerHtml = cut.Find("igc-splitter").InnerHtml;

--- a/tests/IgniteUI.Blazor.Tests/StepperTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/StepperTests.cs
@@ -52,7 +52,7 @@ public class StepperTests : ComponentWithContractTestBase<IgbStepper>
     [Fact]
     public void Stepper_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbStepper>();
+        var cut = Render<IgbStepper>();
         Assert.NotNull(cut.Find("igc-stepper"));
     }
 
@@ -75,7 +75,7 @@ public class StepTests : BlazorComponentTestBase
     [Fact]
     public void Step_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbStep>();
+        var cut = Render<IgbStep>();
         Assert.NotNull(cut.Find("igc-step"));
     }
 
@@ -89,7 +89,7 @@ public class StepTests : BlazorComponentTestBase
     [Fact]
     public void Step_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbStep>(parameters =>
+        var cut = Render<IgbStep>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-step");
@@ -99,7 +99,7 @@ public class StepTests : BlazorComponentTestBase
     [Fact]
     public void Step_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbStep>(parameters =>
+        var cut = Render<IgbStep>(parameters =>
             parameters.AddChildContent("Step Content"));
 
         Assert.Contains("Step Content", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/SwitchTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SwitchTests.cs
@@ -35,7 +35,7 @@ public class SwitchTests : ComponentWithContractTestBase<IgbSwitch>
     [Fact]
     public void Switch_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbSwitch>();
+        var cut = Render<IgbSwitch>();
         Assert.NotNull(cut.Find("igc-switch"));
     }
 
@@ -55,7 +55,7 @@ public class SwitchTests : ComponentWithContractTestBase<IgbSwitch>
     [Fact]
     public void Switch_Checked_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSwitch>(parameters =>
+        var cut = Render<IgbSwitch>(parameters =>
             parameters.Add(p => p.Checked, true));
 
         var element = cut.Find("igc-switch");
@@ -65,7 +65,7 @@ public class SwitchTests : ComponentWithContractTestBase<IgbSwitch>
     [Fact]
     public void Switch_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSwitch>(parameters =>
+        var cut = Render<IgbSwitch>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-switch");
@@ -75,7 +75,7 @@ public class SwitchTests : ComponentWithContractTestBase<IgbSwitch>
     [Fact]
     public void Switch_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbSwitch>(parameters =>
+        var cut = Render<IgbSwitch>(parameters =>
             parameters.Add(p => p.Value, "toggle-value"));
 
         var element = cut.Find("igc-switch");
@@ -85,7 +85,7 @@ public class SwitchTests : ComponentWithContractTestBase<IgbSwitch>
     [Fact]
     public void Switch_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbSwitch>(parameters =>
+        var cut = Render<IgbSwitch>(parameters =>
             parameters.AddChildContent("Dark mode"));
 
         Assert.Contains("Dark mode", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/TabsTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TabsTests.cs
@@ -35,7 +35,7 @@ public class TabsTests : ComponentWithContractTestBase<IgbTabs>
     [Fact]
     public void Tabs_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbTabs>();
+        var cut = Render<IgbTabs>();
         Assert.NotNull(cut.Find("igc-tabs"));
     }
 
@@ -49,7 +49,7 @@ public class TabsTests : ComponentWithContractTestBase<IgbTabs>
     [Fact]
     public void Tabs_Alignment_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTabs>(parameters =>
+        var cut = Render<IgbTabs>(parameters =>
             parameters.Add(p => p.Alignment, TabsAlignment.Center));
 
         var element = cut.Find("igc-tabs");
@@ -59,7 +59,7 @@ public class TabsTests : ComponentWithContractTestBase<IgbTabs>
     [Fact]
     public void Tabs_Activation_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTabs>(parameters =>
+        var cut = Render<IgbTabs>(parameters =>
             parameters.Add(p => p.Activation, TabsActivation.Manual));
 
         var element = cut.Find("igc-tabs");
@@ -78,7 +78,7 @@ public class TabTests : BlazorComponentTestBase
     [Fact]
     public void Tab_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbTab>();
+        var cut = Render<IgbTab>();
         Assert.NotNull(cut.Find("igc-tab"));
     }
 
@@ -92,7 +92,7 @@ public class TabTests : BlazorComponentTestBase
     [Fact]
     public void Tab_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTab>(parameters =>
+        var cut = Render<IgbTab>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-tab");
@@ -102,7 +102,7 @@ public class TabTests : BlazorComponentTestBase
     [Fact]
     public void Tab_Selected_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTab>(parameters =>
+        var cut = Render<IgbTab>(parameters =>
             parameters.Add(p => p.Selected, true));
 
         var element = cut.Find("igc-tab");
@@ -112,7 +112,7 @@ public class TabTests : BlazorComponentTestBase
     [Fact]
     public void Tab_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbTab>(parameters =>
+        var cut = Render<IgbTab>(parameters =>
             parameters.AddChildContent("Tab Label"));
 
         Assert.Contains("Tab Label", cut.Markup);

--- a/tests/IgniteUI.Blazor.Tests/TextInputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TextInputTests.cs
@@ -31,7 +31,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbTextarea>();
+        var cut = Render<IgbTextarea>();
         Assert.NotNull(cut.Find("igc-textarea"));
     }
 
@@ -45,7 +45,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(parameters =>
+        var cut = Render<IgbTextarea>(parameters =>
             parameters.Add(p => p.Value, "Hello world"));
 
         var element = cut.Find("igc-textarea");
@@ -55,7 +55,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_Placeholder_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(parameters =>
+        var cut = Render<IgbTextarea>(parameters =>
             parameters.Add(p => p.Placeholder, "Type here..."));
 
         var element = cut.Find("igc-textarea");
@@ -65,7 +65,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(parameters =>
+        var cut = Render<IgbTextarea>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-textarea");
@@ -75,7 +75,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_Required_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(parameters =>
+        var cut = Render<IgbTextarea>(parameters =>
             parameters.Add(p => p.Required, true));
 
         var element = cut.Find("igc-textarea");
@@ -85,7 +85,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_ReadOnly_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(parameters =>
+        var cut = Render<IgbTextarea>(parameters =>
             parameters.Add(p => p.ReadOnly, true));
 
         var element = cut.Find("igc-textarea");
@@ -95,7 +95,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_Rows_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(parameters =>
+        var cut = Render<IgbTextarea>(parameters =>
             parameters.Add(p => p.Rows, 5.0));
 
         var element = cut.Find("igc-textarea");
@@ -105,7 +105,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(parameters =>
+        var cut = Render<IgbTextarea>(parameters =>
             parameters.Add(p => p.Label, "Comments"));
 
         var element = cut.Find("igc-textarea");
@@ -115,7 +115,7 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     [Fact]
     public void Textarea_Resize_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTextarea>(parameters =>
+        var cut = Render<IgbTextarea>(parameters =>
             parameters.Add(p => p.Resize, TextareaResize.Vertical));
 
         var element = cut.Find("igc-textarea");
@@ -179,7 +179,7 @@ public class MaskInputTests : ComponentWithContractTestBase<IgbMaskInput>
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbMaskInput>();
+        var cut = Render<IgbMaskInput>();
         Assert.NotNull(cut.Find("igc-mask-input"));
     }
 
@@ -193,7 +193,7 @@ public class MaskInputTests : ComponentWithContractTestBase<IgbMaskInput>
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_Mask_RendersAttribute()
     {
-        var cut = RenderComponent<IgbMaskInput>(parameters =>
+        var cut = Render<IgbMaskInput>(parameters =>
             parameters.Add(p => p.Mask, "000-000-0000"));
 
         var element = cut.Find("igc-mask-input");
@@ -203,7 +203,7 @@ public class MaskInputTests : ComponentWithContractTestBase<IgbMaskInput>
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbMaskInput>(parameters =>
+        var cut = Render<IgbMaskInput>(parameters =>
             parameters.Add(p => p.Disabled, true));
 
         var element = cut.Find("igc-mask-input");

--- a/tests/IgniteUI.Blazor.Tests/ThemeProviderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ThemeProviderTests.cs
@@ -8,7 +8,7 @@ public class ThemeProviderTests : BlazorComponentTestBase
     [Fact]
     public void ThemeProvider_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbThemeProvider>();
+        var cut = Render<IgbThemeProvider>();
         cut.Find("igc-theme-provider").Should_Exist();
     }
 
@@ -24,7 +24,7 @@ public class ThemeProviderTests : BlazorComponentTestBase
     [Fact]
     public void ThemeProvider_DefaultValues_DoNotRenderAttributes()
     {
-        var cut = RenderComponent<IgbThemeProvider>();
+        var cut = Render<IgbThemeProvider>();
         var element = cut.Find("igc-theme-provider");
 
         Assert.Null(element.GetAttribute("theme"));
@@ -38,7 +38,7 @@ public class ThemeProviderTests : BlazorComponentTestBase
     [InlineData(Theme.Fluent, "fluent")]
     public void ThemeProvider_Theme_SerializesAsAttribute(Theme theme, string expected)
     {
-        var cut = RenderComponent<IgbThemeProvider>(parameters =>
+        var cut = Render<IgbThemeProvider>(parameters =>
             parameters.Add(p => p.Theme, theme));
 
         var element = cut.Find("igc-theme-provider");
@@ -50,7 +50,7 @@ public class ThemeProviderTests : BlazorComponentTestBase
     [InlineData(ThemeVariant.Dark, "dark")]
     public void ThemeProvider_Variant_SerializesAsAttribute(ThemeVariant variant, string expected)
     {
-        var cut = RenderComponent<IgbThemeProvider>(parameters =>
+        var cut = Render<IgbThemeProvider>(parameters =>
             parameters.Add(p => p.Variant, variant));
 
         var element = cut.Find("igc-theme-provider");
@@ -60,7 +60,7 @@ public class ThemeProviderTests : BlazorComponentTestBase
     [Fact]
     public void ThemeProvider_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbThemeProvider>(parameters =>
+        var cut = Render<IgbThemeProvider>(parameters =>
             parameters.AddChildContent("Scoped Content"));
 
         var element = cut.Find("igc-theme-provider");

--- a/tests/IgniteUI.Blazor.Tests/TileManagerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TileManagerTests.cs
@@ -81,14 +81,14 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void TileManager_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbTileManager>();
+        var cut = Render<IgbTileManager>();
         cut.Find("igc-tile-manager").Should_Exist();
     }
 
     [Fact]
     public void TileManager_ColumnCount_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTileManager>(p =>
+        var cut = Render<IgbTileManager>(p =>
             p.Add(x => x.ColumnCount, 4));
 
         Assert.Equal("4", cut.Find("igc-tile-manager").GetAttribute("column-count"));
@@ -97,7 +97,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void TileManager_ResizeMode_Hover()
     {
-        var cut = RenderComponent<IgbTileManager>(p =>
+        var cut = Render<IgbTileManager>(p =>
             p.Add(x => x.ResizeMode, TileManagerResizeMode.Hover));
 
         Assert.Equal("hover", cut.Find("igc-tile-manager").GetAttribute("resize-mode"));
@@ -106,7 +106,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void TileManager_ResizeMode_Always()
     {
-        var cut = RenderComponent<IgbTileManager>(p =>
+        var cut = Render<IgbTileManager>(p =>
             p.Add(x => x.ResizeMode, TileManagerResizeMode.Always));
 
         Assert.Equal("always", cut.Find("igc-tile-manager").GetAttribute("resize-mode"));
@@ -115,7 +115,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void TileManager_DragMode_Tile()
     {
-        var cut = RenderComponent<IgbTileManager>(p =>
+        var cut = Render<IgbTileManager>(p =>
             p.Add(x => x.DragMode, TileManagerDragMode.Tile));
 
         Assert.Equal("tile", cut.Find("igc-tile-manager").GetAttribute("drag-mode"));
@@ -124,7 +124,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void TileManager_DragMode_TileHeader()
     {
-        var cut = RenderComponent<IgbTileManager>(p =>
+        var cut = Render<IgbTileManager>(p =>
             p.Add(x => x.DragMode, TileManagerDragMode.TileHeader));
 
         Assert.Equal("tile-header", cut.Find("igc-tile-manager").GetAttribute("drag-mode"));
@@ -133,7 +133,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void TileManager_MinColumnWidth_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTileManager>(p =>
+        var cut = Render<IgbTileManager>(p =>
             p.Add(x => x.MinColumnWidth, "200px"));
 
         Assert.Equal("200px", cut.Find("igc-tile-manager").GetAttribute("min-column-width"));
@@ -142,7 +142,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void TileManager_MinRowHeight_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTileManager>(p =>
+        var cut = Render<IgbTileManager>(p =>
             p.Add(x => x.MinRowHeight, "150px"));
 
         Assert.Equal("150px", cut.Find("igc-tile-manager").GetAttribute("min-row-height"));
@@ -151,14 +151,14 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void Tile_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbTile>();
+        var cut = Render<IgbTile>();
         cut.Find("igc-tile").Should_Exist();
     }
 
     [Fact]
     public void Tile_ColSpan_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTile>(p =>
+        var cut = Render<IgbTile>(p =>
             p.Add(x => x.ColSpan, 2));
 
         Assert.Equal("2", cut.Find("igc-tile").GetAttribute("col-span"));
@@ -167,7 +167,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void Tile_RowSpan_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTile>(p =>
+        var cut = Render<IgbTile>(p =>
             p.Add(x => x.RowSpan, 3));
 
         Assert.Equal("3", cut.Find("igc-tile").GetAttribute("row-span"));
@@ -176,7 +176,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void Tile_ColStart_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTile>(p =>
+        var cut = Render<IgbTile>(p =>
             p.Add(x => x.ColStart, 1));
 
         Assert.Equal("1", cut.Find("igc-tile").GetAttribute("col-start"));
@@ -185,7 +185,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void Tile_RowStart_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTile>(p =>
+        var cut = Render<IgbTile>(p =>
             p.Add(x => x.RowStart, 2));
 
         Assert.Equal("2", cut.Find("igc-tile").GetAttribute("row-start"));
@@ -194,7 +194,7 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
     [Fact]
     public void Tile_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbTile>(p =>
+        var cut = Render<IgbTile>(p =>
             p.AddChildContent("<div>Tile content</div>"));
 
         Assert.Contains("Tile content", cut.Find("igc-tile").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/ToggleButtonTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ToggleButtonTests.cs
@@ -18,14 +18,14 @@ public class ToggleButtonTests : ComponentWithContractTestBase<IgbToggleButton>
     [Fact]
     public void ToggleButton_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbToggleButton>();
+        var cut = Render<IgbToggleButton>();
         cut.Find("igc-toggle-button").Should_Exist();
     }
 
     [Fact]
     public void ToggleButton_Value_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToggleButton>(p =>
+        var cut = Render<IgbToggleButton>(p =>
             p.Add(x => x.Value, "bold"));
 
         Assert.Equal("bold", cut.Find("igc-toggle-button").GetAttribute("value"));
@@ -34,7 +34,7 @@ public class ToggleButtonTests : ComponentWithContractTestBase<IgbToggleButton>
     [Fact]
     public void ToggleButton_Selected_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToggleButton>(p =>
+        var cut = Render<IgbToggleButton>(p =>
             p.Add(x => x.Selected, true));
 
         Assert.NotNull(cut.Find("igc-toggle-button").GetAttribute("selected"));
@@ -43,7 +43,7 @@ public class ToggleButtonTests : ComponentWithContractTestBase<IgbToggleButton>
     [Fact]
     public void ToggleButton_Selected_False_NoAttribute()
     {
-        var cut = RenderComponent<IgbToggleButton>(p =>
+        var cut = Render<IgbToggleButton>(p =>
             p.Add(x => x.Selected, false));
 
         Assert.Null(cut.Find("igc-toggle-button").GetAttribute("selected"));
@@ -52,7 +52,7 @@ public class ToggleButtonTests : ComponentWithContractTestBase<IgbToggleButton>
     [Fact]
     public void ToggleButton_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbToggleButton>(p =>
+        var cut = Render<IgbToggleButton>(p =>
             p.Add(x => x.Disabled, true));
 
         Assert.NotNull(cut.Find("igc-toggle-button").GetAttribute("disabled"));
@@ -61,7 +61,7 @@ public class ToggleButtonTests : ComponentWithContractTestBase<IgbToggleButton>
     [Fact]
     public void ToggleButton_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbToggleButton>(p =>
+        var cut = Render<IgbToggleButton>(p =>
             p.AddChildContent("<span>B</span>"));
 
         Assert.Contains("B", cut.Find("igc-toggle-button").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/TooltipTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TooltipTests.cs
@@ -25,14 +25,14 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbTooltip>();
+        var cut = Render<IgbTooltip>();
         cut.Find("igc-tooltip").Should_Exist();
     }
 
     [Fact]
     public void Tooltip_Open_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.Add(x => x.Open, true));
 
         Assert.NotNull(cut.Find("igc-tooltip").GetAttribute("open"));
@@ -41,7 +41,7 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_WithArrow_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.Add(x => x.WithArrow, true));
 
         Assert.NotNull(cut.Find("igc-tooltip").GetAttribute("with-arrow"));
@@ -50,7 +50,7 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_Offset_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.Add(x => x.Offset, 10));
 
         Assert.Equal("10", cut.Find("igc-tooltip").GetAttribute("offset"));
@@ -59,7 +59,7 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_Anchor_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.Add(x => x.Anchor, "my-button"));
 
         Assert.Equal("my-button", cut.Find("igc-tooltip").GetAttribute("anchor"));
@@ -68,7 +68,7 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_ShowDelay_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.Add(x => x.ShowDelay, 500));
 
         Assert.Equal("500", cut.Find("igc-tooltip").GetAttribute("show-delay"));
@@ -77,7 +77,7 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_HideDelay_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.Add(x => x.HideDelay, 300));
 
         Assert.Equal("300", cut.Find("igc-tooltip").GetAttribute("hide-delay"));
@@ -86,7 +86,7 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_Message_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.Add(x => x.Message, "Tooltip text"));
 
         Assert.Equal("Tooltip text", cut.Find("igc-tooltip").GetAttribute("message"));
@@ -95,7 +95,7 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_Sticky_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.Add(x => x.Sticky, true));
 
         Assert.NotNull(cut.Find("igc-tooltip").GetAttribute("sticky"));
@@ -104,7 +104,7 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
     [Fact]
     public void Tooltip_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbTooltip>(p =>
+        var cut = Render<IgbTooltip>(p =>
             p.AddChildContent("Custom tooltip content"));
 
         Assert.Contains("Custom tooltip content", cut.Find("igc-tooltip").InnerHtml);

--- a/tests/IgniteUI.Blazor.Tests/TreeTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TreeTests.cs
@@ -54,14 +54,14 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void Tree_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbTree>();
+        var cut = Render<IgbTree>();
         cut.Find("igc-tree").Should_Exist();
     }
 
     [Fact]
     public void Tree_SingleBranchExpand_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTree>(p =>
+        var cut = Render<IgbTree>(p =>
             p.Add(x => x.SingleBranchExpand, true));
 
         Assert.NotNull(cut.Find("igc-tree").GetAttribute("single-branch-expand"));
@@ -70,7 +70,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void Tree_ToggleNodeOnClick_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTree>(p =>
+        var cut = Render<IgbTree>(p =>
             p.Add(x => x.ToggleNodeOnClick, true));
 
         Assert.NotNull(cut.Find("igc-tree").GetAttribute("toggle-node-on-click"));
@@ -79,7 +79,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void Tree_Selection_Multiple()
     {
-        var cut = RenderComponent<IgbTree>(p =>
+        var cut = Render<IgbTree>(p =>
             p.Add(x => x.Selection, TreeSelection.Multiple));
 
         Assert.Equal("multiple", cut.Find("igc-tree").GetAttribute("selection"));
@@ -88,7 +88,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void Tree_Selection_Cascade()
     {
-        var cut = RenderComponent<IgbTree>(p =>
+        var cut = Render<IgbTree>(p =>
             p.Add(x => x.Selection, TreeSelection.Cascade));
 
         Assert.Equal("cascade", cut.Find("igc-tree").GetAttribute("selection"));
@@ -97,7 +97,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void Tree_Selection_None()
     {
-        var cut = RenderComponent<IgbTree>(p =>
+        var cut = Render<IgbTree>(p =>
             p.Add(x => x.Selection, TreeSelection.None));
 
         Assert.Equal("none", cut.Find("igc-tree").GetAttribute("selection"));
@@ -106,14 +106,14 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void TreeItem_RendersCorrectElement()
     {
-        var cut = RenderComponent<IgbTreeItem>();
+        var cut = Render<IgbTreeItem>();
         cut.Find("igc-tree-item").Should_Exist();
     }
 
     [Fact]
     public void TreeItem_Label_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTreeItem>(p =>
+        var cut = Render<IgbTreeItem>(p =>
             p.Add(x => x.Label, "Node 1"));
 
         Assert.Equal("Node 1", cut.Find("igc-tree-item").GetAttribute("label"));
@@ -122,7 +122,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void TreeItem_Expanded_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTreeItem>(p =>
+        var cut = Render<IgbTreeItem>(p =>
             p.Add(x => x.Expanded, true));
 
         Assert.NotNull(cut.Find("igc-tree-item").GetAttribute("expanded"));
@@ -131,7 +131,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void TreeItem_Active_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTreeItem>(p =>
+        var cut = Render<IgbTreeItem>(p =>
             p.Add(x => x.Active, true));
 
         Assert.NotNull(cut.Find("igc-tree-item").GetAttribute("active"));
@@ -140,7 +140,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void TreeItem_Disabled_RendersAttribute()
     {
-        var cut = RenderComponent<IgbTreeItem>(p =>
+        var cut = Render<IgbTreeItem>(p =>
             p.Add(x => x.Disabled, true));
 
         Assert.NotNull(cut.Find("igc-tree-item").GetAttribute("disabled"));
@@ -149,7 +149,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
     [Fact]
     public void TreeItem_ChildContent_Renders()
     {
-        var cut = RenderComponent<IgbTreeItem>(p =>
+        var cut = Render<IgbTreeItem>(p =>
             p.Add(x => x.Label, "Parent")
              .AddChildContent("<span>Child</span>"));
 
@@ -160,7 +160,7 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
 public class TreeItemTests : ComponentWithContractTestBase<IgbTreeItem>
 {
     /// <summary>Real-usage host: IgbTree > "Node 1" > "Child 1.1" (the component under test).</summary>
-    static readonly RenderFragment treeHost = ContractHost.Of<IgbTree>(ps => ps.AddChildContent(b =>
+    static readonly Func<BunitContext, IRenderedComponent<IComponent>> treeHost = ContractHost.Of<IgbTree>(ps => ps.AddChildContent(b =>
     {
         b.OpenComponent<IgbTreeItem>(0);
         b.AddAttribute(1, "Label", "Node 1");


### PR DESCRIPTION
bUnit is migrated from 1.40.0 → 2.8.6 (latest stable) per https://bunit.dev/docs/migrations/1to2.html, resolving the vulnerable dependency warning in old version.

## What changed

**Package** — `Directory.Packages.props`: bunit 1.40.0 → 2.8.6.
**Mechanical v2 renames** (across tests/IgniteUI.Blazor.Tests):
- `TestContext` → `BunitContext` (base class) — `BlazorComponentTestBase.cs`
- `RenderComponent<T>` → `Render<T>` (~230 call sites)
- `IRenderedFragment` → `IRenderedComponent<IComponent>` — v2 removed the non-generic public interface; `IRenderedComponent<out TComponent>` is covariant, so `<IComponent>` is the correct non-generic scope handle

**Non-mechanical fixes** (v2 removed public API the harness relied on):

1. Contract base constraint — `ComponentWithContractTestBase.cs`: `where TComponent : IComponent` → ` where TComponent : class, IComponent`. The covariant conversion `IRenderedComponent<TComponent>` → `IRenderedComponent<IComponent>` only applies when the type arg is a reference type; Blazor components always are.
2. **ContractHost reworked to a context-thunk** — `ComponentContract.cs`. v2 made `ComponentParameterCollectionBuilder.Build()` and the `ComponentParameterCollection` type internal, closing every public route to a detached host `RenderFragment`. Rather than reflect into internals (fragile), `ContractHost.Of<THost>` now returns `Func<BunitContext, IRenderedComponent<IComponent>>` = `ctx => ctx.Render<THost>(arrange)`, deferring the render to the context. Followed the type through the two `Getter` hosted overloads, the `Host` property, `treeHost` in TreeTests, and the `scope = method.Host(this)` call site.

**Doc** — SKILL.md: `TestContext` → `BunitContext`.


All three TFMs build clean and the full suite is green: 920 passed, 0 failed, 22 skipped on net8.0/net9.0/net10.0 (the 22 skips are pre-existing `[Skip]` attribute specs, untouched

One note: RenderComponent<T> actually still exists in v2 as a compat alias, so that rename wasn't strictly required — but Render<T> is the v2-idiomatic name, so the change is worth keeping.