### PR TITLE
Cover two-way binding (`@bind-`) in the interop contracts

### DIFF
--- a/skills/igniteui-blazor-lite-testing/SKILL.md
+++ b/skills/igniteui-blazor-lite-testing/SKILL.md
@@ -21,7 +21,7 @@ Three test projects under `tests/`, two suites:
 | Property → rendered attribute (direct-render components) | unit: plain bUnit facts (`cut.Find(...).GetAttribute(...)`) |
 | Markup/child content rendering | unit: plain bUnit facts |
 | Message-borne state serialization shapes | unit: `PropertySerializationTests` / `EnumSerializationTests` / `RenderingSerializationTests` |
-| **Interop wire behavior** — method identifiers, argument serialization + type tags, return decoding, event-handler registration/removal transmissions + JS→.NET event dispatch, interop-borne props/data | unit: the component's `ComponentContract` — full authoring guide: [`references/interop-contracts.md`](./references/interop-contracts.md) |
+| **Interop wire behavior** — method identifiers, argument serialization + type tags, return decoding, event-handler registration/removal transmissions + JS→.NET event dispatch, `@bind-` two-way round trips, interop-borne props/data | unit: the component's `ComponentContract` — full authoring guide: [`references/interop-contracts.md`](./references/interop-contracts.md) |
 | `<Member>Script` parameters (JS-side handlers/providers) | unit: automated sweep (`ScriptPropTests`, all components at once — no per-contract entries, no integration coverage exists) |
 | End-to-end prop/event/method behavior against the **real web component in a real browser** | integration: the TestBed sweep |
 | Visual output, client-side component logic | integration / e2e — never unit |

--- a/skills/igniteui-blazor-lite-testing/references/interop-contracts.md
+++ b/skills/igniteui-blazor-lite-testing/references/interop-contracts.md
@@ -2,7 +2,7 @@
 
 Goal: every component with an interop surface carries a declarative `ComponentContract<TComponent>` in its test suite, pinning how its public API maps onto the wire — method identifiers, argument serialization and type tags, return decoding, and event names + args deserialization. Contracts run through the `InteropHarness` seam (`tests/IgniteUI.Blazor.Tests/Interop/`), so the contract verifies a component regardless of the interop stack (swap per component via `InteropHarnessRegistry`).
 
-Scope note: contracts cover **methods, current-state getters, events, and props that travel over interop**. Simple property → attribute rendering (direct-render components) is already covered by the existing attribute tests and the integration suite — never duplicate it with `.Prop`.
+Scope note: contracts cover **methods, current-state getters, events, two-way binding pairs, and props that travel over interop**. Simple property → attribute rendering (direct-render components) is already covered by the existing attribute tests and the integration suite — never duplicate it with `.Prop`.
 
 Exemplars to imitate: `ButtonTests.cs` (simplest), `CarouselTests.cs` (void/bool methods, args, getters, number event), `ChipTests.cs` (bool-detail events, getter), `ChatTests.cs` (renderer-container component: `.Prop` config object, complex event args), `ComboTests.cs` (data sources, uuid refs), `TreeTests.cs` (child refs, hosted getter).
 
@@ -31,7 +31,8 @@ Read the component's source (all `partial` parts) and find every place it:
 
 1. **sends an outbound interop invocation** from a public API member → a `.Method` or `.Getter` spec;
 2. **registers a handler for a JS-originated event** (paired with an `EventCallback<TArgs>` parameter) → an `.Event` spec;
