### PR TITLE
Align component property defaults with the web components, unit & integration checks

### DIFF
--- a/src/components/Blazor/BaseAlertLike.cs
+++ b/src/components/Blazor/BaseAlertLike.cs
@@ -68,7 +68,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _displayTime = 0;
+        private double _displayTime = 4000;
 
         partial void OnDisplayTimeChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/Calendar.cs
+++ b/src/components/Blazor/Calendar.cs
@@ -195,7 +195,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _visibleMonths = 0;
+        private double _visibleMonths = 1;
 
         partial void OnVisibleMonthsChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/Carousel.cs
+++ b/src/components/Blazor/Carousel.cs
@@ -243,7 +243,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _maximumIndicatorsCount = 0;
+        private double _maximumIndicatorsCount = 10;
 
         partial void OnMaximumIndicatorsCountChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/CircularGradient.cs
+++ b/src/components/Blazor/CircularGradient.cs
@@ -102,7 +102,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _opacity = 0;
+        private double _opacity = 1;
 
         partial void OnOpacityChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/DatePicker.cs
+++ b/src/components/Blazor/DatePicker.cs
@@ -371,7 +371,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _visibleMonths = 0;
+        private double _visibleMonths = 1;
 
         partial void OnVisibleMonthsChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/DateRangePicker.cs
+++ b/src/components/Blazor/DateRangePicker.cs
@@ -527,7 +527,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _visibleMonths = 0;
+        private double _visibleMonths = 2;
 
         partial void OnVisibleMonthsChanging(ref double newValue);
         [Parameter]

--- a/src/components/Blazor/DateTimeInputBase.cs
+++ b/src/components/Blazor/DateTimeInputBase.cs
@@ -197,7 +197,7 @@ namespace IgniteUI.Blazor.Controls
             }
 
         }
-        private bool _spinLoop = false;
+        private bool _spinLoop = true;
 
         partial void OnSpinLoopChanging(ref bool newValue);
         /// <summary>

--- a/src/components/Blazor/Dropdown.cs
+++ b/src/components/Blazor/Dropdown.cs
@@ -54,7 +54,7 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnCreatedIgbDropdown();
 
-        private PopoverPlacement _placement = PopoverPlacement.Top;
+        private PopoverPlacement _placement = PopoverPlacement.BottomStart;
 
         partial void OnPlacementChanging(ref PopoverPlacement newValue);
         /// <summary>

--- a/src/components/Blazor/ProgressBase.cs
+++ b/src/components/Blazor/ProgressBase.cs
@@ -48,7 +48,7 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnCreatedIgbProgressBase();
 
-        private double _max = 0;
+        private double _max = 100;
 
         partial void OnMaxChanging(ref double newValue);
         /// <summary>
@@ -108,7 +108,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _animationDuration = 0;
+        private double _animationDuration = 500;
 
         partial void OnAnimationDurationChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/RadioGroup.cs
+++ b/src/components/Blazor/RadioGroup.cs
@@ -59,7 +59,7 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnCreatedIgbRadioGroup();
 
-        private ContentOrientation _alignment = ContentOrientation.Horizontal;
+        private ContentOrientation _alignment = ContentOrientation.Vertical;
 
         partial void OnAlignmentChanging(ref ContentOrientation newValue);
         /// <summary>

--- a/src/components/Blazor/Rating.cs
+++ b/src/components/Blazor/Rating.cs
@@ -61,7 +61,7 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnCreatedIgbRating();
 
-        private double _max = 0;
+        private double _max = 5;
 
         partial void OnMaxChanging(ref double newValue);
         /// <summary>
@@ -83,7 +83,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _step = 0;
+        private double _step = 1;
 
         partial void OnStepChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/Select.cs
+++ b/src/components/Blazor/Select.cs
@@ -184,7 +184,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private PopoverPlacement _placement = PopoverPlacement.Top;
+        private PopoverPlacement _placement = PopoverPlacement.BottomStart;
 
         partial void OnPlacementChanging(ref PopoverPlacement newValue);
         /// <summary>

--- a/src/components/Blazor/SliderBase.cs
+++ b/src/components/Blazor/SliderBase.cs
@@ -80,7 +80,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _max = 0;
+        private double _max = 100;
 
         partial void OnMaxChanging(ref double newValue);
         /// <summary>