-3. **transmits state over interop** rather than rendering it as an attribute → a `.Prop` spec.
+3. **transmits state over interop** rather than rendering it as an attribute → a `.Prop` spec;
+4. **pairs a `[Parameter] X` with an `EventCallback<TValue> XChanged`** (what `@bind-X` needs) → a `.Bind` spec.
 
 The *concrete idioms* for all three depend on which interop stack the component currently sits on — the [cheat-sheet below](#current-stack-cheat-sheet-legacy-renderermessage-pipeline) lists them for the legacy `RendererMessage` pipeline. For a component on a different stack, find the equivalent call sites in its implementation (whatever sits between the public member and the JS runtime — a direct `IJSRuntime.InvokeAsync`, a channel service, etc.); the principles and the DSL below are unchanged.
 
@@ -92,6 +93,25 @@ The contract entry is the member selector plus a sample value: the wire name is 
 - **Data sources** (`Data`/`DataSource` props): covered by `.Prop(c => c.Data, ...)` too — the harness follows whatever indirection the stack uses to the actual transfer. Item property names cross with their .NET names (not camelized). See `ComboTests.cs`.
 - **Props referencing data items** (e.g. Combo's `Value`): add `arrange:` for the `Data` the value points into and state the wire value late, since tracked items cross as refs whose ids are only assigned on transfer: `.Prop(c => c.Value, [_item1], wire: FromRender.Of<object?>((interop, cut) => new RawJson(...)), arrange: ps => ps.Add(c => c.Data, items))`.
 
+### 4. Two-way binding pairs
+
+A `[Parameter] TValue X` plus `EventCallback<TValue> XChanged` is what `@bind-X` needs. `XChanged` is a filtered proxy of a **driving event** (`Change`, or `Select` on Chip): assigning it force-binds a no-op onto that event so it registers, and the callback then fires from inside that event's handler with the value projected out of its detail. A client change only ever arrives as a dispatch of the driving event.
+
+`.Bind` covers what `.Event` can't: it renders the pair with real two-way binding and asserts the **property adopted the value** — what `@bind-X` consumers depend on. (`.Event(c => c.XChanged, …, name: "Change")` does work for the callback half alone, since binding it registers the driving event; it just says nothing about the property.)
+
+```csharp
+.Bind(c => c.Selected, c => c.SelectedChanged, via: c => c.Select,
+      argsJson: """{"detail": true}""", expect: true)
+```
+
+One dispatch pins: the driving event's registration crossed, the callback member kept the callback, the binding received the decoded value, and the property adopted it. Payload is the same shape and can be reused from the driving event's own `.Event` spec.
+
+- `expect:` is the value the dispatch must produce, often a projection of the detail — a checkbox detail is an object, the bound value is its `checked` field. The runner checks the property doesn't already hold it, so a spec can't pass without the change happening. For a type with no value equality add `assert:` and check field-wise.
+- `arrange:` when the dispatch needs more — Calendar's `Selection` for the `Values` branch, Combo's `Data`. Order the named arguments arrange → argsJson → expect, so a spec reads arrange/act/assert.
+- `initial:` only for a pair that must start somewhere other than the type default; no current spec needs it.
+- A pair with no event of its own (`IgbTab.Selected`, written by `IgbTabs`' `Change` handler) is not a `.Bind` spec: cover it in the parent's `.Event` spec, whose arrange binds each child's `XChanged` to a holder the assert then checks.
+- Nothing checks the value going back out: the client already holds it, and the property's own `.Prop` spec (or its rendered-attribute fact) pins how it serializes. `.Bind` is the inbound direction only.
+
 ## Current-stack cheat-sheet (legacy `RendererMessage` pipeline)
 
 > Everything in this section is specific to components still on the legacy
@@ -144,7 +164,8 @@ public class <Name>Tests : ComponentWithContractTestBase<Igb<Name>>
         .Method(c => c.ShowAsync(), c => c.Show(), "show", returns: true)
         .Getter(c => c.GetCurrentValueAsync(), c => c.GetCurrentValue(), "Value", returns: ...)
         .Event(c => c.SomeEvent, ...)
-        .Prop(c => c.SomeProp, ...);
+        .Prop(c => c.SomeProp, ...)
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change, argsJson: ..., initial: ..., expect: ...);
 
     // One runner fact per non-empty contract section (omit facts for empty sections
     [Fact]
@@ -155,6 +176,9 @@ public class <Name>Tests : ComponentWithContractTestBase<Igb<Name>>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     // ... other/existing facts ...
 }
@@ -174,11 +198,13 @@ Common failures:
 - Types/args mismatch → the assertion message shows the recorded wire values; judge which side is off per the authoring modes (in spec mode an unintended wire value is the implementation's bug — the red spec is doing its job).
 - A method call that never returns (test timeout) means its identifier reached JS without a stub match — check the name matches the stub you declared (getters: bare property name).
 - `no property update transmission was observed` → wrong wire name, an attribute-rendered prop, or a serialization exception upstream (nothing transmits at all).
+- `transmitted no "<Event>" event registration` (bind specs) → the pair's `EnsureXHandled()` isn't running, or `via:` names the wrong event; without it the client never reports changes.
+- `the <X>Changed binding was never invoked` → dispatch failures are swallowed by the control, so this one message covers three causes: wrong `via:`, a payload the args type doesn't decode, or a value that doesn't coerce to the bound type.
 
 Finish with a full-suite sanity run: same command without `--filter`.
 
 ## Definition of done (per component)
 
 - Contract on exactly one suite, all facts green, plus full suite green on all TFMs.
-- Every public method that goes out through interop — async **and** its sync twin (declared together via the twin overloads) — every registered JS-originated event, and every interop-borne prop is either covered, globally excluded, or named in the skip comment with a mechanism reason — nothing silently omitted. (`<Member>Script` params are covered by the `ScriptPropTests` sweep.)
+- Every public method that goes out through interop — async **and** its sync twin (declared together via the twin overloads) — every registered JS-originated event, every interop-borne prop, and every `@bind-` pair is either covered, globally excluded, or named in the skip comment with a mechanism reason — nothing silently omitted. (`<Member>Script` params are covered by the `ScriptPropTests` sweep.)
 - Implementation issues found along the way are handled per the authoring modes (`// TODO:` markers or fixes), never silently skipped.

--- a/skills/igniteui-blazor-lite-testing/references/interop-contracts.md
+++ b/skills/igniteui-blazor-lite-testing/references/interop-contracts.md
@@ -49,6 +49,16 @@ wire:    FromRender.Of<object?>((interop, cut) => new RawJson(...))  // a prop w
 
 The render scope handed to the lambda is the cut for an arranged spec and the whole host render for a hosted one — the same scope the spec's own `assert:` receives. Pair it with `arrange:` (or `host:`/`target:`) so there is something rendered to reference.
 
+### Dates
+
+Decoding converts to local time (`ReturnToDate`, default `RoundTripDateConversion.Auto`), so a decoded date is `Kind=Local` with a shifted reading. Rules:
+
+- State every date **expectation** as the UTC instant with an explicit `DateTimeKind.Utc` — `returns:`, `expect:`, args. The runner compares against its local rendering and asserts the kind; an `Unspecified` expectation throws.
+- Never write `.ToLocalTime()` in a spec to make a comparison pass. If one seems needed, the assertion helper is missing a case — add it there. The one exception is an author-written `assert:` lambda, where you do the comparing: use `…Utc).ToLocalTime()` (see `DateRangePickerTests`' bind assert).
+- Outbound dates (`.Prop` values, method args) are not decoded and keep the kind the spec wrote, so their wire expectation is a plain literal — `DateTimeKind.Utc` serializes with `Z`.
+
+Exemplars: `CalendarTests` (scalar + array), `DateRangePickerTests` (nested in an object), `DatePickerTests`/`DateTimeInputTests` (nullable, with a `// TODO:` for the cleared case crossing as `MinValue`).
+
 ### 1. Methods and getters
 
 - Every public API member that produces an outbound invocation gets a spec. Distinguish two kinds:
@@ -59,7 +69,7 @@ The render scope handed to the lambda is the cut for an arranged spec and the wh
   | Return kind | Contract form |
   |---|---|
   | none | omit — void overload |
-  | scalar (bool/number/string/date) | just the value: `returns: true` / `5.0` / a UTC `DateTime` — the wire return kind is derived from the value's type, and the decoded .NET return must round-trip back to it (dates compared as instants) |
+  | scalar (bool/number/string/date) | just the value: `returns: true` / `5.0` / a UTC `DateTime` — the wire return kind is derived from the value's type, and the decoded .NET return must round-trip back to it (dates: see the rule above — stated as the UTC instant, asserted as its local rendering) |
   | single serialized object | arranged `Getter` overload with `InteropReturn.Object(...)` + value-level `assert:` — see `ChatTests.cs` `DraftMessage` |
   | array of component/data-item references | arranged `Getter` overload with `InteropReturn.Array` of refs, `Assert.Same` against arranged instances — see `TileManagerTests.cs` `Tiles`, `ComboTests.cs` `Value` |
   | single bound-object reference | arranged `Getter` overload with `InteropReturn.Ref(...)`, `Assert.Same` against the arranged child — see `SelectTests.cs`/`DropdownTests.cs` `SelectedItem` |
@@ -134,7 +144,7 @@ One dispatch pins: the driving event's registration crossed, the callback member
 | `ObjectToParam(x, typeof(SomeEnum))`, tag `"Json"` | `SomeEnum.Member` | the `[WCEnumName("...")]` value if the member has one, else camelCase of the member name (`Next` → `"next"`) |
 | `ObjectToParam(x)` with a plain string, tag `"Json"` | `"item-1"`     | `"item-1"`                           |
 | `ObjectToParam(x)` with a marshal-by-value object, tag `"Json"` | an options object | `new JsonSubset("""{"key": value, ...}""")` |
-| `x` DateTime, tag `"Date"`                 | a `DateTime`             | the same `DateTime` (compared as instant) |
+| `x` DateTime, tag `"Date"`                 | a `DateTime`             | the same `DateTime` — outbound, so it keeps the kind the spec wrote |
 | array helpers (`IntArrayToString`, ...), tag `"NumberArray"` etc. | array | `new RawJson("[1,2,3]")`            |
 | `ComponentToJson(x, i)`, tag `"Component"`  | an `Igb*` component      | `"containerId:::<that component's own container id>"` (a `FromRender` value) — no element handle |
 | `ComponentToJson(x, i)`, tag `"Component"`  | an `ElementReference`    | `"elementIndex:::<i>"`, plus the handle itself declared via `elements:` (it rides beside the arguments, not in them) |

--- a/src/componentsBase/WebInputs/Tab.cs
+++ b/src/componentsBase/WebInputs/Tab.cs
@@ -19,7 +19,7 @@ namespace IgniteUI.Blazor.Controls
             }
             set
             {
-                if (!value.Equals(EventCallback<string>.Empty))
+                if (!value.Equals(EventCallback<bool>.Empty))
                 {
                     if (!CompareEventCallbacks(value, _selectedChanged, ref eventCallbacksCache))
                     {

--- a/src/componentsBase/WebInputs/Tabs.cs
+++ b/src/componentsBase/WebInputs/Tabs.cs
@@ -31,7 +31,7 @@ namespace IgniteUI.Blazor.Controls
 
                 }
 
-                if (!EventCallback<string>.Empty.Equals(item.SelectedChanged))
+                if (!EventCallback<bool>.Empty.Equals(item.SelectedChanged))
                 {
                     var task = item.SelectedChanged.InvokeAsync(item.Selected);
                     if (task.Exception != null)

--- a/tests/IgniteUI.Blazor.Tests/CalendarTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CalendarTests.cs
@@ -21,6 +21,18 @@ public class CalendarTests : ComponentWithContractTestBase<IgbCalendar>
         .Event(c => c.Change,
             argsJson: """{"detail": {"retType": "date", "value": "2026-01-02T03:04:05.000Z"}}""",
             assert: args => Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), ((DateTime)args.Detail).ToUniversalTime()))
+        // Single selection:
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": {"retType": "date", "value": "2026-01-02T03:04:05.000Z"}}""",
+            expect: new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc))
+        // Multiple selection:
+        .Bind(c => c.Values, c => c.ValuesChanged, via: c => c.Change,
+            arrange: ps => ps.Add(c => c.Selection, CalendarSelection.Multiple),
+            argsJson: """{"detail": {"retType": "Array", "type": "", "value": [{"retType": "date", "value": "2026-01-02T03:04:05.000Z"}, {"retType": "date", "value": "2026-01-03T03:04:05.000Z"}]}}""",
+            expect: [
+                new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                new DateTime(2026, 1, 3, 3, 4, 5, DateTimeKind.Utc),
+            ])
         .Prop(c => c.Selection, CalendarSelection.Range, wire: "range")
         .Prop(c => c.ShowWeekNumbers, true)
         .Prop(c => c.WeekStart, WeekDays.Monday, wire: "monday")
@@ -69,6 +81,9 @@ public class CalendarTests : ComponentWithContractTestBase<IgbCalendar>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Calendar_TypeMetadata()

--- a/tests/IgniteUI.Blazor.Tests/CheckboxTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/CheckboxTests.cs
@@ -23,6 +23,9 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
                 Assert.True(args.Detail.Checked);
                 Assert.Equal("checkbox-value", args.Detail.Value);
             })
+        .Bind(c => c.Checked, c => c.CheckedChanged, via: c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"checked": true, "value": "checkbox-value"}}}""",
+            expect: true)
         .Event(c => c.Focus)
         .Event(c => c.Blur);
 
@@ -31,6 +34,9 @@ public class CheckboxTests : ComponentWithContractTestBase<IgbCheckbox>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Checkbox_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/ChipTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ChipTests.cs
@@ -13,13 +13,18 @@ public class ChipTests : ComponentWithContractTestBase<IgbChip>
             assert: args => Assert.True(args.Detail))
         .Event(c => c.Remove,
             argsJson: """{"detail": true}""",
-            assert: args => Assert.True(args.Detail));
+            assert: args => Assert.True(args.Detail))
+        .Bind(c => c.Selected, c => c.SelectedChanged, via: c => c.Select,
+            argsJson: """{"detail": true}""", expect: true);
 
     [Fact]
     public Task Methods_FollowContract() => VerifyMethodContract();
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Chip_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/ComboTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComboTests.cs
@@ -55,6 +55,11 @@ public class ComboTests : ComponentWithContractTestBase<IgbCombo<ComboItem>>
             returns: FromRender.Of((interop, cut) => InteropReturn.Array(
                 $$"""[{"refType": "uuid", "id": "{{DataItemId(interop, cut, 1)}}"}]""")),
             assert: (cut, result) => Assert.Same(_valueItem2, Assert.Single(result)))
+        // The payload carries uuid refs, which only exist once the data has transferred.
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            arrange: ps => ps.Add(c => c.Data, new[] { _valueItem1, _valueItem2 }),
+            argsJson: FromRender.Of((interop, cut) => ChangeDetail(UuidRef(interop, cut, 0), UuidRef(interop, cut, 0))),
+            expect: [_valueItem1])
         .Event(c => c.Change,
             arrange: ps => ps.Add(c => c.Data, new[] { _valueItem1, _valueItem2 }),
             argsJson: FromRender.Of((interop, cut) => ChangeDetail(UuidRef(interop, cut, 0), UuidRef(interop, cut, 0))),
@@ -147,6 +152,9 @@ public class ComboTests : ComponentWithContractTestBase<IgbCombo<ComboItem>>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Combo_TypeMetadata()

--- a/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
@@ -52,6 +52,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
     /// <code>Methods_FollowContract() => <see cref="VerifyMethodContract"/></code>
     /// <code>Props_FollowContract() => <see cref="VerifyPropContract"/></code>
     /// <code>Events_FollowContract() => <see cref="VerifyEventContract"/></code>
+    /// <code>Binds_FollowContract() => <see cref="VerifyBindContract"/></code>
     /// Each method, property, and event in the contract is exercised in isolation, with a fresh component instance (or a shared instance for methods that don't require an arrangement).
     /// The harness is primed to a ready state before each test, and any stubbed return values are set up before invoking the method or reading the property.
     /// The test asserts that the expected interop calls are made with the correct arguments and types, and that the return values are as expected.
@@ -73,6 +74,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
         RequireSectionFact(contract.Methods.Count > 0, "Methods_FollowContract", nameof(VerifyMethodContract));
         RequireSectionFact(contract.Props.Count > 0, "Props_FollowContract", nameof(VerifyPropContract));
         RequireSectionFact(contract.Events.Count > 0, "Events_FollowContract", nameof(VerifyEventContract));
+        RequireSectionFact(contract.Binds.Count > 0, "Binds_FollowContract", nameof(VerifyBindContract));
     }
 
     private void RequireSectionFact(bool hasSpecs, string factName, string runnerName)
@@ -304,6 +306,127 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
     }
 
     /// <summary>
+    /// Runner for the contract's <c>.Bind</c> specs — expose it on the suite as
+    /// <c>[Fact] public void Binds_FollowContract() => VerifyBindContract();</c>.
+    /// Renders a fresh instance per spec bound exactly as <c>@bind-X</c> would, then dispatches
+    /// the paired event and verifies the round trip <b>inbound</b> side: binding alone transmitted that
+    /// paired event's registration (the client's cue to report changes) and the member kept the callback;
+    /// the dispatch pushed the decoded value to the binding; and the component's own property adopted it.
+    /// </summary>
+    /// <exception cref="ContractViolationException">
+    /// Any spec failure, naming the violated pair and carrying the declaring contract
+    /// line as the top stack frame.
+    /// </exception>
+    protected void VerifyBindContract()
+    {
+        var harness = InteropFor<TComponent>();
+        // Dispatch needs no readiness, but arranged data (items referenced by uuid) only
+        // transfers once ready — same reasoning as the event runner.
+        harness.PrimeReady();
+
+        foreach (var bind in InteropContract.Binds)
+        {
+            try
+            {
+                object? received = null;
+                var delivered = false;
+                void Sink(object? value)
+                {
+                    // Record only: OnRaiseEvent swallows exceptions, so anything thrown in here
+                    // would vanish and read as "never invoked".
+                    received = value;
+                    delivered = true;
+                }
+
+                var cut = Render<TComponent>(ps =>
+                {
+                    bind.Arrange?.Invoke(ps);
+                    bind.BindPair(ps, Sink);
+                });
+
+                // A setter whose emptiness guard is wrong can drop the callback, leaving the
+                // binding silently dead however well the rest of the wiring behaves.
+                Assert.True(
+                    bind.ChangedIsBound(cut.Instance),
+                    $"{bind.PropertyName}Changed did not keep the bound callback — check its setter's empty-callback guard");
+
+                // Read where the property actually starts: if that is already the expected value,
+                // everything below would pass without the dispatch changing anything.
+                if (Equals(bind.ReadProperty(cut.Instance), bind.Expected))
+                {
+                    throw new XunitException(
+                        $"{bind.PropertyName} already holds the expected value before the dispatch — expect a " +
+                        "different one, or state an initial: the change moves away from");
+                }
+
+                // Binding only the callback must still subscribe the client, by forcing the
+                // paired event's registration onto the wire.
+                var containerId = harness.ContainerIdOf(cut);
+                var registration = harness.FindPropertyUpdate(containerId, WireMemberName(bind.DrivingEvent))
+                    ?? throw new XunitException(
+                        $"binding transmitted no \"{bind.DrivingEvent}\" event registration — without it the " +
+                        "client never reports changes, so the binding can never fire");
+                Assert.Equal(bind.DrivingEvent, registration.GetString());
+
+                harness.RaiseEvent(containerId, bind.DrivingEvent, bind.ArgsJson.Get(harness, cut));
+
+                if (!delivered)
+                {
+                    throw new XunitException(
+                        $"the {bind.PropertyName}Changed binding was never invoked — dispatch failures are " +
+                        "swallowed by the control, so check the driving event, the args JSON shape, and that " +
+                        "the payload decodes to the bound type");
+                }
+                // What the binding was handed is the decode's result.
+                if (bind.AssertValue is null)
+                {
+                    AssertReturn(bind.Expected, received);
+                }
+                else
+                {
+                    bind.AssertValue(received);
+                }
+
+                // And the property is written from that same decoded value, so the two must agree.
+                var adopted = bind.ReadProperty(cut.Instance);
+                try
+                {
+                    Assert.Equal(received, adopted);
+                }
+                catch (XunitException mismatch)
+                {
+                    throw new XunitException(
+                        $"{bind.PropertyName} did not adopt the value pushed to the binding — {mismatch.Message}");
+                }
+
+                // TODO: unbinding is blocked by the same defect as an event callback's, so one fix
+                // covers both — clearing the parameter arrives as a callback with a Receiver and a
+                // null Delegate, which fails the setter's Empty check, takes the *bound* branch, and
+                // NREs in BaseRendererControl.CompareEventCallbacks on leftDelegate.Equals(...).
+                // What to assert differs from an event's, though: a bind member's empty branch only
+                // nulls its field (no SetHandler(null), no OnRefChanged), so the driving event stays
+                // registered and the property keeps adopting client changes — only the callback
+                // stops. Needs BindPair to accept a null sink, as EventContractSpec.Bind already
+                // does. Then:
+                // received = null;
+                // cut.Render(ps => bind.BindPair(ps, null));
+                // Assert.False(bind.ChangedIsBound(cut.Instance));   // member resets to Empty
+                // harness.RaiseEvent(containerId, bind.DrivingEvent, bind.ArgsJson.Get(harness, cut));
+                // Assert.Null(received);                             // the callback stops firing
+                // Assert.NotNull(bind.ReadProperty(cut.Instance));   // but the property still tracks
+            }
+            catch (Exception ex) when (ex is not ContractViolationException)
+            {
+                throw Violation($"binding \"{bind.PropertyName}\"", bind.Source, ex);
+            }
+        }
+    }
+
+    /// <summary>The wire spelling of a member name — camelCase, as the serializer and <c>OnPropertyPropagatedOut</c> emit it.</summary>
+    private static string WireMemberName(string memberName) =>
+        char.ToLowerInvariant(memberName[0]) + memberName[1..];
+
+    /// <summary>
     /// Runner for the contract's <c>.Event</c> specs — expose it on the suite as
     /// <c>[Fact] public void Events_FollowContract() => VerifyEventContract();</c>.
     /// Renders a fresh instance per spec with the callback bound (plus any arrangement),
@@ -344,7 +467,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
                 // identity; dispatch alone can't catch a registration that never
                 // reached the wire.
                 Assert.Equal(bound, evt.Get(cut.Instance));
-                var wireName = char.ToLowerInvariant(evt.EventName[0]) + evt.EventName[1..];
+                var wireName = WireMemberName(evt.EventName);
                 var registration = harness.FindPropertyUpdate(containerId, wireName)
                     ?? throw new XunitException("no event-handler registration transmission was observed");
                 Assert.Equal(evt.EventName, registration.GetString());
@@ -372,7 +495,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
                 // a raw Empty (what bUnit/programmatic SetParameters passes) does reach the
                 // unset branch and NREs in OnRefChanged on newValue.ToString(). Once fixed,
                 // validate the removal round-trip; pin the actual cleared wire shape then:
-                // cut.SetParametersAndRender(ps => bound = evt.Bind(ps, null));
+                // cut.Render(ps => bound = evt.Bind(ps, null));   // bUnit 2.x: no SetParametersAndRender
                 // Assert.Equal(bound, evt.Get(cut.Instance)); // member resets to the empty callback
                 // var cleared = harness.FindPropertyUpdate(containerId, wireName);
                 // Assert.Equal(JsonValueKind.Null, cleared!.Value.ValueKind);

--- a/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
@@ -601,12 +601,45 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
     /// <summary>Compares a decoded .NET return against the spec's expected value.</summary>
     private static void AssertReturn(object? expected, object? actual)
     {
-        // Date returns are decoded to local time; compare instants instead of kinds.
-        if (expected is DateTime expectedDate && actual is DateTime actualDate)
+        switch (expected)
         {
-            Assert.Equal(expectedDate.ToUniversalTime(), actualDate.ToUniversalTime());
-            return;
+            case DateTime expectedInstant:
+                AssertDecodedDate(expectedInstant, actual);
+                break;
+            case IEnumerable<DateTime> expectedInstants:
+                // Dates in a collection follow the same rule; xUnit's own equality would compare
+                // them by reading alone, which is neither the instant nor the conversion.
+                var expectedList = expectedInstants.ToList();
+                var actualList = Assert.IsAssignableFrom<IEnumerable<DateTime>>(actual).ToList();
+                Assert.Equal(expectedList.Count, actualList.Count);
+                for (var i = 0; i < expectedList.Count; i++)
+                {
+                    AssertDecodedDate(expectedList[i], actualList[i]);
+                }
+                break;
+            default:
+                Assert.Equal(expected, actual);
+                break;
         }
-        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// One decoded date: stated by the spec as the UTC instant that crossed the wire, and required
+    /// to arrive as the local rendering of it — reading *and* <see cref="DateTimeKind"/>. Asserting
+    /// the kind is what pins the conversion in every timezone, including the one where local and
+    /// UTC coincide and a plain instant comparison could not tell the two apart.
+    /// </summary>
+    private static void AssertDecodedDate(DateTime expectedInstant, object? actual)
+    {
+        if (expectedInstant.Kind == DateTimeKind.Unspecified)
+        {
+            throw new XunitException(
+                $"expected date {expectedInstant:o} has Kind=Unspecified — state the instant explicitly " +
+                "(DateTimeKind.Utc), since ToLocalTime and ToUniversalTime read an unspecified kind in " +
+                "opposite directions and would shift it silently");
+        }
+        var actualDate = Assert.IsType<DateTime>(actual);
+        Assert.Equal(expectedInstant.ToLocalTime(), actualDate);
+        Assert.Equal(DateTimeKind.Local, actualDate.Kind);
     }
 }

--- a/tests/IgniteUI.Blazor.Tests/DatePickerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DatePickerTests.cs
@@ -28,6 +28,9 @@ public class DatePickerTests : ComponentWithContractTestBase<IgbDatePicker>
         .Event(c => c.Change,
             argsJson: """{"detail": "2026-01-02T03:04:05.000Z"}""",
             assert: args => Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), args.Detail.ToUniversalTime()))
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": "2026-01-02T03:04:05.000Z"}""",
+            expect: new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc))
         .Event(c => c.Input,
             argsJson: """{"detail": "2026-01-02T03:04:05.000Z"}""",
             assert: args => Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), args.Detail.ToUniversalTime()))