@@ -206,7 +206,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _step = 0;
+        private double _step = 1;
 
         partial void OnStepChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/Stepper.cs
+++ b/src/components/Blazor/Stepper.cs
@@ -211,7 +211,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _animationDuration = 0;
+        private double _animationDuration = 320;
 
         partial void OnAnimationDurationChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/Textarea.cs
+++ b/src/components/Blazor/Textarea.cs
@@ -272,7 +272,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _rows = 0;
+        private double _rows = 3;
 
         partial void OnRowsChanging(ref double newValue);
         /// <summary>
@@ -323,7 +323,7 @@ namespace IgniteUI.Blazor.Controls
             var iv = InvokeMethodSync("p:Value", new object[] { }, new string[] { });
             return ReturnToString(iv);
         }
-        private bool _spellcheck = false;
+        private bool _spellcheck = true;
 
         partial void OnSpellcheckChanging(ref bool newValue);
         /// <summary>

--- a/src/components/Blazor/ThemeProvider.cs
+++ b/src/components/Blazor/ThemeProvider.cs
@@ -63,7 +63,7 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnCreatedIgbThemeProvider();
 
-        private Theme _theme = Theme.Material;
+        private Theme _theme = Theme.Bootstrap;
 
         partial void OnThemeChanging(ref Theme newValue);
         /// <summary>

--- a/src/components/Blazor/Tile.cs
+++ b/src/components/Blazor/Tile.cs
@@ -60,7 +60,7 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnCreatedIgbTile();
 
-        private double _colSpan = 0;
+        private double _colSpan = 1;
 
         partial void OnColSpanChanging(ref double newValue);
         /// <summary>
@@ -80,7 +80,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _rowSpan = 0;
+        private double _rowSpan = 1;
 
         partial void OnRowSpanChanging(ref double newValue);
         /// <summary>
@@ -233,7 +233,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _position = 0;
+        private double _position = -1;
 
         partial void OnPositionChanging(ref double newValue);
         /// <summary>

--- a/src/components/Blazor/Tooltip.cs
+++ b/src/components/Blazor/Tooltip.cs
@@ -100,7 +100,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _offset = 0;
+        private double _offset = 6;
 
         partial void OnOffsetChanging(ref double newValue);
         /// <summary>
@@ -120,7 +120,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private PopoverPlacement _placement = PopoverPlacement.Top;
+        private PopoverPlacement _placement = PopoverPlacement.Bottom;
 
         partial void OnPlacementChanging(ref PopoverPlacement newValue);
         /// <summary>
@@ -202,7 +202,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _showDelay = 0;
+        private double _showDelay = 200;
 
         partial void OnShowDelayChanging(ref double newValue);
         /// <summary>
@@ -222,7 +222,7 @@ namespace IgniteUI.Blazor.Controls
 
             }
         }
-        private double _hideDelay = 0;
+        private double _hideDelay = 300;
 
         partial void OnHideDelayChanging(ref double newValue);
         /// <summary>

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
@@ -15,6 +15,8 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
         public static List<string> dependantMethods = new List<string>() { };
         // Exluded events as per the component config
         public static List<string> excludedEvents = new List<string>() { };