@@ -90,6 +93,9 @@ public class DatePickerTests : ComponentWithContractTestBase<IgbDatePicker>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void DatePicker_TypeMetadata()

--- a/tests/IgniteUI.Blazor.Tests/DateRangePickerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DateRangePickerTests.cs
@@ -49,6 +49,20 @@ public class DateRangePickerTests : ComponentWithContractTestBase<IgbDateRangePi
                 Assert.Equal(new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc), args.Detail.Start.ToUniversalTime());
                 Assert.Equal(new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc), args.Detail.End.ToUniversalTime());
             })
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"start": "2026-03-01T00:00:00.000Z", "end": "2026-03-10T00:00:00.000Z"}}}""",
+            expect: new IgbDateRangeValue
+            {
+                Start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+                End = new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc),
+            },
+            assert: value =>
+            {
+                // IgbDateRangeValue has no value equality, so the pushed value is checked field-wise:
+                Assert.NotNull(value);
+                Assert.Equal(new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime(), value.Start);
+                Assert.Equal(new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc).ToLocalTime(), value.End);
+            })
         .Event(c => c.Input,
             argsJson: """{"detail": {"retType": "object", "type": "", "value": {"start": "2026-03-01T00:00:00.000Z", "end": "2026-03-10T00:00:00.000Z"}}}""",
             assert: args =>
@@ -129,6 +143,9 @@ public class DateRangePickerTests : ComponentWithContractTestBase<IgbDateRangePi
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     /// <summary>
     /// The wrapper must report the same initial values as <c>IgbDateRangePicker</c>'s web component,

--- a/tests/IgniteUI.Blazor.Tests/DateTimeInputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DateTimeInputTests.cs
@@ -28,6 +28,9 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
         .Event(c => c.Change,
             argsJson: """{"detail": "2026-01-02T03:04:05.000Z"}""",
             assert: args => Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), args.Detail.ToUniversalTime()))
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": "2026-01-02T03:04:05.000Z"}""",
+            expect: new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc))
         .Event(c => c.InputOcurred,
             argsJson: """{"detail": "typed text"}""", assert: args => Assert.Equal("typed text", args.Detail))
         .Event(c => c.Focus)
@@ -59,6 +62,9 @@ public class DateTimeInputTests : ComponentWithContractTestBase<IgbDateTimeInput
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void DateTimeInput_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/InputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InputTests.cs
@@ -21,6 +21,8 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
         .Event(c => c.Change,
             argsJson: """{"detail": "new value"}""",
             assert: args => Assert.Equal("new value", args.Detail))
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": "new value"}""", expect: "new value")
         .Event(c => c.InputOcurred,
             argsJson: """{"detail": "typed text"}""",
             assert: args => Assert.Equal("typed text", args.Detail))
@@ -32,6 +34,9 @@ public class InputTests : ComponentWithContractTestBase<IgbInput>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Input_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/Interop/ComponentContract.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/ComponentContract.cs
@@ -183,6 +183,53 @@ public sealed class EventContractSpec<TComponent> where TComponent : IComponent
 }
 
 /// <summary>
+/// A two-way binding pair — the <c>@bind-X</c> contract: a <c>[Parameter] X</c> plus its
+/// <c>EventCallback&lt;TValue&gt; XChanged</c>, driven by dispatching <see cref="DrivingEvent"/>.
+/// Assigning <c>XChanged</c> internally registers the paired event and its handler provides updates.
+/// </summary>
+public sealed class BindContractSpec<TComponent> where TComponent : IComponent
+{
+    /// <summary>The bound property's name, for failure messages and its wire spelling.</summary>
+    public required string PropertyName { get; init; }
+
+    /// <summary>The paired event whose client-side dispatch drives the change.</summary>
+    public required string DrivingEvent { get; init; }
+
+    /// <summary>
+    /// Arranges the render exactly as <c>@bind-X</c> would (bUnit's <c>ps.Bind</c>), routing the
+    /// pushed value to the sink so the spec asserts the user-facing contract rather than the
+    /// callback member. Returns nothing — the sink is the observation.
+    /// </summary>
+    public required Action<ComponentParameterCollectionBuilder<TComponent>, Action<object?>> BindPair { get; init; }
+
+    /// <summary>Reads the bound property back off the component, to assert it was updated.</summary>
+    public required Func<TComponent, object?> ReadProperty { get; init; }
+
+    /// <summary>
+    /// Whether the callback member kept what its setter was handed. A setter whose
+    /// "is this empty?" guard is wrong can drop or null it, leaving the binding silently dead.
+    /// </summary>
+    public required Func<TComponent, bool> ChangedIsBound { get; init; }
+
+    /// <summary>The payload dispatched for <see cref="DrivingEvent"/>, settled against the render when declared late.</summary>
+    public FromRender<string> ArgsJson { get; init; } = "{}";
+
+    /// <summary>The value the binding must receive — often a projection of the event's detail, so always stated.</summary>
+    public object? Expected { get; init; }
+
+    /// <summary>
+    /// Value-level check applied to the pushed value, for payloads whose type has no value equality;
+    /// replaces the comparison against <see cref="Expected"/>, which then only documents intent and guards vacuity.
+    /// </summary>
+    public Action<object?>? AssertValue { get; init; }
+
+    /// <summary>Extra render setup the pair needs to be reachable (child components, data, ...).</summary>
+    public Action<ComponentParameterCollectionBuilder<TComponent>>? Arrange { get; init; }
+
+    public SpecSource? Source { get; init; }
+}
+
+/// <summary>
 /// Pins a component's interop contract: how its public API maps onto the wire —
 /// method identifiers, argument serialization and type tags, return decoding, and
 /// event names + args deserialization. Runs through the <see cref="InteropHarness"/>