+        // Props whose initial value is allowed to differ from the client component's, as per the component config
+        public static List<string> excludedDefaultProps = new List<string>() { };
 
         // gets the full list of valid properties for type
         public static List<PropertyInfo> GetValidProps(Type type)

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/TestUtil.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/TestUtil.cs
@@ -7,6 +7,20 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
 {
     public static class TestUtil
     {
+        /// <summary>
+        /// Whether a property's initial value can be compared against the client component's.
+        /// Only booleans, numbers and enums have an unambiguous representation on both sides;
+        /// strings, objects, collections and dates are left null by the wrapper while the client
+        /// reports an empty string or undefined, so comparing those would report noise instead
+        /// of defects.
+        /// </summary>
+        public static bool HasComparableDefault(PropertyInfo prop)
+        {
+            var type = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+            return type == typeof(bool) || type.IsEnum || type == typeof(double)
+                || type == typeof(int) || type == typeof(float) || type == typeof(decimal) || type == typeof(long);
+        }
+
         public static bool PropertyValuesAreEqual(object? serverValue, string? clientValue, PropertyInfo prop)
         {
             string serverString = serverValue is Enum ?

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
@@ -74,6 +74,7 @@
         ReflectionUtils.dependantProps = app.config.GetSection(type + ":DependantProps")?.Get<string[]>()?.ToList() ?? new List<string>();
         ReflectionUtils.dependantMethods = app.config.GetSection(type + ":DependantMethods")?.Get<string[]>()?.ToList() ?? new List<string>();
         ReflectionUtils.excludedEvents = app.config.GetSection(type + ":ExcludedEvents")?.Get<string[]>()?.ToList() ?? new List<string>();
+        ReflectionUtils.excludedDefaultProps = app.config.GetSection(type + ":ExcludedDefaultProps")?.Get<string[]>()?.ToList() ?? new List<string>();
 
         app.StateHasChanged();
         await Task.Delay(1);
@@ -91,6 +92,8 @@
 
         app.componentParameters = new Dictionary<string, object>();
 
+        // Defaults first: it is the only point where nothing has been assigned yet.
+        await app.TestPropDefaults();
         await app.TestEvents();
         await app.TestServerTemplates();
         await app.TestClientTemplates();
@@ -222,6 +225,49 @@
                 errorMessages.Add("Method result mismatch after calling. Method name:  " + method.Name + ". Expected:" + expected + ", but got: " + actualResult);
             }
 
+        }
+    }
+
+    /// <summary>
+    /// The reverse of <see cref="TestProps"/>: instead of setting a value and checking it reaches
+    /// the client, this reads what the client component starts with and checks the wrapper reports
+    /// the same. Runs before any property is set, since that is the only moment the defaults are still intact.
+    /// </summary>
+    public async Task TestPropDefaults()
+    {
+        if (selectedType == null || dc == null)
+        {
+            return;
+        }
+
+        var props = ReflectionUtils.GetValidProps(selectedType)
+            .Where(x => TestUtil.HasComparableDefault(x) && !ReflectionUtils.excludedDefaultProps.Contains(x.Name));
+
+        foreach (var p in props)
+        {
+            var serverValue = p.GetValue(dc.Instance);
+            if (serverValue == null)
+            {
+                continue;
+            }
+
+            var clientPropName = ReflectionUtils.GetActualPropertyName(p);
+            var clientValue = await GetClientPropValue(clientPropName);
+            if (clientValue == null || clientValue == "undefined")
+            {
+                // The component does not expose the member yet (lazily created), nothing to compare.
+                continue;
+            }
+
+            if (!TestUtil.PropertyValuesAreEqual(serverValue, clientValue, p))
+            {
+                var serverString = serverValue is Enum
+                    ? TestUtil.EnumActualValue(serverValue)
+                    : serverValue.ToString();
+                this.errorMessages.Add("Default value mismatch before setting. Prop name:  " + p.Name
+                    + ". The wrapper reports:" + serverString
+                    + ", but the client component starts with: " + clientValue);
+            }
         }
     }
 