@@ -195,10 +242,12 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
     private readonly List<MethodContractSpec<TComponent>> _methods = [];
     private readonly List<EventContractSpec<TComponent>> _events = [];
     private readonly List<StatePropContractSpec<TComponent>> _props = [];
+    private readonly List<BindContractSpec<TComponent>> _binds = [];
 
     public IReadOnlyList<MethodContractSpec<TComponent>> Methods => _methods;
     public IReadOnlyList<EventContractSpec<TComponent>> Events => _events;
     public IReadOnlyList<StatePropContractSpec<TComponent>> Props => _props;
+    public IReadOnlyList<BindContractSpec<TComponent>> Binds => _binds;
 
     /// <summary>
     /// A void API method (async-only members): asserts identifier, arguments and type tags.
@@ -639,6 +688,69 @@ public sealed class ComponentContract<TComponent> where TComponent : IComponent
             Bind = (ps, on) => BindMember(ps, member, on),
             Get = GetterOf(member),
             ArgsType = typeof(IgbVoidEventArgs),
+            Source = new SpecSource(atFile, atLine),
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// A two-way binding pair — what <c>@bind-X</c> relies on. Identified by its two members,
+    /// which share one <typeparamref name="TValue"/> so a mismatched pair cannot compile.
+    /// <paramref name="via"/> is the paired event whose client-side dispatch drives the change.
+    /// </summary>
+    /// <param name="property">The bound property, e.g. <c>c => c.Selected</c>.</param>
+    /// <param name="changed">Its change callback, e.g. <c>c => c.SelectedChanged</c>.</param>
+    /// <param name="via">The paired event that carries the change, e.g. <c>c => c.Select</c>.</param>
+    /// <param name="argsJson">
+    /// The payload dispatched for <paramref name="via"/> — normally identical to the one the
+    /// event's own <c>.Event</c> spec already uses.
+    /// </param>
+    /// <param name="expect"> The value the binding must receive. </param>
+    /// <param name="arrange">Extra render setup the pair needs (child components, data).</param>
+    /// <param name="assert">
+    /// Value-level check for payload types with no value equality, replaces the comparison against
+    /// <paramref name="expect"/>, which then only documents intent.
+    /// </param>
+    /// <param name="initial">
+    /// The bound starting value. Defaults to the type's own default, which is what every pair
+    /// needs; state it only for a pair that must start somewhere else to be meaningful.
+    /// </param>
+    public ComponentContract<TComponent> Bind<TValue, TArgs>(
+        Expression<Func<TComponent, TValue>> property,
+        Expression<Func<TComponent, EventCallback<TValue>>> changed,
+        Expression<Func<TComponent, EventCallback<TArgs>>> via,
+        FromRender<string> argsJson,
+        TValue expect,
+        Action<ComponentParameterCollectionBuilder<TComponent>>? arrange = null,
+        Action<TValue>? assert = null,
+        TValue initial = default!,
+        [CallerFilePath] string atFile = "",
+        [CallerLineNumber] int atLine = 0)
+    {
+        var propertyName = MemberOf(property).Name;
+        var changedName = MemberOf(changed).Name;
+        // @bind-X resolves the callback by name, so a bindable pair must follow the convention:
+        if (changedName != propertyName + "Changed")
+        {
+            throw new ArgumentException(
+                $"\"{changedName}\" cannot be the change callback of \"{propertyName}\" — @bind-{propertyName} " +
+                $"resolves \"{propertyName}Changed\" by name.", nameof(changed));
+        }
+        var (readProp, readChanged) = (property.Compile(), changed.Compile());
+
+        _binds.Add(new BindContractSpec<TComponent>
+        {
+            PropertyName = MemberOf(property).Name,
+            DrivingEvent = MemberName(via),
+            // Exactly what @bind-X expands to, via bUnit's own two-way binding helper. The
+            // wrappers have no <Prop>Expression parameter, so the value expression is omitted.
+            BindPair = (ps, sink) => ps.Bind(property, initial, value => sink(value)),
+            ReadProperty = c => readProp(c),
+            ChangedIsBound = c => !EventCallback<TValue>.Empty.Equals(readChanged(c)),
+            ArgsJson = argsJson,
+            Expected = expect,
+            AssertValue = assert is null ? null : o => assert((TValue)o!),
+            Arrange = arrange,
             Source = new SpecSource(atFile, atLine),
         });
         return this;

--- a/tests/IgniteUI.Blazor.Tests/MaskInputTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/MaskInputTests.cs
@@ -26,6 +26,8 @@ public class MaskInputTests : ComponentWithContractTestBase<IgbMaskInput>
             "setCustomValidity", args: ["custom message"], types: ["String"])
         .Event(c => c.Change,
             argsJson: """{"detail": "new value"}""", assert: args => Assert.Equal("new value", args.Detail))
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": "new value"}""", expect: "new value")
         .Event(c => c.InputOcurred,
             argsJson: """{"detail": "typed text"}""", assert: args => Assert.Equal("typed text", args.Detail))
         .Event(c => c.Focus)
@@ -50,6 +52,9 @@ public class MaskInputTests : ComponentWithContractTestBase<IgbMaskInput>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact(Skip = "Indirect rendering, awaiting render simplification.")]
     public void MaskInput_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/RadioTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RadioTests.cs
@@ -23,6 +23,10 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
                 Assert.True(args.Detail.Checked);
                 Assert.Equal("option1", args.Detail.Value);
             })
+        // The bound value uses checked:
+        .Bind(c => c.Checked, c => c.CheckedChanged, via: c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"checked": true, "value": "option1"}}}""",
+            expect: true)
         .Event(c => c.Focus)
         .Event(c => c.Blur);
 
@@ -31,6 +35,9 @@ public class RadioTests : ComponentWithContractTestBase<IgbRadio>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Radio_RendersCorrectElement()
@@ -122,13 +129,20 @@ public class RadioGroupTests : ComponentWithContractTestBase<IgbRadioGroup>
             {
                 Assert.True(args.Detail.Checked);
                 Assert.Equal("selected-option", args.Detail.Value);
-            });
+            })
+        // The group binds the selected option's value:
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"checked": true, "value": "selected-option"}}}""",
+            expect: "selected-option");
 
     [Fact]
     public Task Methods_FollowContract() => VerifyMethodContract();
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void RadioGroup_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/RatingTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/RatingTests.cs
@@ -17,6 +17,8 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
         .Event(c => c.Change,
             argsJson: """{"detail": 4}""",
             assert: args => Assert.Equal(4, args.Detail))
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": 4}""", expect: 4.0)
         .Event(c => c.Hover,
             argsJson: """{"detail": 2}""",
             assert: args => Assert.Equal(2, args.Detail));
@@ -26,6 +28,9 @@ public class RatingTests : ComponentWithContractTestBase<IgbRating>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Rating_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/SelectTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SelectTests.cs
@@ -75,13 +75,21 @@ public class SelectTests : ComponentWithContractTestBase<IgbSelect>
             {
                 Assert.Same(cut.FindComponents<IgbSelectItem>()[1].Instance, args.Detail);
                 Assert.Equal("ca", args.Detail.Value); // Change propagates Detail.Value into Select.Value
-            });
+            })
+        // The detail is the selected item; the binding receives that item's Value.
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            arrange: arrangeItems,
+            argsJson: FromRender.Of((interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-select-item:nth-of-type(2)")}}}"}}"""),
+            expect: "ca");
 
     [Fact]
     public Task Methods_FollowContract() => VerifyMethodContract();
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Select_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/SliderTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SliderTests.cs
@@ -20,13 +20,18 @@ public class SliderTests : ComponentWithContractTestBase<IgbSlider>
             assert: args => Assert.Equal(3, args.Detail))
         .Event(c => c.Change,
             argsJson: """{"detail": 5}""",
-            assert: args => Assert.Equal(5, args.Detail));
+            assert: args => Assert.Equal(5, args.Detail))
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": 5}""", expect: 5.0);
 
     [Fact]
     public Task Methods_FollowContract() => VerifyMethodContract();
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Slider_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/SwitchTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SwitchTests.cs
@@ -23,6 +23,9 @@ public class SwitchTests : ComponentWithContractTestBase<IgbSwitch>
                 Assert.True(args.Detail.Checked);
                 Assert.Equal("switch-value", args.Detail.Value);
             })
+        .Bind(c => c.Checked, c => c.CheckedChanged, via: c => c.Change,
+            argsJson: """{"detail": {"retType": "object", "type": "", "value": {"checked": true, "value": "switch-value"}}}""",
+            expect: true)
         .Event(c => c.Focus)
         .Event(c => c.Blur);
 
@@ -31,6 +34,9 @@ public class SwitchTests : ComponentWithContractTestBase<IgbSwitch>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Switch_RendersCorrectElement()

--- a/tests/IgniteUI.Blazor.Tests/TabsTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TabsTests.cs
@@ -1,27 +1,46 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
 using IgniteUI.Blazor.Tests.Interop;