--- a/tests/IgniteUI.Blazor.Lite.TestBed/componentsConfig.json
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/componentsConfig.json
@@ -51,6 +51,12 @@
     "ExcludedProps": [
       // BUG 35189
       "ValueFormatOptions"
+    ],
+    "ExcludedDefaultProps": [
+      // Derived on the client, not stored: upperBound reports max and lowerBound reports min
+      // while unset, so the wrapper cannot mirror either with a constant initializer.
+      "UpperBound",
+      "LowerBound"
     ]
   },
   "IgbTextarea": {
@@ -189,6 +195,12 @@
     "ExcludedProps": [
       // BUG 35189
       "ValueFormatOptions"
+    ],
+    "ExcludedDefaultProps": [
+      // Derived on the client, not stored: upperBound reports max and lowerBound reports min
+      // while unset, so the wrapper cannot mirror either with a constant initializer.
+      "UpperBound",
+      "LowerBound"
     ]
   },
   "IgbStepper": {

--- a/tests/IgniteUI.Blazor.Tests/CalendarTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CalendarTests.cs
@@ -172,4 +172,16 @@ public class CalendarTests : ComponentWithContractTestBase<IgbCalendar>
         cal.ActiveDate = date;
         Assert.Equal(date, cal.ActiveDate);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbCalendar</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Calendar_DefaultValues_MatchWebComponent()
+    {
+        var calendar = new IgbCalendar();
+
+        Assert.Equal(1, calendar.VisibleMonths);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/CarouselTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CarouselTests.cs
@@ -158,4 +158,16 @@ public class CarouselTests : ComponentWithContractTestBase<IgbCarousel>
         var cut = Render<IgbCarouselIndicator>();
         cut.Find("igc-carousel-indicator").Should_Exist();
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbCarousel</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Carousel_DefaultValues_MatchWebComponent()
+    {
+        var carousel = new IgbCarousel();
+
+        Assert.Equal(10, carousel.MaximumIndicatorsCount);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/CircularGradientTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CircularGradientTests.cs
@@ -52,4 +52,16 @@ public class CircularGradientTests : BlazorComponentTestBase
         Assert.Equal("blue", el.GetAttribute("color"));
         Assert.Equal("1", el.GetAttribute("opacity"));
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbCircularGradient</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void CircularGradient_DefaultValues_MatchWebComponent()
+    {
+        var gradient = new IgbCircularGradient();
+
+        Assert.Equal(1, gradient.Opacity);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/CircularProgressTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CircularProgressTests.cs
@@ -93,4 +93,17 @@ public class CircularProgressTests : BlazorComponentTestBase
 
         Assert.Contains("igc-circular-gradient", cut.Find("igc-circular-progress").InnerHtml);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbCircularProgress</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void CircularProgress_DefaultValues_MatchWebComponent()
+    {
+        var progress = new IgbCircularProgress();
+
+        Assert.Equal(100, progress.Max);
+        Assert.Equal(500, progress.AnimationDuration);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/DatePickerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DatePickerTests.cs
@@ -162,4 +162,16 @@ public class DatePickerTests : ComponentWithContractTestBase<IgbDatePicker>
         picker.Value = date;
         Assert.Equal(date, picker.Value);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbDatePicker</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void DatePicker_DefaultValues_MatchWebComponent()
+    {
+        var picker = new IgbDatePicker();
+
+        Assert.Equal(1, picker.VisibleMonths);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/DateRangePickerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DateRangePickerTests.cs
@@ -129,4 +129,16 @@ public class DateRangePickerTests : ComponentWithContractTestBase<IgbDateRangePi
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbDateRangePicker</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void DateRangePicker_DefaultValues_MatchWebComponent()
+    {
+        var picker = new IgbDateRangePicker();
+
+        Assert.Equal(2, picker.VisibleMonths);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/DateTimeInputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DateTimeInputTests.cs
@@ -138,4 +138,16 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
 
         Assert.NotNull(cut.Find("igc-date-time-input").GetAttribute("outlined"));
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbDateTimeInput</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void DateTimeInput_DefaultValues_MatchWebComponent()
+    {
+        var input = new IgbDateTimeInput();
+
+        Assert.True(input.SpinLoop);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/DropdownTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DropdownTests.cs
@@ -232,4 +232,16 @@ public class DropdownHeaderTests : BlazorComponentTestBase
 
         Assert.Contains("Category", cut.Find("igc-dropdown-header").InnerHtml);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbDropdown</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Dropdown_DefaultValues_MatchWebComponent()
+    {
+        var dropdown = new IgbDropdown();
+
+        Assert.Equal(PopoverPlacement.BottomStart, dropdown.Placement);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/LinearProgressTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/LinearProgressTests.cs
@@ -104,4 +104,17 @@ public class LinearProgressTests : BlazorComponentTestBase
         var element = cut.Find("igc-linear-progress");
         Assert.Equal("500", element.GetAttribute("animation-duration"));
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbLinearProgress</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void LinearProgress_DefaultValues_MatchWebComponent()
+    {
+        var progress = new IgbLinearProgress();
+
+        Assert.Equal(100, progress.Max);
+        Assert.Equal(500, progress.AnimationDuration);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/RadioTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RadioTests.cs
@@ -169,4 +169,16 @@ public class RadioGroupTests : ComponentWithContractTestBase<IgbRadioGroup>
     {
         Assert.True(typeof(IgbRadioGroup).IsSubclassOf(typeof(BaseRendererControl)));
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbRadioGroup</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void RadioGroup_DefaultValues_MatchWebComponent()
+    {
+        var group = new IgbRadioGroup();
+
+        Assert.Equal(ContentOrientation.Vertical, group.Alignment);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/RangeSliderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RangeSliderTests.cs
@@ -120,4 +120,17 @@ public class RangeSliderTests : ComponentWithContractTestBase<IgbRangeSlider>
     {
         Assert.True(typeof(IgbRangeSlider).IsSubclassOf(typeof(IgbSliderBase)));
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbRangeSlider</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void RangeSlider_DefaultValues_MatchWebComponent()
+    {
+        var slider = new IgbRangeSlider();
+
+        Assert.Equal(100, slider.Max);
+        Assert.Equal(1, slider.Step);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/RatingTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RatingTests.cs
@@ -155,4 +155,17 @@ public class RatingSymbolTests : BlazorComponentTestBase
         var cut = Render<IgbRatingSymbol>();
         cut.Find("igc-rating-symbol").Should_Exist();
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbRating</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Rating_DefaultValues_MatchWebComponent()
+    {
+        var rating = new IgbRating();
+
+        Assert.Equal(5, rating.Max);
+        Assert.Equal(1, rating.Step);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/SelectTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SelectTests.cs
@@ -286,4 +286,16 @@ public class SelectHeaderTests : BlazorComponentTestBase
 
         Assert.Contains("Group A", cut.Find("igc-select-header").InnerHtml);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbSelect</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Select_DefaultValues_MatchWebComponent()
+    {
+        var select = new IgbSelect();
+
+        Assert.Equal(PopoverPlacement.BottomStart, select.Placement);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/SliderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SliderTests.cs
@@ -236,4 +236,17 @@ public class SliderLabelTests : BlazorComponentTestBase
 
         Assert.Contains("Low", cut.Find("igc-slider-label").InnerHtml);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbSlider</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Slider_DefaultValues_MatchWebComponent()
+    {
+        var slider = new IgbSlider();
+
+        Assert.Equal(100, slider.Max);
+        Assert.Equal(1, slider.Step);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/SnackbarTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SnackbarTests.cs
@@ -86,4 +86,16 @@ public class SnackbarTests : ComponentWithContractTestBase<IgbSnackbar>
 
         Assert.Contains("Item deleted", cut.Markup);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbSnackbar</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Snackbar_DefaultValues_MatchWebComponent()
+    {
+        var snackbar = new IgbSnackbar();
+
+        Assert.Equal(4000, snackbar.DisplayTime);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/StepperTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/StepperTests.cs
@@ -104,4 +104,16 @@ public class StepTests : BlazorComponentTestBase
 
         Assert.Contains("Step Content", cut.Markup);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbStepper</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Stepper_DefaultValues_MatchWebComponent()
+    {
+        var stepper = new IgbStepper();
+
+        Assert.Equal(320, stepper.AnimationDuration);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/TextareaTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TextareaTests.cs
@@ -207,4 +207,17 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
     {
         Assert.True(typeof(IgbTextarea).IsSubclassOf(typeof(BaseRendererControl)));
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbTextarea</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Textarea_DefaultValues_MatchWebComponent()
+    {
+        var textarea = new IgbTextarea();
+
+        Assert.Equal(3, textarea.Rows);
+        Assert.True(textarea.Spellcheck);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/ThemeProviderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ThemeProviderTests.cs
@@ -12,8 +12,8 @@ public class ThemeProviderTests : BlazorComponentTestBase
         cut.Find("igc-theme-provider").Should_Exist();
     }
 
-    [Fact(Skip = "Default should be Bootstrap")]
-    public void ThemeProvider_DefaultValues_AreMaterialAndLight()
+    [Fact]
+    public void ThemeProvider_DefaultValues_AreBootstrapAndLight()
     {
         var provider = new IgbThemeProvider();
 

--- a/tests/IgniteUI.Blazor.Tests/TileManagerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TileManagerTests.cs
@@ -246,4 +246,18 @@ public class TileTests : ComponentWithContractTestBase<IgbTile>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbTile</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Tile_DefaultValues_MatchWebComponent()
+    {
+        var tile = new IgbTile();
+
+        Assert.Equal(1, tile.ColSpan);
+        Assert.Equal(1, tile.RowSpan);
+        Assert.Equal(-1, tile.Position);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/ToastTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ToastTests.cs
@@ -72,4 +72,16 @@ public class ToastTests : ComponentWithContractTestBase<IgbToast>
 
         Assert.Contains("Operation successful", cut.Markup);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbToast</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Toast_DefaultValues_MatchWebComponent()
+    {
+        var toast = new IgbToast();
+
+        Assert.Equal(4000, toast.DisplayTime);
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/TooltipTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TooltipTests.cs
@@ -109,4 +109,19 @@ public class TooltipTests : ComponentWithContractTestBase<IgbTooltip>
 
         Assert.Contains("Custom tooltip content", cut.Find("igc-tooltip").InnerHtml);
     }
+
+    /// <summary>
+    /// The wrapper must report the same initial values as <c>IgbTooltip</c>'s web component,
+    /// so reading a property that was never assigned does not lie about the rendered state.
+    /// </summary>
+    [Fact]
+    public void Tooltip_DefaultValues_MatchWebComponent()
+    {
+        var tooltip = new IgbTooltip();
+
+        Assert.Equal(PopoverPlacement.Bottom, tooltip.Placement);
+        Assert.Equal(6, tooltip.Offset);
+        Assert.Equal(200, tooltip.ShowDelay);
+        Assert.Equal(300, tooltip.HideDelay);
+    }
 }


### PR DESCRIPTION
Discovered in #286


The backing fields for 27 wrapper properties were initialized to the C# type default — `0`, `false`, or the first enum member — instead of the default the underlying web component actually starts with. Reading such a property before assigning it reported a value the component never used: `Tooltip.ShowDelay` returned `0` while the tooltip actually waited 200ms, and `Tooltip.Placement` returned `Top` while the popover opened at the bottom.

## Why it matters

Rendering was never wrong. A property is serialized only when it has been marked dirty, and `_isDirty` is set exclusively by `MarkPropDirty`/`OnRefChanged` with no bulk-serialize path, so an unassigned property is never sent to the client and the component keeps applying its own default.

The problem is on the read side. The getter returns the backing field, so any code that inspects a property it has not set — a conditional, a computed value, a variable bound to it — sees a number or enum member that does not describe the rendered component. None of these properties expose a `Get<Prop>()`/`Get<Prop>Async()` accessor either, so there was no way to obtain the effective value from .NET.

The enum cases are the most likely to cause real trouble: `Placement` on `IgbDropdown`, `IgbSelect` and `IgbTooltip`, and `Theme` on `IgbThemeProvider`.

## Changes

| Property | Was | Now (upstream default) |
|---|---|---|
| [`BaseAlertLike.DisplayTime`](src/components/Blazor/BaseAlertLike.cs#L74) | `0` | `4000` |
| [`Calendar.VisibleMonths`](src/components/Blazor/Calendar.cs#L232) | `0` | `1` |
| [`DateRangePicker.VisibleMonths`](src/components/Blazor/DateRangePicker.cs#L530) | `0` | `2` |
| [`Carousel.MaximumIndicatorsCount`](src/components/Blazor/Carousel.cs#L247) | `0` | `10` |
| [`CircularGradient.Opacity`](src/components/Blazor/CircularGradient.cs#L106) | `0` | `1` |
| [`DatePicker.VisibleMonths`](src/components/Blazor/DatePicker.cs#L382) | `0` | `1` |
| [`DateTimeInputBase.SpinLoop`](src/components/Blazor/DateTimeInputBase.cs#L207) | `false` | `true` |
| [`Dropdown.Placement`](src/components/Blazor/Dropdown.cs#L57) | `Top` | `BottomStart` |
| [`ProgressBase.Max`](src/components/Blazor/ProgressBase.cs#L54) | `0` | `100` |
| [`ProgressBase.AnimationDuration`](src/components/Blazor/ProgressBase.cs#L114) | `0` | `500` |
| [`RadioGroup.Alignment`](src/components/Blazor/RadioGroup.cs#L62) | `Horizontal` | `Vertical` |
| [`Rating.Max`](src/components/Blazor/Rating.cs#L64) | `0` | `5` |
| [`Rating.Step`](src/components/Blazor/Rating.cs#L86) | `0` | `1` |
| [`Select.Placement`](src/components/Blazor/Select.cs#L195) | `Top` | `BottomStart` |
| [`SliderBase.Max`](src/components/Blazor/SliderBase.cs#L83) | `0` | `100` |
| [`SliderBase.Step`](src/components/Blazor/SliderBase.cs#L209) | `0` | `1` |
| [`Stepper.AnimationDuration`](src/components/Blazor/Stepper.cs#L221) | `0` | `320` |
| [`Textarea.Rows`](src/components/Blazor/Textarea.cs#L279) | `0` | `3` |
| [`Textarea.Spellcheck`](src/components/Blazor/Textarea.cs#L338) | `false` | `true` |
| [`ThemeProvider.Theme`](src/components/Blazor/ThemeProvider.cs#L66) | `Material` | `Bootstrap` |
| [`Tile.ColSpan`](src/components/Blazor/Tile.cs#L63) | `0` | `1` |
| [`Tile.RowSpan`](src/components/Blazor/Tile.cs#L83) | `0` | `1` |
| [`Tile.Position`](src/components/Blazor/Tile.cs#L236) | `0` | `-1` |
| [`Tooltip.Offset`](src/components/Blazor/Tooltip.cs#L104) | `0` | `6` |
| [`Tooltip.Placement`](src/components/Blazor/Tooltip.cs#L124) | `Top` | `Bottom` |
| [`Tooltip.ShowDelay`](src/components/Blazor/Tooltip.cs#L206) | `0` | `200` |
| [`Tooltip.HideDelay`](src/components/Blazor/Tooltip.cs#L226) | `0` | `300` |

One line per property; no other production code touched.

Most defaults were taken from `custom-elements.json`, with the enum ones resolved through each member's `[WCEnumName]` attribute rather than by name — that is what maps `bottom-start` to `BottomStart`. It also shows `SliderTickLabelRotation.Zero` is **not** a mismatch despite looking like one: its `[WCEnumName("0")]` already equals upstream's `0`, so it is left as is.

The last four — `DateRangePicker.VisibleMonths`, `SliderBase.Max`, `SliderBase.Step` and `Tile.Position` — are **not** in the manifest at all. Upstream implements those members as accessors rather than plain fields, so the metadata records no default and only the running component knows the value (`_visibleMonths = 2`, `_max = 100`, `_step = 1`, `_position = -1`). They were found by the integration check described below, which is the argument for having it.

### Deliberately not changed

`Slider`/`RangeSlider` `UpperBound` also reports `100` on the client, but it is derived rather than stored:

```ts
public get upperBound(): number {
  const current = this._upperBound ?? this._max;
  return clamp(current, lower, this._max);
}
```

Pinning the wrapper to `100` would be wrong the moment `Max` is set to anything else. It and `LowerBound` (derived from `min` the same way, and equal only by coincidence today) are listed in `ExcludedDefaultProps` instead, with the reason recorded in the config.

## Test coverage

Both directions are now pinned, so this cannot silently regress:

- **Unit** — each affected component's existing test file gains a `..._DefaultValues_MatchWebComponent` check. `ThemeProviderTests` already had one, written and skipped with the note *"Default should be Bootstrap"*; it is un-skipped here.
- **Integration** — `TestPropDefaults` in the TestBed runs before any property is assigned and compares every comparable property against the value the real component starts with. It is the reverse of the existing `TestProps` sweep, which only proves that values written from .NET reach the client, and is what surfaced the four accessor-backed defaults. Scoped to booleans, numbers and enums, since strings, objects and dates are left null by the wrapper while the client reports `''` or undefined.

## Behavior after the change

- An unassigned property still serializes nothing, so the component's own default continues to apply — unchanged.
- Assigning the old C# default still transmits: `ShowDelay = 0` marks the property dirty because `200 != 0`.
- Assigning the new default also transmits, via the `!IsPropDirty` arm of the setter.
- The getter now reports what the component actually uses.

## Verification

`dotnet build` clean; unit suite **902 passed, 0 failed**; integration suite **71 passed, 0 failed**. The pre-existing assertions on these properties all follow an explicit assignment, so none depended on the old initial values.

Both checks were confirmed to actually fail on a regression: reverting `Tooltip.ShowDelay` to `0` fails the unit check, and the integration sweep reports it as *"Default value mismatch before setting. Prop name: ShowDelay. The wrapper reports:0, but the client component starts with: 200"*.