+using Microsoft.AspNetCore.Components;
 
 namespace IgniteUI.Blazor.Tests;
 
 public class TabsTests : ComponentWithContractTestBase<IgbTabs>
 {
-    protected override ComponentContract<IgbTabs> InteropContract { get; } = new ComponentContract<IgbTabs>()
-        .Event(c => c.Change,
-            arrange: ps => ps.AddChildContent(builder =>
+    /// <summary>What each arranged tab's <c>@bind-Selected</c> received, filled during the dispatch.</summary>
+    static readonly bool?[] tabSelection = new bool?[2];
+
+    /// <summary>Two tabs, each binding SelectedChanged — IgbTab has no selection event of its own.</summary>
+    static readonly Action<ComponentParameterCollectionBuilder<IgbTabs>> tabsArrange = ps =>
+        {
+            tabSelection[0] = null;
+            tabSelection[1] = null;
+            ps.AddChildContent(builder =>
             {
                 builder.OpenComponent<IgbTab>(0);
                 builder.AddAttribute(1, "id", "tab-1");
+                builder.AddAttribute(2, "SelectedChanged", new EventCallback<bool>(null, (Action<bool>)(v => tabSelection[0] = v)));
                 builder.CloseComponent();
-                builder.OpenComponent<IgbTab>(2);
-                builder.AddAttribute(3, "id", "tab-2");
+                builder.OpenComponent<IgbTab>(3);
+                builder.AddAttribute(4, "id", "tab-2");
+                builder.AddAttribute(5, "SelectedChanged", new EventCallback<bool>(null, (Action<bool>)(v => tabSelection[1] = v)));
                 builder.CloseComponent();
-            }),
+            });
+        };
+
+    protected override ComponentContract<IgbTabs> InteropContract { get; } = new ComponentContract<IgbTabs>()
+        .Event(c => c.Change,
+            tabsArrange,
             argsJson: FromRender.Of((interop, cut) => $$$"""{"detail": {"refType": "name", "id": "{{{interop.ContainerIdOf(cut, "igc-tab:nth-of-type(2)")}}}"}}"""),
             assert: (cut, args) =>
             {
                 Assert.Same(cut.Instance.ActualTabsCollection[1], args.Detail);
-                Assert.True(args.Detail.Selected); // OnHandlingChange propagates selection
+                // The handler owns selection for every child: it writes each tab's Selected and
+                // pushes it through that tab's @bind-Selected, which is IgbTab's only route.
+                Assert.True(args.Detail.Selected);
+                Assert.False(cut.Instance.ActualTabsCollection[0].Selected);
+                Assert.False(tabSelection[0]);
+                Assert.True(tabSelection[1]);
             })
         .Method(c => c.SelectAsync("tab-1"), c => c.Select("tab-1"), "select", args: ["tab-1"], types: ["String"])
         .Getter(c => c.GetSelectedAsync(), c => c.GetSelected(), "Selected", returns: "tab-1");
@@ -82,6 +101,8 @@ public class TabsTests : ComponentWithContractTestBase<IgbTabs>
     }
 }
 
+// IgbTab has no interop surface of its own: its @bind-Selected pair is driven entirely by
+// IgbTabs' Change handler, and is covered by that event's spec above.
 public class TabTests : BlazorComponentTestBase
 {
     [Fact]

--- a/tests/IgniteUI.Blazor.Tests/TextareaTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TextareaTests.cs
@@ -19,6 +19,8 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
         .Event(c => c.Change,
             argsJson: """{"detail": "new value"}""",
             assert: args => Assert.Equal("new value", args.Detail))
+        .Bind(c => c.Value, c => c.ValueChanged, via: c => c.Change,
+            argsJson: """{"detail": "new value"}""", expect: "new value")
         .Event(c => c.Focus)
         .Event(c => c.Blur);
 
@@ -27,6 +29,9 @@ public class TextareaTests : ComponentWithContractTestBase<IgbTextarea>
 
     [Fact]
     public void Events_FollowContract() => VerifyEventContract();
+
+    [Fact]
+    public void Binds_FollowContract() => VerifyBindContract();
 
     [Fact]
     public void Textarea_RendersCorrectElement()


### PR DESCRIPTION
## Description
Cover two-way binding (`@bind-`) in the interop contracts and fix Tab's two-way issue (plus a date comparison update to be resilient outside UTC env) split in separate commits. Tabs turned out to be uncoverable by the two-way setup unf.

## Motivation / Context
Reviewing the XML docs ([#286](https://github.com/IgniteUI/igniteui-blazor/pull/286#discussion_r3701894859))  turned up `IgbTab.SelectedChanged` comparing an `EventCallback<bool>` against `EventCallback<string>.Empty` — always false, so its unbind branch is dead. The bug survived because the two-way-binding surface had **no behavior coverage at all**: 17 `X`/`XChanged` pairs, zero contract specs, and one hand-written test for `IgbChip`. The integration sweep drops every bind member by reflection, so nothing covered them.

## What changed

- **New `.Bind` contract section.** One line per pair, arranged with bUnit's own `ps.Bind` (real `@bind-X`). Each spec pins four things: the driving event's registration crossed the wire, the callback member kept the callback it was handed, the dispatch pushed the decoded value to the binding, and the component's property adopted it. Inbound only — the client already holds the value, and how the property serializes outbound is what its `.Prop` spec (or rendered-attribute fact) already pins.
- **All 17 pairs covered** — 17 `.Bind` specs across 15 suites (the `IgbCheckboxBase` pair is pinned on both `CheckboxTests` and `SwitchTests`). Payloads reuse each driving event's existing `.Event` spec.
- `IgbTab.Selected` is the one exception: `IgbTab` has no events and registers nothing, so its pair is driven entirely by `IgbTabs.Change`. It's covered inside that event's spec, whose arrange binds both children's `SelectedChanged` and asserts each receives the right value.
- **Fixed the two mismatched guards**, `Tab.cs` and `Tabs.cs`, two lines. Every generated occurrence was already type-correct.
- **Dates now pin the inbound conversion.** Decoding converts to local time; a spec states the UTC instant and the runner compares against its local rendering *and* asserts `Kind` — which is what makes it hold in every timezone, including a UTC CI box. `Unspecified` expectations throw, and `AssertReturn` applies the same rule element-wise to date collections.

## Testing

**919 tests, 897 passing, 22 skipped on net8.0/net9.0/net10.0** (was 903 — +16 bind facts). No new build warnings.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [x] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:
Tabs, Components with two-way bindable props


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**:
 - **Hosting model**: <!-- Blazor Server / WebAssembly / Hybrid / United -->
 - **Browser(s)**:
 - **OS**:

## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
