### PR TITLE
refactor: dead code cleanup: generated partial hooks

### DIFF
--- a/src/components/Blazor/Accordion.cs
+++ b/src/components/Blazor/Accordion.cs
@@ -161,7 +161,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpening(IgbExpansionPanelComponentEventArgs args);
         private EventCallback<IgbExpansionPanelComponentEventArgs>? _opening = null;
 
         /// <summary>
@@ -181,11 +180,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opening, ref eventCallbacksCache))
                     {
                         _opening = value;
-                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opening", value, (args) =>
-                        {
-                            OnHandlingOpening(args);
-
-                        });
+                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opening", value);
                         this.OnRefChanged("Opening", null, "event:::Opening", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openingRef = refName;
@@ -238,7 +233,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpened(IgbExpansionPanelComponentEventArgs args);
         private EventCallback<IgbExpansionPanelComponentEventArgs>? _opened = null;
 
         /// <summary>
@@ -258,11 +252,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opened, ref eventCallbacksCache))
                     {
                         _opened = value;
-                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opened", value, (args) =>
-                        {
-                            OnHandlingOpened(args);
-
-                        });
+                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opened", value);
                         this.OnRefChanged("Opened", null, "event:::Opened", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openedRef = refName;
@@ -315,7 +305,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbExpansionPanelComponentEventArgs args);
         private EventCallback<IgbExpansionPanelComponentEventArgs>? _closing = null;
 
         /// <summary>
@@ -335,11 +324,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -392,7 +377,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbExpansionPanelComponentEventArgs args);
         private EventCallback<IgbExpansionPanelComponentEventArgs>? _closed = null;
 
         /// <summary>
@@ -412,11 +396,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;

--- a/src/components/Blazor/Accordion.cs
+++ b/src/components/Blazor/Accordion.cs
@@ -72,21 +72,20 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameAccordion(string name, ref object item);
         public override object FindByName(string name)
         {
-
             var baseResult = base.FindByName(name);
             if (baseResult != null)
             {
                 return baseResult;
             }
 
-            object item = null;
-            FindByNameAccordion(name, ref item);
-            if (item != null)
+            foreach (var item in ContentItems)
             {
-                return item;
+                if (item.Name == name || item.ContainerId == name)
+                {
+                    return item;
+                }
             }
 
             return null;

--- a/src/components/Blazor/Accordion.cs
+++ b/src/components/Blazor/Accordion.cs
@@ -439,13 +439,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbAccordion(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbAccordion(ser);
 
             if (IsPropDirty("SingleExpand"))
             { ser.AddBooleanProp("singleExpand", this._singleExpand); }

--- a/src/components/Blazor/Accordion.cs
+++ b/src/components/Blazor/Accordion.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _singleExpand = false;
 
-        partial void OnSingleExpandChanging(ref bool newValue);
         /// <summary>
         /// Allows only one panel to be expanded at a time.
         /// </summary>

--- a/src/components/Blazor/ActiveStepChangedEventArgs.cs
+++ b/src/components/Blazor/ActiveStepChangedEventArgs.cs
@@ -37,26 +37,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameActiveStepChangedEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameActiveStepChangedEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ActiveStepChangedEventArgs.cs
+++ b/src/components/Blazor/ActiveStepChangedEventArgs.cs
@@ -60,13 +60,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbActiveStepChangedEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbActiveStepChangedEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/ActiveStepChangedEventArgs.cs
+++ b/src/components/Blazor/ActiveStepChangedEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbActiveStepChangedEventArgsDetail _detail;
 
-        partial void OnDetailChanging(ref IgbActiveStepChangedEventArgsDetail newValue);
-
         /// <summary>
         /// The payload of the event, carrying the index of the step that became active.
         /// </summary>
@@ -25,7 +23,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/ActiveStepChangedEventArgsDetail.cs
+++ b/src/components/Blazor/ActiveStepChangedEventArgsDetail.cs
@@ -31,26 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameActiveStepChangedEventArgsDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameActiveStepChangedEventArgsDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ActiveStepChangedEventArgsDetail.cs
+++ b/src/components/Blazor/ActiveStepChangedEventArgsDetail.cs
@@ -53,13 +53,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbActiveStepChangedEventArgsDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbActiveStepChangedEventArgsDetail(ser);
 
             if (IsPropDirty("Index"))
             { ser.AddNumberProp("index", this._index); }

--- a/src/components/Blazor/ActiveStepChangedEventArgsDetail.cs
+++ b/src/components/Blazor/ActiveStepChangedEventArgsDetail.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _index = 0;
 
-        partial void OnIndexChanging(ref double newValue);
-
         /// <summary>
         /// The index of the step that became active.
         /// </summary>

--- a/src/components/Blazor/ActiveStepChangingEventArgs.cs
+++ b/src/components/Blazor/ActiveStepChangingEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbActiveStepChangingEventArgsDetail _detail;
 
-        partial void OnDetailChanging(ref IgbActiveStepChangingEventArgsDetail newValue);
-
         /// <summary>
         /// The payload of the event, carrying the index of the currently active step and the index of
         /// the step that is about to become active.
@@ -26,7 +24,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/ActiveStepChangingEventArgs.cs
+++ b/src/components/Blazor/ActiveStepChangingEventArgs.cs
@@ -38,26 +38,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameActiveStepChangingEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameActiveStepChangingEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ActiveStepChangingEventArgs.cs
+++ b/src/components/Blazor/ActiveStepChangingEventArgs.cs
@@ -61,13 +61,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbActiveStepChangingEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbActiveStepChangingEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/ActiveStepChangingEventArgsDetail.cs
+++ b/src/components/Blazor/ActiveStepChangingEventArgsDetail.cs
@@ -50,26 +50,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameActiveStepChangingEventArgsDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameActiveStepChangingEventArgsDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ActiveStepChangingEventArgsDetail.cs
+++ b/src/components/Blazor/ActiveStepChangingEventArgsDetail.cs
@@ -74,13 +74,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbActiveStepChangingEventArgsDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbActiveStepChangingEventArgsDetail(ser);
 
             if (IsPropDirty("OldIndex"))
             { ser.AddNumberProp("oldIndex", this._oldIndex); }

--- a/src/components/Blazor/ActiveStepChangingEventArgsDetail.cs
+++ b/src/components/Blazor/ActiveStepChangingEventArgsDetail.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _oldIndex = 0;
 
-        partial void OnOldIndexChanging(ref double newValue);
-
         /// <summary>
         /// The index of the step that is currently active.
         /// </summary>
@@ -33,8 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private double _newIndex = 0;
-
-        partial void OnNewIndexChanging(ref double newValue);
 
         /// <summary>
         /// The index of the step that is about to become active.

--- a/src/components/Blazor/Avatar.cs
+++ b/src/components/Blazor/Avatar.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _src;
 
-        partial void OnSrcChanging(ref string newValue);
         /// <summary>
         /// The image source to use.
         /// </summary>
@@ -74,7 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _alt;
 
-        partial void OnAltChanging(ref string newValue);
         /// <summary>
         /// Alternative text for the image.
         /// </summary>
@@ -94,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _initials;
 
-        partial void OnInitialsChanging(ref string newValue);
         /// <summary>
         /// Initials to use as a fallback when no image is available.
         /// </summary>
@@ -114,7 +111,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private AvatarShape _shape = AvatarShape.Square;
 
-        partial void OnShapeChanging(ref AvatarShape newValue);
         /// <summary>
         /// The shape of the avatar.
         /// </summary>

--- a/src/components/Blazor/Avatar.cs
+++ b/src/components/Blazor/Avatar.cs
@@ -129,25 +129,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameAvatar(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameAvatar(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Avatar.cs
+++ b/src/components/Blazor/Avatar.cs
@@ -161,13 +161,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbAvatar(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbAvatar(ser);
 
             if (IsPropDirty("Src"))
             { ser.AddStringProp("src", this._src); }

--- a/src/components/Blazor/Badge.cs
+++ b/src/components/Blazor/Badge.cs
@@ -162,13 +162,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbBadge(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbBadge(ser);
 
             if (IsPropDirty("Variant"))
             { ser.AddEnumProp("variant", this._variant); }

--- a/src/components/Blazor/Badge.cs
+++ b/src/components/Blazor/Badge.cs
@@ -130,25 +130,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameBadge(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameBadge(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Badge.cs
+++ b/src/components/Blazor/Badge.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private StyleVariant _variant = StyleVariant.Primary;
 
-        partial void OnVariantChanging(ref StyleVariant newValue);
         /// <summary>
         /// The type (style variant) of the badge.
         /// </summary>
@@ -74,7 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _outlined = false;
 
-        partial void OnOutlinedChanging(ref bool newValue);
         /// <summary>
         /// Sets whether to draw an outlined version of the badge.
         /// </summary>
@@ -94,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private BadgeShape _shape = BadgeShape.Rounded;
 
-        partial void OnShapeChanging(ref BadgeShape newValue);
         /// <summary>
         /// The shape of the badge.
         /// </summary>
@@ -114,7 +111,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _dot = false;
 
-        partial void OnDotChanging(ref bool newValue);
         /// <summary>
         /// Sets whether to render a dot type badge.
         /// When enabled, the badge appears as a small dot without any content.

--- a/src/components/Blazor/Banner.cs
+++ b/src/components/Blazor/Banner.cs
@@ -324,13 +324,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbBanner(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbBanner(ser);
 
             if (IsPropDirty("Open"))
             { ser.AddBooleanProp("open", this._open); }

--- a/src/components/Blazor/Banner.cs
+++ b/src/components/Blazor/Banner.cs
@@ -78,25 +78,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameBanner(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameBanner(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Banner.cs
+++ b/src/components/Blazor/Banner.cs
@@ -182,7 +182,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -202,11 +201,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -259,7 +254,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -279,11 +273,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;

--- a/src/components/Blazor/Banner.cs
+++ b/src/components/Blazor/Banner.cs
@@ -56,7 +56,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _open = false;
 
-        partial void OnOpenChanging(ref bool newValue);
         /// <summary>
         /// Whether the banner is open.
         /// Setting this property programmatically will immediately show or hide the

--- a/src/components/Blazor/BaseAlertLike.cs
+++ b/src/components/Blazor/BaseAlertLike.cs
@@ -162,25 +162,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameBaseAlertLike(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameBaseAlertLike(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/BaseAlertLike.cs
+++ b/src/components/Blazor/BaseAlertLike.cs
@@ -45,7 +45,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _open = false;
 
-        partial void OnOpenChanging(ref bool newValue);
         /// <summary>
         /// Whether the component is in shown state.
         /// </summary>
@@ -65,7 +64,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _displayTime = 4000;
 
-        partial void OnDisplayTimeChanging(ref double newValue);
         /// <summary>
         /// Determines the duration in milliseconds in which the component will be visible.
         /// </summary>
@@ -85,7 +83,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _keepOpen = false;
 
-        partial void OnKeepOpenChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the component should close after the <see cref="DisplayTime"/> is over.
         /// </summary>
@@ -105,7 +102,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private AbsolutePosition _position = AbsolutePosition.Bottom;
 
-        partial void OnPositionChanging(ref AbsolutePosition newValue);
         /// <summary>
         /// Sets the position of the component in the viewport.
         /// <list type="bullet">
@@ -137,7 +133,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private NotificationPositioning _positioning = NotificationPositioning.Viewport;
 
-        partial void OnPositioningChanging(ref NotificationPositioning newValue);
         /// <summary>
         /// Sets the positioning strategy of the component.
         /// <list type="bullet">

--- a/src/components/Blazor/BaseAlertLike.cs
+++ b/src/components/Blazor/BaseAlertLike.cs
@@ -280,13 +280,9 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToBoolean(iv);
         }
 
-        partial void SerializeCoreIgbBaseAlertLike(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbBaseAlertLike(ser);
 
             if (IsPropDirty("Open"))
             { ser.AddBooleanProp("open", this._open); }

--- a/src/components/Blazor/BaseComboBox.cs
+++ b/src/components/Blazor/BaseComboBox.cs
@@ -39,25 +39,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameBaseComboBox(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameBaseComboBox(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/BaseComboBox.cs
+++ b/src/components/Blazor/BaseComboBox.cs
@@ -129,13 +129,9 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToBoolean(iv);
         }
 
-        partial void SerializeCoreIgbBaseComboBox(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbBaseComboBox(ser);
 
             if (IsPropDirty("Open"))
             { ser.AddBooleanProp("open", this._open); }

--- a/src/components/Blazor/BaseComboBox.cs
+++ b/src/components/Blazor/BaseComboBox.cs
@@ -21,7 +21,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _open = false;
 
-        partial void OnOpenChanging(ref bool newValue);
         /// <summary>
         /// Sets the open state of the component.
         /// </summary>

--- a/src/components/Blazor/BaseOptionLike.cs
+++ b/src/components/Blazor/BaseOptionLike.cs
@@ -45,7 +45,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _active = false;
 
-        partial void OnActiveChanging(ref bool newValue);
         /// <summary>
         /// Whether the item is active.
         /// </summary>
@@ -65,7 +64,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Whether the item is disabled.
         /// </summary>
@@ -85,7 +83,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _selected = false;
 
-        partial void OnSelectedChanging(ref bool newValue);
         /// <summary>
         /// Whether the item is selected.
         /// </summary>
@@ -105,7 +102,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The current value of the item.
         /// If not specified, the text content of the item is used.

--- a/src/components/Blazor/BaseOptionLike.cs
+++ b/src/components/Blazor/BaseOptionLike.cs
@@ -121,25 +121,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameBaseOptionLike(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameBaseOptionLike(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/BaseOptionLike.cs
+++ b/src/components/Blazor/BaseOptionLike.cs
@@ -153,13 +153,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbBaseOptionLike(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbBaseOptionLike(ser);
 
             if (IsPropDirty("Active"))
             { ser.AddBooleanProp("active", this._active); }

--- a/src/components/Blazor/Button.cs
+++ b/src/components/Blazor/Button.cs
@@ -80,26 +80,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameButton(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameButton(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/Button.cs
+++ b/src/components/Blazor/Button.cs
@@ -101,13 +101,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbButton(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbButton(ser);
 
             if (IsPropDirty("Variant"))
             { ser.AddEnumProp("variant", this._variant); }

--- a/src/components/Blazor/Button.cs
+++ b/src/components/Blazor/Button.cs
@@ -52,7 +52,6 @@ namespace IgniteUI.Blazor.Controls
 
         private ButtonVariant _variant = ButtonVariant.Contained;
 
-        partial void OnVariantChanging(ref ButtonVariant newValue);
         /// <summary>
         /// The variant of the button which determines its visual appearance.
         /// <list type="bullet">

--- a/src/components/Blazor/ButtonBase.cs
+++ b/src/components/Blazor/ButtonBase.cs
@@ -45,7 +45,6 @@ namespace IgniteUI.Blazor.Controls
 
         private ButtonBaseType _displayType = ButtonBaseType.Button;
 
-        partial void OnDisplayTypeChanging(ref ButtonBaseType newValue);
         /// <summary>
         /// The type of the button, which determines its behavior and semantics.
         /// <list type="bullet">
@@ -74,8 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _href;
 
-        partial void OnHrefChanging(ref string newValue);
-
         /// <summary>
         /// The URL the button points to. When set, the component renders as an
         /// <c>&lt;a&gt;</c> element instead of a <c>&lt;button&gt;</c>, enabling navigation on click.
@@ -98,7 +95,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _download;
 
-        partial void OnDownloadChanging(ref string newValue);
         /// <summary>
         /// Prompts the browser to download the linked resource rather than navigating
         /// to it. The optional value is used as the suggested file name.
@@ -120,7 +116,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ButtonBaseTarget _target = ButtonBaseTarget._blank;
 
-        partial void OnTargetChanging(ref ButtonBaseTarget newValue);
         /// <summary>
         /// Where to open the linked document. Only effective when <see cref="Href"/> is set.
         /// <list type="bullet">
@@ -149,7 +144,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _rel;
 
-        partial void OnRelChanging(ref string newValue);
         /// <summary>
         /// The relationship between the current document and the linked URL.
         /// Accepts a space-separated list of link types (e.g. <c>noopener noreferrer</c>).
@@ -173,7 +167,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// When set, the button will be disabled and non-interactive.
         /// </summary>
@@ -193,7 +186,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _command;
 
-        partial void OnCommandChanging(ref string newValue);
         /// <summary>
         /// The command to invoke on the target element specified by <see cref="Commandfor"/>.
         /// Part of the <see href="https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API">
@@ -216,7 +208,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _commandfor;
 
-        partial void OnCommandforChanging(ref string? newValue);
         /// <summary>
         /// The ID of the target element for the invoker command.
         /// Part of the <see href="https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API">

--- a/src/components/Blazor/ButtonBase.cs
+++ b/src/components/Blazor/ButtonBase.cs
@@ -320,7 +320,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _focus = null;
 
         /// <summary>
@@ -340,11 +339,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _focus, ref eventCallbacksCache))
                     {
                         _focus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value, (args) =>
-                        {
-                            OnHandlingFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value);
                         this.OnRefChanged("Focus", null, "nativeEvent:::Focus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._focusRef = refName;
@@ -397,7 +392,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _blur = null;
 
         /// <summary>
@@ -417,11 +411,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _blur, ref eventCallbacksCache))
                     {
                         _blur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value, (args) =>
-                        {
-                            OnHandlingBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value);
                         this.OnRefChanged("Blur", null, "nativeEvent:::Blur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._blurRef = refName;

--- a/src/components/Blazor/ButtonBase.cs
+++ b/src/components/Blazor/ButtonBase.cs
@@ -470,13 +470,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbButtonBase(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbButtonBase(ser);
 
             if (IsPropDirty("DisplayType"))
             { ser.AddEnumProp("displayType", this._displayType); }

--- a/src/components/Blazor/ButtonBase.cs
+++ b/src/components/Blazor/ButtonBase.cs
@@ -228,25 +228,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameButtonBase(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameButtonBase(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         /// <summary>
         /// Sets focus on the button.
         /// </summary>

--- a/src/components/Blazor/ButtonGroup.cs
+++ b/src/components/Blazor/ButtonGroup.cs
@@ -170,7 +170,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingSelect(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _select = null;
 
         /// <summary>
@@ -190,11 +189,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _select, ref eventCallbacksCache))
                     {
                         _select = value;
-                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Select", value, (args) =>
-                        {
-                            OnHandlingSelect(args);
-
-                        });
+                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Select", value);
                         this.OnRefChanged("Select", null, "event:::Select", true, false, (refName, oldValue, newValue) =>
                         {
                             this._selectRef = refName;
@@ -247,7 +242,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingDeselect(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _deselect = null;
 
         /// <summary>
@@ -267,11 +261,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _deselect, ref eventCallbacksCache))
                     {
                         _deselect = value;
-                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Deselect", value, (args) =>
-                        {
-                            OnHandlingDeselect(args);
-
-                        });
+                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Deselect", value);
                         this.OnRefChanged("Deselect", null, "event:::Deselect", true, false, (refName, oldValue, newValue) =>
                         {
                             this._deselectRef = refName;

--- a/src/components/Blazor/ButtonGroup.cs
+++ b/src/components/Blazor/ButtonGroup.cs
@@ -129,25 +129,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameButtonGroup(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameButtonGroup(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ButtonGroup.cs
+++ b/src/components/Blazor/ButtonGroup.cs
@@ -316,13 +316,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbButtonGroup(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbButtonGroup(ser);
 
             if (IsPropDirty("Disabled"))
             { ser.AddBooleanProp("disabled", this._disabled); }

--- a/src/components/Blazor/ButtonGroup.cs
+++ b/src/components/Blazor/ButtonGroup.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Disables all buttons inside the group.
         /// </summary>
@@ -74,7 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ContentOrientation _alignment = ContentOrientation.Horizontal;
 
-        partial void OnAlignmentChanging(ref ContentOrientation newValue);
         /// <summary>
         /// Sets the orientation of the buttons in the group.
         /// </summary>
@@ -94,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ButtonGroupSelection _selection = ButtonGroupSelection.Single;
 
-        partial void OnSelectionChanging(ref ButtonGroupSelection newValue);
         /// <summary>
         /// Controls the mode of selection for the button group.
         /// </summary>
@@ -113,8 +110,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string[] _selectedItems;
-
-        partial void OnSelectedItemsChanging(ref string[] newValue);
 
         /// <summary>
         /// Gets or sets the values of the currently selected buttons.

--- a/src/components/Blazor/Calendar.cs
+++ b/src/components/Blazor/Calendar.cs
@@ -515,13 +515,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValues(DateTime[] oldValue, ref DateTime[] newValue);
 
-        partial void SerializeCoreIgbCalendar(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCalendar(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddDateTimeProp("value", this._value); }

--- a/src/components/Blazor/Calendar.cs
+++ b/src/components/Blazor/Calendar.cs
@@ -431,8 +431,6 @@ namespace IgniteUI.Blazor.Controls
                             if (this.Selection == CalendarSelection.Single)
                             {
                                 newValueValue = (DateTime)(args.Detail);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -450,8 +448,6 @@ namespace IgniteUI.Blazor.Controls
                             if (this.Selection != CalendarSelection.Single)
                             {
                                 newValueValues = (DateTime[])(DowncastArray<DateTime>(args.Detail));
-                                ;
-                                OnEventUpdatingValues(this._values, ref newValueValues);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -510,10 +506,6 @@ namespace IgniteUI.Blazor.Controls
                 this._change = null;
             }
         }
-
-        partial void OnEventUpdatingValue(DateTime oldValue, ref DateTime newValue);
-
-        partial void OnEventUpdatingValues(DateTime[] oldValue, ref DateTime[] newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/Calendar.cs
+++ b/src/components/Blazor/Calendar.cs
@@ -369,7 +369,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbComponentDataValueChangedEventArgs args);
         private EventCallback<IgbComponentDataValueChangedEventArgs>? _change = null;
 
         /// <summary>
@@ -391,8 +390,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbComponentDataValueChangedEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(DateTime);
 
                             if (this.Selection == CalendarSelection.Single)

--- a/src/components/Blazor/Calendar.cs
+++ b/src/components/Blazor/Calendar.cs
@@ -275,26 +275,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameCalendar(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCalendar(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         private EventCallback<DateTime>? _valueChanged = null;
 
         /// <summary>

--- a/src/components/Blazor/Calendar.cs
+++ b/src/components/Blazor/Calendar.cs
@@ -33,8 +33,6 @@ namespace IgniteUI.Blazor.Controls
 
         private DateTime _value = DateTime.MinValue;
 
-        partial void OnValueChanging(ref DateTime newValue);
-
         /// <summary>
         /// The current value of the calendar.
         /// Used when <see cref="IgbCalendarBase.Selection"/> is set to <see cref="CalendarSelection.Single"/>.
@@ -74,8 +72,6 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToDate(iv);
         }
         private DateTime[] _values;
-
-        partial void OnValuesChanging(ref DateTime[] newValue);
 
         /// <summary>
         /// The current values of the calendar.
@@ -120,7 +116,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime _activeDate = DateTime.MinValue;
 
-        partial void OnActiveDateChanging(ref DateTime newValue);
         /// <summary>
         /// Sets the date which is shown in view and is highlighted. By default it is the current date.
         /// </summary>
@@ -140,7 +135,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideOutsideDays = false;
 
-        partial void OnHideOutsideDaysChanging(ref bool newValue);
         /// <summary>
         /// Whether to hide the dates that do not belong to the current active month.
         /// </summary>
@@ -160,7 +154,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideHeader = false;
 
-        partial void OnHideHeaderChanging(ref bool newValue);
         /// <summary>
         /// Whether to render the calendar header part.
         /// When <see cref="IgbCalendarBase.Selection"/> is set to <see cref="CalendarSelection.Multiple"/>
@@ -182,7 +175,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private CalendarHeaderOrientation _headerOrientation = CalendarHeaderOrientation.Horizontal;
 
-        partial void OnHeaderOrientationChanging(ref CalendarHeaderOrientation newValue);
         /// <summary>
         /// The orientation of the calendar header.
         /// </summary>
@@ -202,7 +194,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ContentOrientation _orientation = ContentOrientation.Horizontal;
 
-        partial void OnOrientationChanging(ref ContentOrientation newValue);
         /// <summary>
         /// The orientation of the calendar months when more than one month
         /// is being shown.
@@ -223,7 +214,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _visibleMonths = 1;
 
-        partial void OnVisibleMonthsChanging(ref double newValue);
         /// <summary>
         /// The number of months displayed in the days view.
         /// </summary>
@@ -243,7 +233,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private CalendarActiveView _activeView = CalendarActiveView.Days;
 
-        partial void OnActiveViewChanging(ref CalendarActiveView newValue);
         /// <summary>
         /// The current active view of the component.
         /// </summary>
@@ -263,7 +252,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbCalendarFormatOptions _formatOptions;
 
-        partial void OnFormatOptionsChanging(ref IgbCalendarFormatOptions newValue);
         /// <summary>
         /// The options used to format the months and the weekdays in the calendar views.
         /// </summary>
@@ -273,7 +261,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._formatOptions; }
             set
             {
-                OnFormatOptionsChanging(ref value);
                 MarkPropDirty("FormatOptions");
                 if (this._formatOptions != null)
                 {

--- a/src/components/Blazor/CalendarBase.cs
+++ b/src/components/Blazor/CalendarBase.cs
@@ -202,13 +202,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCalendarBase(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCalendarBase(ser);
 
             if (IsPropDirty("Selection"))
             { ser.AddEnumProp("selection", this._selection); }

--- a/src/components/Blazor/CalendarBase.cs
+++ b/src/components/Blazor/CalendarBase.cs
@@ -29,7 +29,6 @@ namespace IgniteUI.Blazor.Controls
 
         private CalendarSelection _selection = CalendarSelection.Single;
 
-        partial void OnSelectionChanging(ref CalendarSelection newValue);
         /// <summary>
         /// Sets the type of selection in the component.
         /// </summary>
@@ -49,7 +48,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _showWeekNumbers = false;
 
-        partial void OnShowWeekNumbersChanging(ref bool newValue);
         /// <summary>
         /// Whether to show the week numbers.
         /// </summary>
@@ -69,7 +67,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private WeekDays _weekStart = WeekDays.Sunday;
 
-        partial void OnWeekStartChanging(ref WeekDays newValue);
         /// <summary>
         /// Gets/Sets the first day of the week.
         /// </summary>
@@ -89,7 +86,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _locale;
 
-        partial void OnLocaleChanging(ref string newValue);
         /// <summary>
         /// Gets/Sets the locale used for formatting and displaying the dates in the component.
         /// </summary>
@@ -109,7 +105,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbCalendarResourceStrings _resourceStrings;
 
-        partial void OnResourceStringsChanging(ref IgbCalendarResourceStrings newValue);
         /// <summary>
         /// The resource strings for localization.
         /// </summary>
@@ -119,7 +114,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._resourceStrings; }
             set
             {
-                OnResourceStringsChanging(ref value);
                 MarkPropDirty("ResourceStrings");
                 if (this._resourceStrings != null)
                 {
@@ -135,7 +129,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDateRangeDescriptor[]? _specialDates;
 
-        partial void OnSpecialDatesChanging(ref IgbDateRangeDescriptor[]? newValue);
         /// <summary>
         /// Gets/Sets the special dates for the component.
         /// </summary>
@@ -155,7 +148,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDateRangeDescriptor[]? _disabledDates;
 
-        partial void OnDisabledDatesChanging(ref IgbDateRangeDescriptor[]? newValue);
         /// <summary>
         /// Gets/Sets the disabled dates for the component.
         /// </summary>

--- a/src/components/Blazor/CalendarBase.cs
+++ b/src/components/Blazor/CalendarBase.cs
@@ -166,25 +166,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCalendarBase(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCalendarBase(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CalendarFormatOptions.cs
+++ b/src/components/Blazor/CalendarFormatOptions.cs
@@ -53,26 +53,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCalendarFormatOptions(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCalendarFormatOptions(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/CalendarFormatOptions.cs
+++ b/src/components/Blazor/CalendarFormatOptions.cs
@@ -14,7 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _weekday;
 
-        partial void OnWeekdayChanging(ref string newValue);
         /// <summary>
         /// The representation of the weekday names, one of <c>long</c>, <c>short</c> or <c>narrow</c>.
         /// Defaults to <c>narrow</c>.
@@ -35,7 +34,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _month;
 
-        partial void OnMonthChanging(ref string newValue);
         /// <summary>
         /// The representation of the month names, one of <c>numeric</c>, <c>2-digit</c>, <c>long</c>,
         /// <c>short</c> or <c>narrow</c>. Defaults to <c>long</c>.

--- a/src/components/Blazor/CalendarFormatOptions.cs
+++ b/src/components/Blazor/CalendarFormatOptions.cs
@@ -75,13 +75,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbCalendarFormatOptions(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCalendarFormatOptions(ser);
 
             if (IsPropDirty("Weekday"))
             { ser.AddStringProp("weekday", this._weekday); }

--- a/src/components/Blazor/CalendarResourceStrings.cs
+++ b/src/components/Blazor/CalendarResourceStrings.cs
@@ -231,26 +231,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCalendarResourceStrings(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCalendarResourceStrings(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/CalendarResourceStrings.cs
+++ b/src/components/Blazor/CalendarResourceStrings.cs
@@ -8,7 +8,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _selectMonth;
 
-        partial void OnSelectMonthChanging(ref string newValue);
         [Parameter]
         public string SelectMonth
         {
@@ -25,7 +24,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _selectYear;
 
-        partial void OnSelectYearChanging(ref string newValue);
         [Parameter]
         public string SelectYear
         {
@@ -42,7 +40,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _selectDate;
 
-        partial void OnSelectDateChanging(ref string newValue);
         [Parameter]
         public string SelectDate
         {
@@ -59,7 +56,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _selectRange;
 
-        partial void OnSelectRangeChanging(ref string newValue);
         [Parameter]
         public string SelectRange
         {
@@ -76,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _selectedDate;
 
-        partial void OnSelectedDateChanging(ref string newValue);
         [Parameter]
         public string SelectedDate
         {
@@ -93,7 +88,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _startDate;
 
-        partial void OnStartDateChanging(ref string newValue);
         [Parameter]
         public string StartDate
         {
@@ -110,7 +104,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _endDate;
 
-        partial void OnEndDateChanging(ref string newValue);
         [Parameter]
         public string EndDate
         {
@@ -127,7 +120,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _previousMonth;
 
-        partial void OnPreviousMonthChanging(ref string newValue);
         [Parameter]
         public string PreviousMonth
         {
@@ -144,7 +136,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _nextMonth;
 
-        partial void OnNextMonthChanging(ref string newValue);
         [Parameter]
         public string NextMonth
         {
@@ -161,7 +152,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _previousYear;
 
-        partial void OnPreviousYearChanging(ref string newValue);
         [Parameter]
         public string PreviousYear
         {
@@ -178,7 +168,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _nextYear;
 
-        partial void OnNextYearChanging(ref string newValue);
         [Parameter]
         public string NextYear
         {
@@ -195,7 +184,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _previousYears;
 
-        partial void OnPreviousYearsChanging(ref string newValue);
         [Parameter]
         public string PreviousYears
         {
@@ -212,7 +200,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _nextYears;
 
-        partial void OnNextYearsChanging(ref string newValue);
         [Parameter]
         public string NextYears
         {
@@ -229,7 +216,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _weekLabel;
 
-        partial void OnWeekLabelChanging(ref string newValue);
         [Parameter]
         public string WeekLabel
         {

--- a/src/components/Blazor/CalendarResourceStrings.cs
+++ b/src/components/Blazor/CalendarResourceStrings.cs
@@ -265,13 +265,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbCalendarResourceStrings(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCalendarResourceStrings(ser);
 
             if (IsPropDirty("SelectMonth"))
             { ser.AddStringProp("selectMonth", this._selectMonth); }

--- a/src/components/Blazor/Card.cs
+++ b/src/components/Blazor/Card.cs
@@ -103,13 +103,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCard(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCard(ser);
 
             if (IsPropDirty("Elevated"))
             { ser.AddBooleanProp("elevated", this._elevated); }

--- a/src/components/Blazor/Card.cs
+++ b/src/components/Blazor/Card.cs
@@ -74,25 +74,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCard(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCard(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Card.cs
+++ b/src/components/Blazor/Card.cs
@@ -55,7 +55,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _elevated = false;
 
-        partial void OnElevatedChanging(ref bool newValue);
         /// <summary>
         /// Sets the card to have an elevated appearance with shadow.
         /// When false, the card uses an outlined style with a border.

--- a/src/components/Blazor/CardActions.cs
+++ b/src/components/Blazor/CardActions.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private ContentOrientation _orientation = ContentOrientation.Horizontal;
 
-        partial void OnOrientationChanging(ref ContentOrientation newValue);
         /// <summary>
         /// The orientation of the actions layout.
         /// </summary>

--- a/src/components/Blazor/CardActions.cs
+++ b/src/components/Blazor/CardActions.cs
@@ -101,13 +101,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCardActions(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCardActions(ser);
 
             if (IsPropDirty("Orientation"))
             { ser.AddEnumProp("orientation", this._orientation); }

--- a/src/components/Blazor/CardActions.cs
+++ b/src/components/Blazor/CardActions.cs
@@ -72,25 +72,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCardActions(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCardActions(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CardContent.cs
+++ b/src/components/Blazor/CardContent.cs
@@ -50,25 +50,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameCardContent(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCardContent(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CardContent.cs
+++ b/src/components/Blazor/CardContent.cs
@@ -78,15 +78,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCardContent(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbCardContent(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/CardHeader.cs
+++ b/src/components/Blazor/CardHeader.cs
@@ -78,15 +78,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCardHeader(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbCardHeader(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/CardHeader.cs
+++ b/src/components/Blazor/CardHeader.cs
@@ -50,25 +50,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameCardHeader(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCardHeader(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CardMedia.cs
+++ b/src/components/Blazor/CardMedia.cs
@@ -78,15 +78,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCardMedia(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbCardMedia(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/CardMedia.cs
+++ b/src/components/Blazor/CardMedia.cs
@@ -50,25 +50,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameCardMedia(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCardMedia(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Carousel.cs
+++ b/src/components/Blazor/Carousel.cs
@@ -479,7 +479,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingSlideChanged(IgbNumberEventArgs args);
         private EventCallback<IgbNumberEventArgs>? _slideChanged = null;
 
         /// <summary>
@@ -499,11 +498,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _slideChanged, ref eventCallbacksCache))
                     {
                         _slideChanged = value;
-                        this.SetHandler<IgbNumberEventArgs>(this.Name, "SlideChanged", value, (args) =>
-                        {
-                            OnHandlingSlideChanged(args);
-
-                        });
+                        this.SetHandler<IgbNumberEventArgs>(this.Name, "SlideChanged", value);
                         this.OnRefChanged("SlideChanged", null, "event:::SlideChanged", true, false, (refName, oldValue, newValue) =>
                         {
                             this._slideChangedRef = refName;
@@ -556,7 +551,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingPlaying(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _playing = null;
 
         /// <summary>
@@ -576,11 +570,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _playing, ref eventCallbacksCache))
                     {
                         _playing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Playing", value, (args) =>
-                        {
-                            OnHandlingPlaying(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Playing", value);
                         this.OnRefChanged("Playing", null, "event:::Playing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._playingRef = refName;
@@ -633,7 +623,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingPaused(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _paused = null;
 
         /// <summary>
@@ -653,11 +642,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _paused, ref eventCallbacksCache))
                     {
                         _paused = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Paused", value, (args) =>
-                        {
-                            OnHandlingPaused(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Paused", value);
                         this.OnRefChanged("Paused", null, "event:::Paused", true, false, (refName, oldValue, newValue) =>
                         {
                             this._pausedRef = refName;

--- a/src/components/Blazor/Carousel.cs
+++ b/src/components/Blazor/Carousel.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _disableLoop = false;
 
-        partial void OnDisableLoopChanging(ref bool newValue);
         /// <summary>
         /// Whether the carousel should skip rotating to the first slide after it reaches the last.
         /// </summary>
@@ -74,7 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disablePauseOnInteraction = false;
 
-        partial void OnDisablePauseOnInteractionChanging(ref bool newValue);
         /// <summary>
         /// Whether the carousel should ignore user interactions and not pause on them.
         /// </summary>
@@ -94,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideNavigation = false;
 
-        partial void OnHideNavigationChanging(ref bool newValue);
         /// <summary>
         /// Whether the carousel should skip rendering of the default navigation buttons.
         /// </summary>
@@ -114,7 +111,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideIndicators = false;
 
-        partial void OnHideIndicatorsChanging(ref bool newValue);
         /// <summary>
         /// Whether the carousel should skip rendering of the indicator controls (dots).
         /// </summary>
@@ -134,7 +130,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _vertical = false;
 
-        partial void OnVerticalChanging(ref bool newValue);
         /// <summary>
         /// Whether the carousel has vertical alignment.
         /// </summary>
@@ -154,7 +149,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private CarouselIndicatorsOrientation _indicatorsOrientation = CarouselIndicatorsOrientation.End;
 
-        partial void OnIndicatorsOrientationChanging(ref CarouselIndicatorsOrientation newValue);
         /// <summary>
         /// Sets the orientation of the indicator controls (dots).
         /// </summary>
@@ -174,7 +168,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _indicatorsLabelFormat;
 
-        partial void OnIndicatorsLabelFormatChanging(ref string newValue);
         /// <summary>
         /// The format used to set the aria-label on the carousel indicators.
         /// Instances of <c>{0}</c> will be replaced with the index of the corresponding slide.
@@ -195,7 +188,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _slidesLabelFormat;
 
-        partial void OnSlidesLabelFormatChanging(ref string newValue);
         /// <summary>
         /// The format used to set the aria-label on the carousel slides and the text displayed
         /// when the number of indicators is greater than the maximum indicator count.
@@ -218,7 +210,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _interval = 0;
 
-        partial void OnIntervalChanging(ref double newValue);
         /// <summary>
         /// The duration in milliseconds between changing the active slide.
         /// </summary>
@@ -238,7 +229,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _maximumIndicatorsCount = 10;
 
-        partial void OnMaximumIndicatorsCountChanging(ref double newValue);
         /// <summary>
         /// The maximum number of indicator controls (dots) that can be shown. Defaults to <c>10</c>.
         /// </summary>
@@ -258,7 +248,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private HorizontalTransitionAnimation _animationType = HorizontalTransitionAnimation.Slide;
 
-        partial void OnAnimationTypeChanging(ref HorizontalTransitionAnimation newValue);
         /// <summary>
         /// The animation type.
         /// </summary>

--- a/src/components/Blazor/Carousel.cs
+++ b/src/components/Blazor/Carousel.cs
@@ -708,13 +708,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbCarousel(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCarousel(ser);
 
             if (IsPropDirty("DisableLoop"))
             { ser.AddBooleanProp("disableLoop", this._disableLoop); }

--- a/src/components/Blazor/Carousel.cs
+++ b/src/components/Blazor/Carousel.cs
@@ -338,25 +338,6 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToBoolean(iv);
         }
 
-        partial void FindByNameCarousel(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCarousel(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CarouselIndicator.cs
+++ b/src/components/Blazor/CarouselIndicator.cs
@@ -77,15 +77,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCarouselIndicator(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbCarouselIndicator(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/CarouselIndicator.cs
+++ b/src/components/Blazor/CarouselIndicator.cs
@@ -49,25 +49,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameCarouselIndicator(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCarouselIndicator(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CarouselSlide.cs
+++ b/src/components/Blazor/CarouselSlide.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _active = false;
 
-        partial void OnActiveChanging(ref bool newValue);
         /// <summary>
         /// The current active slide for the carousel component.
         /// </summary>

--- a/src/components/Blazor/CarouselSlide.cs
+++ b/src/components/Blazor/CarouselSlide.cs
@@ -100,13 +100,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCarouselSlide(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCarouselSlide(ser);
 
             if (IsPropDirty("Active"))
             { ser.AddBooleanProp("active", this._active); }

--- a/src/components/Blazor/CarouselSlide.cs
+++ b/src/components/Blazor/CarouselSlide.cs
@@ -71,25 +71,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCarouselSlide(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCarouselSlide(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Chat.cs
+++ b/src/components/Blazor/Chat.cs
@@ -174,7 +174,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingMessageCreated(IgbChatMessageEventArgs args);
         private EventCallback<IgbChatMessageEventArgs>? _messageCreated = null;
 
         /// <summary>
@@ -194,11 +193,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _messageCreated, ref eventCallbacksCache))
                     {
                         _messageCreated = value;
-                        this.SetHandler<IgbChatMessageEventArgs>(this.Name, "MessageCreated", value, (args) =>
-                        {
-                            OnHandlingMessageCreated(args);
-
-                        });
+                        this.SetHandler<IgbChatMessageEventArgs>(this.Name, "MessageCreated", value);
                         this.OnRefChanged("MessageCreated", null, "event:::MessageCreated", true, false, (refName, oldValue, newValue) =>
                         {
                             this._messageCreatedRef = refName;
@@ -251,7 +246,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingMessageReact(IgbChatMessageReactionEventArgs args);
         private EventCallback<IgbChatMessageReactionEventArgs>? _messageReact = null;
 
         /// <summary>
@@ -271,11 +265,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _messageReact, ref eventCallbacksCache))
                     {
                         _messageReact = value;
-                        this.SetHandler<IgbChatMessageReactionEventArgs>(this.Name, "MessageReact", value, (args) =>
-                        {
-                            OnHandlingMessageReact(args);
-
-                        });
+                        this.SetHandler<IgbChatMessageReactionEventArgs>(this.Name, "MessageReact", value);
                         this.OnRefChanged("MessageReact", null, "event:::MessageReact", true, false, (refName, oldValue, newValue) =>
                         {
                             this._messageReactRef = refName;
@@ -328,7 +318,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingAttachmentClick(IgbChatMessageAttachmentEventArgs args);
         private EventCallback<IgbChatMessageAttachmentEventArgs>? _attachmentClick = null;
 
         /// <summary>
@@ -348,11 +337,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _attachmentClick, ref eventCallbacksCache))
                     {
                         _attachmentClick = value;
-                        this.SetHandler<IgbChatMessageAttachmentEventArgs>(this.Name, "AttachmentClick", value, (args) =>
-                        {
-                            OnHandlingAttachmentClick(args);
-
-                        });
+                        this.SetHandler<IgbChatMessageAttachmentEventArgs>(this.Name, "AttachmentClick", value);
                         this.OnRefChanged("AttachmentClick", null, "event:::AttachmentClick", true, false, (refName, oldValue, newValue) =>
                         {
                             this._attachmentClickRef = refName;
@@ -405,7 +390,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTypingChange(IgbComponentBoolValueChangedEventArgs args);
         private EventCallback<IgbComponentBoolValueChangedEventArgs>? _typingChange = null;
 
         /// <summary>
@@ -425,11 +409,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _typingChange, ref eventCallbacksCache))
                     {
                         _typingChange = value;
-                        this.SetHandler<IgbComponentBoolValueChangedEventArgs>(this.Name, "TypingChange", value, (args) =>
-                        {
-                            OnHandlingTypingChange(args);
-
-                        });
+                        this.SetHandler<IgbComponentBoolValueChangedEventArgs>(this.Name, "TypingChange", value);
                         this.OnRefChanged("TypingChange", null, "event:::TypingChange", true, false, (refName, oldValue, newValue) =>
                         {
                             this._typingChangeRef = refName;
@@ -482,7 +462,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInputFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _inputFocus = null;
 
         /// <summary>
@@ -502,11 +481,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _inputFocus, ref eventCallbacksCache))
                     {
                         _inputFocus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "InputFocus", value, (args) =>
-                        {
-                            OnHandlingInputFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "InputFocus", value);
                         this.OnRefChanged("InputFocus", null, "event:::InputFocus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputFocusRef = refName;
@@ -559,7 +534,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInputBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _inputBlur = null;
 
         /// <summary>
@@ -579,11 +553,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _inputBlur, ref eventCallbacksCache))
                     {
                         _inputBlur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "InputBlur", value, (args) =>
-                        {
-                            OnHandlingInputBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "InputBlur", value);
                         this.OnRefChanged("InputBlur", null, "event:::InputBlur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputBlurRef = refName;
@@ -636,7 +606,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInputChange(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _inputChange = null;
 
         /// <summary>
@@ -656,11 +625,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _inputChange, ref eventCallbacksCache))
                     {
                         _inputChange = value;
-                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "InputChange", value, (args) =>
-                        {
-                            OnHandlingInputChange(args);
-
-                        });
+                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "InputChange", value);
                         this.OnRefChanged("InputChange", null, "event:::InputChange", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputChangeRef = refName;

--- a/src/components/Blazor/Chat.cs
+++ b/src/components/Blazor/Chat.cs
@@ -702,13 +702,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbChat(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChat(ser);
 
             if (IsPropDirty("Messages"))
             { ser.AddSerializableArrayProp("messages", this._messages); }

--- a/src/components/Blazor/Chat.cs
+++ b/src/components/Blazor/Chat.cs
@@ -118,25 +118,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameChat(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChat(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Chat.cs
+++ b/src/components/Blazor/Chat.cs
@@ -46,7 +46,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbChatMessage[] _messages;
 
-        partial void OnMessagesChanging(ref IgbChatMessage[] newValue);
         /// <summary>
         /// The list of chat messages currently displayed.
         /// Use this property to set or update the message history.
@@ -67,7 +66,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbChatDraftMessage _draftMessage;
 
-        partial void OnDraftMessageChanging(ref IgbChatDraftMessage newValue);
         /// <summary>
         /// The chat message currently being composed but not yet sent.
         /// Includes the draft text and any attachments.
@@ -78,7 +76,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._draftMessage; }
             set
             {
-                OnDraftMessageChanging(ref value);
                 MarkPropDirty("DraftMessage");
                 if (this._draftMessage != null)
                 {
@@ -94,7 +91,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbChatOptions? _options;
 
-        partial void OnOptionsChanging(ref IgbChatOptions? newValue);
         /// <summary>
         /// Controls the chat behavior and appearance through a configuration object.
         /// Use this to toggle UI options, provide suggestions, templates, etc.
@@ -105,7 +101,9 @@ namespace IgniteUI.Blazor.Controls
             get { return this._options; }
             set
             {
-                OnOptionsChanging(ref value);
+                // Never store a null options object, and input attachments are not supported yet.
+                value ??= new IgbChatOptions();
+                value.DisableInputAttachments = true;
                 MarkPropDirty("Options");
                 if (this._options != null)
                 {

--- a/src/components/Blazor/ChatAttachmentRenderContext.cs
+++ b/src/components/Blazor/ChatAttachmentRenderContext.cs
@@ -64,13 +64,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatAttachmentRenderContext(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatAttachmentRenderContext(ser);
 
             if (IsPropDirty("Attachment"))
             { ser.AddSerializableProp("attachment", this._attachment); }

--- a/src/components/Blazor/ChatAttachmentRenderContext.cs
+++ b/src/components/Blazor/ChatAttachmentRenderContext.cs
@@ -11,7 +11,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbChatMessageAttachment _attachment;
 
-        partial void OnAttachmentChanging(ref IgbChatMessageAttachment newValue);
         /// <summary>
         /// The specific attachment being rendered.
         /// </summary>
@@ -21,7 +20,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._attachment; }
             set
             {
-                OnAttachmentChanging(ref value);
                 MarkPropDirty("Attachment");
                 if (this._attachment != null)
                 {

--- a/src/components/Blazor/ChatAttachmentRenderContext.cs
+++ b/src/components/Blazor/ChatAttachmentRenderContext.cs
@@ -34,25 +34,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameChatAttachmentRenderContext(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatAttachmentRenderContext(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatDraftMessage.cs
+++ b/src/components/Blazor/ChatDraftMessage.cs
@@ -47,25 +47,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameChatDraftMessage(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatDraftMessage(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatDraftMessage.cs
+++ b/src/components/Blazor/ChatDraftMessage.cs
@@ -10,7 +10,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _text;
 
-        partial void OnTextChanging(ref string newValue);
         /// <summary>
         /// The textual content of the draft message.
         /// </summary>
@@ -30,7 +29,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbChatMessageAttachment[] _attachments;
 
-        partial void OnAttachmentsChanging(ref IgbChatMessageAttachment[] newValue);
         /// <summary>
         /// An array of attachments associated with the draft message.
         /// </summary>

--- a/src/components/Blazor/ChatDraftMessage.cs
+++ b/src/components/Blazor/ChatDraftMessage.cs
@@ -77,13 +77,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatDraftMessage(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatDraftMessage(ser);
 
             if (IsPropDirty("Text"))
             { ser.AddStringProp("text", this._text); }

--- a/src/components/Blazor/ChatInputRenderContext.cs
+++ b/src/components/Blazor/ChatInputRenderContext.cs
@@ -29,25 +29,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameChatInputRenderContext(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatInputRenderContext(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatInputRenderContext.cs
+++ b/src/components/Blazor/ChatInputRenderContext.cs
@@ -58,13 +58,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatInputRenderContext(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatInputRenderContext(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddStringProp("value", this._value); }

--- a/src/components/Blazor/ChatInputRenderContext.cs
+++ b/src/components/Blazor/ChatInputRenderContext.cs
@@ -11,7 +11,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The current value of the input field.
         /// </summary>

--- a/src/components/Blazor/ChatMessage.cs
+++ b/src/components/Blazor/ChatMessage.cs
@@ -13,7 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _id;
 
-        partial void OnIdChanging(ref string newValue);
         /// <summary>
         /// A unique identifier for the message.
         /// </summary>
@@ -33,7 +32,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _text;
 
-        partial void OnTextChanging(ref string newValue);
         /// <summary>
         /// The textual content of the message.
         /// </summary>
@@ -53,7 +51,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _sender;
 
-        partial void OnSenderChanging(ref string newValue);
         /// <summary>
         /// The identifier or name of the sender of the message.
         /// </summary>
@@ -73,7 +70,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _timestamp;
 
-        partial void OnTimestampChanging(ref string newValue);
         /// <summary>
         /// The timestamp indicating when the message was sent.
         /// </summary>
@@ -93,7 +89,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbChatMessageAttachment[] _attachments;
 
-        partial void OnAttachmentsChanging(ref IgbChatMessageAttachment[] newValue);
         /// <summary>
         /// Optional list of attachments associated with the message,
         /// such as images, files, or links.
@@ -114,7 +109,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string[] _reactions;
 
-        partial void OnReactionsChanging(ref string[] newValue);
         /// <summary>
         /// Optional list of reactions associated with the message.
         /// </summary>

--- a/src/components/Blazor/ChatMessage.cs
+++ b/src/components/Blazor/ChatMessage.cs
@@ -161,13 +161,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatMessage(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatMessage(ser);
 
             if (IsPropDirty("Id"))
             { ser.AddStringProp("id", this._id); }

--- a/src/components/Blazor/ChatMessage.cs
+++ b/src/components/Blazor/ChatMessage.cs
@@ -127,25 +127,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameChatMessage(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatMessage(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatMessageAttachment.cs
+++ b/src/components/Blazor/ChatMessageAttachment.cs
@@ -13,7 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _id;
 
-        partial void OnIdChanging(ref string newValue);
         /// <summary>
         /// A unique identifier for the attachment.
         /// </summary>
@@ -33,7 +32,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _url;
 
-        partial void OnUrlChanging(ref string newValue);
         /// <summary>
         /// The URL from which the attachment can be downloaded or viewed.
         /// Typically used for attachments stored on a server or CDN.
@@ -54,7 +52,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _attachmentType;
 
-        partial void OnAttachmentTypeChanging(ref string newValue);
         /// <summary>
         /// The MIME type or a custom type identifier for the attachment (e.g. "image/png", "pdf", "audio").
         /// </summary>
@@ -75,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _thumbnail;
 
-        partial void OnThumbnailChanging(ref string newValue);
         /// <summary>
         /// Optional URL to a thumbnail preview of the attachment (e.g. for images or videos).
         /// </summary>

--- a/src/components/Blazor/ChatMessageAttachment.cs
+++ b/src/components/Blazor/ChatMessageAttachment.cs
@@ -90,25 +90,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameChatMessageAttachment(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatMessageAttachment(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatMessageAttachment.cs
+++ b/src/components/Blazor/ChatMessageAttachment.cs
@@ -122,13 +122,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatMessageAttachment(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatMessageAttachment(ser);
 
             if (IsPropDirty("Id"))
             { ser.AddStringProp("id", this._id); }

--- a/src/components/Blazor/ChatMessageAttachmentEventArgs.cs
+++ b/src/components/Blazor/ChatMessageAttachmentEventArgs.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbChatMessageAttachmentEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatMessageAttachmentEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/ChatMessageAttachmentEventArgs.cs
+++ b/src/components/Blazor/ChatMessageAttachmentEventArgs.cs
@@ -37,26 +37,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameChatMessageAttachmentEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatMessageAttachmentEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ChatMessageAttachmentEventArgs.cs
+++ b/src/components/Blazor/ChatMessageAttachmentEventArgs.cs
@@ -14,7 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbChatMessageAttachment _detail;
 
-        partial void OnDetailChanging(ref IgbChatMessageAttachment newValue);
         /// <summary>
         /// The chat message attachment the event was raised for.
         /// </summary>
@@ -24,7 +23,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/ChatMessageEventArgs.cs
+++ b/src/components/Blazor/ChatMessageEventArgs.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbChatMessageEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatMessageEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/ChatMessageEventArgs.cs
+++ b/src/components/Blazor/ChatMessageEventArgs.cs
@@ -14,7 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbChatMessage _detail;
 
-        partial void OnDetailChanging(ref IgbChatMessage newValue);
         /// <summary>
         /// The chat message the event was raised for.
         /// </summary>
@@ -24,7 +23,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/ChatMessageEventArgs.cs
+++ b/src/components/Blazor/ChatMessageEventArgs.cs
@@ -37,26 +37,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameChatMessageEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatMessageEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ChatMessageReaction.cs
+++ b/src/components/Blazor/ChatMessageReaction.cs
@@ -13,7 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbChatMessage _message;
 
-        partial void OnMessageChanging(ref IgbChatMessage newValue);
         /// <summary>
         /// The chat message that the reaction is associated with.
         /// </summary>
@@ -23,7 +22,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._message; }
             set
             {
-                OnMessageChanging(ref value);
                 MarkPropDirty("Message");
                 if (this._message != null)
                 {
@@ -39,7 +37,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _reaction;
 
-        partial void OnReactionChanging(ref string newValue);
         /// <summary>
         /// The string representation of the reaction, such as an emoji or a string;
         /// </summary>

--- a/src/components/Blazor/ChatMessageReaction.cs
+++ b/src/components/Blazor/ChatMessageReaction.cs
@@ -86,13 +86,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatMessageReaction(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatMessageReaction(ser);
 
             if (IsPropDirty("Message"))
             { ser.AddSerializableProp("message", this._message); }

--- a/src/components/Blazor/ChatMessageReaction.cs
+++ b/src/components/Blazor/ChatMessageReaction.cs
@@ -55,25 +55,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameChatMessageReaction(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatMessageReaction(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatMessageReactionEventArgs.cs
+++ b/src/components/Blazor/ChatMessageReactionEventArgs.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbChatMessageReactionEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatMessageReactionEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/ChatMessageReactionEventArgs.cs
+++ b/src/components/Blazor/ChatMessageReactionEventArgs.cs
@@ -37,26 +37,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameChatMessageReactionEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatMessageReactionEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ChatMessageReactionEventArgs.cs
+++ b/src/components/Blazor/ChatMessageReactionEventArgs.cs
@@ -14,7 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbChatMessageReaction _detail;
 
-        partial void OnDetailChanging(ref IgbChatMessageReaction newValue);
         /// <summary>
         /// The reaction the event was raised for, together with the chat message it is associated with.
         /// </summary>
@@ -24,7 +23,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/ChatMessageRenderContext.cs
+++ b/src/components/Blazor/ChatMessageRenderContext.cs
@@ -11,7 +11,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbChatMessage _message;
 
-        partial void OnMessageChanging(ref IgbChatMessage newValue);
         /// <summary>
         /// The specific chat message being rendered.
         /// </summary>
@@ -21,7 +20,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._message; }
             set
             {
-                OnMessageChanging(ref value);
                 MarkPropDirty("Message");
                 if (this._message != null)
                 {

--- a/src/components/Blazor/ChatMessageRenderContext.cs
+++ b/src/components/Blazor/ChatMessageRenderContext.cs
@@ -64,13 +64,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatMessageRenderContext(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatMessageRenderContext(ser);
 
             if (IsPropDirty("Message"))
             { ser.AddSerializableProp("message", this._message); }

--- a/src/components/Blazor/ChatMessageRenderContext.cs
+++ b/src/components/Blazor/ChatMessageRenderContext.cs
@@ -34,25 +34,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameChatMessageRenderContext(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatMessageRenderContext(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatOptions.cs
+++ b/src/components/Blazor/ChatOptions.cs
@@ -240,25 +240,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameChatOptions(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatOptions(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatOptions.cs
+++ b/src/components/Blazor/ChatOptions.cs
@@ -281,13 +281,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatOptions(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatOptions(ser);
 
             if (IsPropDirty("CurrentUserId"))
             { ser.AddStringProp("currentUserId", this._currentUserId); }

--- a/src/components/Blazor/ChatOptions.cs
+++ b/src/components/Blazor/ChatOptions.cs
@@ -11,7 +11,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _currentUserId;
 
-        partial void OnCurrentUserIdChanging(ref string newValue);
         /// <summary>
         /// The ID of the current user. Used to differentiate between incoming and outgoing messages.
         /// </summary>
@@ -31,7 +30,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableAutoScroll = false;
 
-        partial void OnDisableAutoScrollChanging(ref bool newValue);
         /// <summary>
         /// If <see langword="true"/>, prevents the chat from automatically scrolling to the latest message.
         /// </summary>
@@ -51,7 +49,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableInputAttachments = false;
 
-        partial void OnDisableInputAttachmentsChanging(ref bool newValue);
         /// <summary>
         /// If <see langword="true"/>, disables the ability to upload and send attachments.
         /// Defaults to <see langword="false"/>.
@@ -72,7 +69,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _isTyping = false;
 
-        partial void OnIsTypingChanging(ref bool newValue);
         /// <summary>
         /// Indicates whether the other user is currently typing a message.
         /// </summary>
@@ -92,7 +88,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _headerText;
 
-        partial void OnHeaderTextChanging(ref string newValue);
         /// <summary>
         /// Optional header text to display at the top of the chat component.
         /// </summary>
@@ -112,7 +107,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _inputPlaceholder;
 
-        partial void OnInputPlaceholderChanging(ref string newValue);
         /// <summary>
         /// Optional placeholder text for the chat input area.
         /// Provides a hint to the user about what they can type (e.g. "Type a message...").
@@ -133,7 +127,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string[] _suggestions;
 
-        partial void OnSuggestionsChanging(ref string[] newValue);
         /// <summary>
         /// Suggested text snippets or quick replies that can be shown as user-selectable options.
         /// </summary>
@@ -153,7 +146,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ChatSuggestionsPosition _suggestionsPosition = ChatSuggestionsPosition.BelowInput;
 
-        partial void OnSuggestionsPositionChanging(ref ChatSuggestionsPosition newValue);
         /// <summary>
         /// Controls the position of the chat suggestions within the component layout.
         /// <list type="bullet">
@@ -180,7 +172,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _stopTypingDelay = 0;
 
-        partial void OnStopTypingDelayChanging(ref double newValue);
         /// <summary>
         /// Time in milliseconds to wait before dispatching a stop typing event.
         /// Default is <c>3000</c>.
@@ -200,8 +191,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private bool _adoptRootStyles = false;
-
-        partial void OnAdoptRootStylesChanging(ref bool newValue);
 
         /// <summary>
         /// When <see langword="true"/>, lets content rendered by custom renderers inside the component's
@@ -228,7 +217,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbChatRenderers _renderers;
 
-        partial void OnRenderersChanging(ref IgbChatRenderers newValue);
         /// <summary>
         /// An object containing a collection of custom renderers for different parts of the chat UI.
         /// </summary>
@@ -238,7 +226,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._renderers; }
             set
             {
-                OnRenderersChanging(ref value);
                 MarkPropDirty("Renderers");
                 if (this._renderers != null)
                 {

--- a/src/components/Blazor/ChatRenderContext.cs
+++ b/src/components/Blazor/ChatRenderContext.cs
@@ -12,7 +12,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbChat _instance;
 
-        partial void OnInstanceChanging(ref IgbChat newValue);
         /// <summary>
         /// The instance of the <see cref="IgbChat"/> component.
         /// </summary>

--- a/src/components/Blazor/ChatRenderContext.cs
+++ b/src/components/Blazor/ChatRenderContext.cs
@@ -30,25 +30,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameChatRenderContext(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatRenderContext(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ChatRenderContext.cs
+++ b/src/components/Blazor/ChatRenderContext.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbChatRenderContext(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatRenderContext(ser);
 
             if (IsPropDirty("Instance"))
             { ser.AddSerializableProp("instance", this._instance); }

--- a/src/components/Blazor/ChatRenderers.cs
+++ b/src/components/Blazor/ChatRenderers.cs
@@ -881,13 +881,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbChatRenderers(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChatRenderers(ser);
 
             if (IsPropDirty("AttachmentRef"))
             { ser.AddStringProp("attachmentRef", this._attachmentRef); }

--- a/src/components/Blazor/ChatRenderers.cs
+++ b/src/components/Blazor/ChatRenderers.cs
@@ -833,26 +833,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameChatRenderers(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChatRenderers(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ChatRenderers.cs
+++ b/src/components/Blazor/ChatRenderers.cs
@@ -9,7 +9,6 @@ namespace IgniteUI.Blazor.Controls
         private string _attachmentRef;
         private RenderFragment<IgbChatAttachmentRenderContext> _attachment;
 
-        partial void OnAttachmentChanging(ref RenderFragment<IgbChatAttachmentRenderContext> newValue);
         /// <summary>
         /// Custom renderer for a single chat message attachment.
         /// </summary>
@@ -21,7 +20,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._attachment;
-                OnAttachmentChanging(ref value);
                 if (oldValue != value || !IsPropDirty("Attachment"))
                 {
                     MarkPropDirty("Attachment");
@@ -70,7 +68,6 @@ namespace IgniteUI.Blazor.Controls
         private string _attachmentContentRef;
         private RenderFragment<IgbChatAttachmentRenderContext> _attachmentContent;
 
-        partial void OnAttachmentContentChanging(ref RenderFragment<IgbChatAttachmentRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the content of an attachment.
         /// </summary>
@@ -82,7 +79,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._attachmentContent;
-                OnAttachmentContentChanging(ref value);
                 if (oldValue != value || !IsPropDirty("AttachmentContent"))
                 {
                     MarkPropDirty("AttachmentContent");
@@ -131,7 +127,6 @@ namespace IgniteUI.Blazor.Controls
         private string _attachmentHeaderRef;
         private RenderFragment<IgbChatAttachmentRenderContext> _attachmentHeader;
 
-        partial void OnAttachmentHeaderChanging(ref RenderFragment<IgbChatAttachmentRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the header of an attachment.
         /// </summary>
@@ -143,7 +138,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._attachmentHeader;
-                OnAttachmentHeaderChanging(ref value);
                 if (oldValue != value || !IsPropDirty("AttachmentHeader"))
                 {
                     MarkPropDirty("AttachmentHeader");
@@ -192,7 +186,6 @@ namespace IgniteUI.Blazor.Controls
         private string _inputRef;
         private RenderFragment<IgbChatInputRenderContext> _input;
 
-        partial void OnInputChanging(ref RenderFragment<IgbChatInputRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the main chat input field.
         /// </summary>
@@ -204,7 +197,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._input;
-                OnInputChanging(ref value);
                 if (oldValue != value || !IsPropDirty("Input"))
                 {
                     MarkPropDirty("Input");
@@ -253,7 +245,6 @@ namespace IgniteUI.Blazor.Controls
         private string _inputActionsRef;
         private RenderFragment<IgbChatRenderContext> _inputActions;
 
-        partial void OnInputActionsChanging(ref RenderFragment<IgbChatRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the actions container within the input area.
         /// </summary>
@@ -265,7 +256,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._inputActions;
-                OnInputActionsChanging(ref value);
                 if (oldValue != value || !IsPropDirty("InputActions"))
                 {
                     MarkPropDirty("InputActions");
@@ -314,7 +304,6 @@ namespace IgniteUI.Blazor.Controls
         private string _inputActionsEndRef;
         private RenderFragment<IgbChatRenderContext> _inputActionsEnd;
 
-        partial void OnInputActionsEndChanging(ref RenderFragment<IgbChatRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the actions at the end of the input area.
         /// </summary>
@@ -326,7 +315,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._inputActionsEnd;
-                OnInputActionsEndChanging(ref value);
                 if (oldValue != value || !IsPropDirty("InputActionsEnd"))
                 {
                     MarkPropDirty("InputActionsEnd");
@@ -375,7 +363,6 @@ namespace IgniteUI.Blazor.Controls
         private string _inputActionsStartRef;
         private RenderFragment<IgbChatRenderContext> _inputActionsStart;
 
-        partial void OnInputActionsStartChanging(ref RenderFragment<IgbChatRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the actions at the start of the input area.
         /// </summary>
@@ -387,7 +374,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._inputActionsStart;
-                OnInputActionsStartChanging(ref value);
                 if (oldValue != value || !IsPropDirty("InputActionsStart"))
                 {
                     MarkPropDirty("InputActionsStart");
@@ -436,7 +422,6 @@ namespace IgniteUI.Blazor.Controls
         private string _messageRef;
         private RenderFragment<IgbChatMessageRenderContext> _message;
 
-        partial void OnMessageChanging(ref RenderFragment<IgbChatMessageRenderContext> newValue);
         /// <summary>
         /// Custom renderer for an entire chat message bubble.
         /// </summary>
@@ -448,7 +433,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._message;
-                OnMessageChanging(ref value);
                 if (oldValue != value || !IsPropDirty("Message"))
                 {
                     MarkPropDirty("Message");
@@ -497,7 +481,6 @@ namespace IgniteUI.Blazor.Controls
         private string _messageActionsRef;
         private RenderFragment<IgbChatMessageRenderContext> _messageActions;
 
-        partial void OnMessageActionsChanging(ref RenderFragment<IgbChatMessageRenderContext> newValue);
         /// <summary>
         /// Custom renderer for message-specific actions (e.g. reply or delete buttons).
         /// </summary>
@@ -509,7 +492,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._messageActions;
-                OnMessageActionsChanging(ref value);
                 if (oldValue != value || !IsPropDirty("MessageActions"))
                 {
                     MarkPropDirty("MessageActions");
@@ -558,7 +540,6 @@ namespace IgniteUI.Blazor.Controls
         private string _messageAttachmentsRef;
         private RenderFragment<IgbChatMessageRenderContext> _messageAttachments;
 
-        partial void OnMessageAttachmentsChanging(ref RenderFragment<IgbChatMessageRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the attachments associated with a message.
         /// </summary>
@@ -570,7 +551,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._messageAttachments;
-                OnMessageAttachmentsChanging(ref value);
                 if (oldValue != value || !IsPropDirty("MessageAttachments"))
                 {
                     MarkPropDirty("MessageAttachments");
@@ -619,7 +599,6 @@ namespace IgniteUI.Blazor.Controls
         private string _messageContentRef;
         private RenderFragment<IgbChatMessageRenderContext> _messageContent;
 
-        partial void OnMessageContentChanging(ref RenderFragment<IgbChatMessageRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the main text and content of a message.
         /// </summary>
@@ -631,7 +610,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._messageContent;
-                OnMessageContentChanging(ref value);
                 if (oldValue != value || !IsPropDirty("MessageContent"))
                 {
                     MarkPropDirty("MessageContent");
@@ -680,7 +658,6 @@ namespace IgniteUI.Blazor.Controls
         private string _messageHeaderRef;
         private RenderFragment<IgbChatMessageRenderContext> _messageHeader;
 
-        partial void OnMessageHeaderChanging(ref RenderFragment<IgbChatMessageRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the header of a message, including sender and timestamp.
         /// </summary>
@@ -692,7 +669,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._messageHeader;
-                OnMessageHeaderChanging(ref value);
                 if (oldValue != value || !IsPropDirty("MessageHeader"))
                 {
                     MarkPropDirty("MessageHeader");
@@ -741,7 +717,6 @@ namespace IgniteUI.Blazor.Controls
         private string _sendButtonRef;
         private RenderFragment<IgbChatRenderContext> _sendButton;
 
-        partial void OnSendButtonChanging(ref RenderFragment<IgbChatRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the message send button.
         /// </summary>
@@ -753,7 +728,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._sendButton;
-                OnSendButtonChanging(ref value);
                 if (oldValue != value || !IsPropDirty("SendButton"))
                 {
                     MarkPropDirty("SendButton");
@@ -802,7 +776,6 @@ namespace IgniteUI.Blazor.Controls
         private string _suggestionPrefixRef;
         private RenderFragment<IgbChatRenderContext> _suggestionPrefix;
 
-        partial void OnSuggestionPrefixChanging(ref RenderFragment<IgbChatRenderContext> newValue);
         /// <summary>
         /// Custom renderer for the prefix text shown before suggestions.
         /// </summary>
@@ -814,7 +787,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._suggestionPrefix;
-                OnSuggestionPrefixChanging(ref value);
                 if (oldValue != value || !IsPropDirty("SuggestionPrefix"))
                 {
                     MarkPropDirty("SuggestionPrefix");

--- a/src/components/Blazor/Checkbox.cs
+++ b/src/components/Blazor/Checkbox.cs
@@ -87,13 +87,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbCheckbox(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCheckbox(ser);
 
             if (IsPropDirty("Indeterminate"))
             { ser.AddBooleanProp("indeterminate", this._indeterminate); }

--- a/src/components/Blazor/Checkbox.cs
+++ b/src/components/Blazor/Checkbox.cs
@@ -66,26 +66,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCheckbox(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCheckbox(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/Checkbox.cs
+++ b/src/components/Blazor/Checkbox.cs
@@ -48,7 +48,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _indeterminate = false;
 
-        partial void OnIndeterminateChanging(ref bool newValue);
         /// <summary>
         /// Draws the checkbox in indeterminate state.
         /// </summary>

--- a/src/components/Blazor/CheckboxBase.cs
+++ b/src/components/Blazor/CheckboxBase.cs
@@ -619,13 +619,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingChecked(bool oldValue, ref bool newValue);
 
-        partial void SerializeCoreIgbCheckboxBase(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCheckboxBase(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddStringProp("value", this._value); }

--- a/src/components/Blazor/CheckboxBase.cs
+++ b/src/components/Blazor/CheckboxBase.cs
@@ -184,25 +184,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCheckboxBase(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCheckboxBase(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CheckboxBase.cs
+++ b/src/components/Blazor/CheckboxBase.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The value of the control.
         /// </summary>
@@ -73,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _checked = false;
 
-        partial void OnCheckedChanging(ref bool newValue);
         /// <summary>
         /// The checked state of the control.
         /// </summary>
@@ -111,7 +109,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ToggleLabelPosition _labelPosition = ToggleLabelPosition.After;
 
-        partial void OnLabelPositionChanging(ref ToggleLabelPosition newValue);
         /// <summary>
         /// The label position of the control.
         /// </summary>
@@ -131,7 +128,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -151,7 +147,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a required field in a form context.
         /// </summary>
@@ -171,7 +166,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/CheckboxBase.cs
+++ b/src/components/Blazor/CheckboxBase.cs
@@ -411,8 +411,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueChecked = (bool)(args.Detail.Checked);
-                                ;
-                                OnEventUpdatingChecked(this._checked, ref newValueChecked);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -616,8 +614,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingChecked(bool oldValue, ref bool newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/CheckboxBase.cs
+++ b/src/components/Blazor/CheckboxBase.cs
@@ -358,7 +358,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbCheckboxChangeEventArgs args);
         private EventCallback<IgbCheckboxChangeEventArgs>? _change = null;
 
         /// <summary>
@@ -380,8 +379,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbCheckboxChangeEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueChecked = default(bool);
 
                             {
@@ -468,7 +465,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _focus = null;
 
         /// <summary>
@@ -488,11 +484,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _focus, ref eventCallbacksCache))
                     {
                         _focus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value, (args) =>
-                        {
-                            OnHandlingFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value);
                         this.OnRefChanged("Focus", null, "nativeEvent:::Focus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._focusRef = refName;
@@ -545,7 +537,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _blur = null;
 
         /// <summary>
@@ -565,11 +556,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _blur, ref eventCallbacksCache))
                     {
                         _blur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value, (args) =>
-                        {
-                            OnHandlingBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value);
                         this.OnRefChanged("Blur", null, "nativeEvent:::Blur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._blurRef = refName;

--- a/src/components/Blazor/CheckboxChangeEventArgs.cs
+++ b/src/components/Blazor/CheckboxChangeEventArgs.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbCheckboxChangeEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCheckboxChangeEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/CheckboxChangeEventArgs.cs
+++ b/src/components/Blazor/CheckboxChangeEventArgs.cs
@@ -14,7 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbCheckboxChangeEventArgsDetail _detail;
 
-        partial void OnDetailChanging(ref IgbCheckboxChangeEventArgsDetail newValue);
         /// <summary>
         /// The payload of the event, carrying the new checked state and the value of the control.
         /// </summary>
@@ -24,7 +23,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/CheckboxChangeEventArgs.cs
+++ b/src/components/Blazor/CheckboxChangeEventArgs.cs
@@ -37,26 +37,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameCheckboxChangeEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCheckboxChangeEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/CheckboxChangeEventArgsDetail.cs
+++ b/src/components/Blazor/CheckboxChangeEventArgsDetail.cs
@@ -13,7 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _checked = false;
 
-        partial void OnCheckedChanging(ref bool newValue);
         /// <summary>
         /// The checked state of the control after the change.
         /// </summary>
@@ -33,7 +32,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The value of the control.
         /// </summary>

--- a/src/components/Blazor/CheckboxChangeEventArgsDetail.cs
+++ b/src/components/Blazor/CheckboxChangeEventArgsDetail.cs
@@ -80,13 +80,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCheckboxChangeEventArgsDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCheckboxChangeEventArgsDetail(ser);
 
             if (IsPropDirty("Checked"))
             { ser.AddBooleanProp("checked", this._checked); }

--- a/src/components/Blazor/CheckboxChangeEventArgsDetail.cs
+++ b/src/components/Blazor/CheckboxChangeEventArgsDetail.cs
@@ -50,25 +50,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCheckboxChangeEventArgsDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCheckboxChangeEventArgsDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Chip.cs
+++ b/src/components/Blazor/Chip.cs
@@ -165,25 +165,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameChip(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameChip(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Chip.cs
+++ b/src/components/Blazor/Chip.cs
@@ -367,8 +367,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueSelected = (bool)(args.Detail);
-                                ;
-                                OnEventUpdatingSelected(this._selected, ref newValueSelected);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -418,8 +416,6 @@ namespace IgniteUI.Blazor.Controls
                 this._select = null;
             }
         }
-
-        partial void OnEventUpdatingSelected(bool oldValue, ref bool newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/Chip.cs
+++ b/src/components/Blazor/Chip.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Sets the disabled state for the chip.
         /// </summary>
@@ -73,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _removable = false;
 
-        partial void OnRemovableChanging(ref bool newValue);
         /// <summary>
         /// Defines if the chip is removable or not.
         /// </summary>
@@ -93,7 +91,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _selectable = false;
 
-        partial void OnSelectableChanging(ref bool newValue);
         /// <summary>
         /// Defines if the chip is selectable or not.
         /// </summary>
@@ -113,7 +110,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _selected = false;
 
-        partial void OnSelectedChanging(ref bool newValue);
         /// <summary>
         /// Defines if the chip is selected or not.
         /// </summary>
@@ -151,7 +147,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private StyleVariant _variant = StyleVariant.Primary;
 
-        partial void OnVariantChanging(ref StyleVariant newValue);
         /// <summary>
         /// A property that sets the color variant of the chip component.
         /// </summary>

--- a/src/components/Blazor/Chip.cs
+++ b/src/components/Blazor/Chip.cs
@@ -237,7 +237,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingRemove(IgbComponentBoolValueChangedEventArgs args);
         private EventCallback<IgbComponentBoolValueChangedEventArgs>? _remove = null;
 
         /// <summary>
@@ -257,11 +256,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _remove, ref eventCallbacksCache))
                     {
                         _remove = value;
-                        this.SetHandler<IgbComponentBoolValueChangedEventArgs>(this.Name, "Remove", value, (args) =>
-                        {
-                            OnHandlingRemove(args);
-
-                        });
+                        this.SetHandler<IgbComponentBoolValueChangedEventArgs>(this.Name, "Remove", value);
                         this.OnRefChanged("Remove", null, "event:::Remove", true, false, (refName, oldValue, newValue) =>
                         {
                             this._removeRef = refName;
@@ -314,7 +309,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingSelect(IgbComponentBoolValueChangedEventArgs args);
         private EventCallback<IgbComponentBoolValueChangedEventArgs>? _select = null;
 
         /// <summary>
@@ -337,8 +331,6 @@ namespace IgniteUI.Blazor.Controls
                         _select = value;
                         this.SetHandler<IgbComponentBoolValueChangedEventArgs>(this.Name, "Select", value, (args) =>
                         {
-                            OnHandlingSelect(args);
-
                             var newValueSelected = default(bool);
 
                             {

--- a/src/components/Blazor/Chip.cs
+++ b/src/components/Blazor/Chip.cs
@@ -421,13 +421,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingSelected(bool oldValue, ref bool newValue);
 
-        partial void SerializeCoreIgbChip(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbChip(ser);
 
             if (IsPropDirty("Disabled"))
             { ser.AddBooleanProp("disabled", this._disabled); }

--- a/src/components/Blazor/CircularGradient.cs
+++ b/src/components/Blazor/CircularGradient.cs
@@ -144,13 +144,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCircularGradient(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCircularGradient(ser);
 
             if (IsPropDirty("Offset"))
             { ser.AddStringProp("offset", this._offset); }

--- a/src/components/Blazor/CircularGradient.cs
+++ b/src/components/Blazor/CircularGradient.cs
@@ -57,7 +57,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _offset;
 
-        partial void OnOffsetChanging(ref string newValue);
         /// <summary>
         /// Defines where the gradient stop is placed along the gradient vector.
         /// </summary>
@@ -77,7 +76,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _color;
 
-        partial void OnColorChanging(ref string newValue);
         /// <summary>
         /// Defines the color of the gradient stop.
         /// </summary>
@@ -97,7 +95,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _opacity = 1;
 
-        partial void OnOpacityChanging(ref double newValue);
         /// <summary>
         /// Defines the opacity of the gradient stop.
         /// </summary>

--- a/src/components/Blazor/CircularGradient.cs
+++ b/src/components/Blazor/CircularGradient.cs
@@ -113,25 +113,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCircularGradient(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCircularGradient(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CircularProgress.cs
+++ b/src/components/Blazor/CircularProgress.cs
@@ -45,25 +45,5 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCircularProgress(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCircularProgress(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
     }
 }

--- a/src/components/Blazor/CircularProgress.cs
+++ b/src/components/Blazor/CircularProgress.cs
@@ -65,15 +65,5 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbCircularProgress(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbCircularProgress(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/Combo.cs
+++ b/src/components/Blazor/Combo.cs
@@ -636,25 +636,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameCombo(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCombo(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         /// <summary>
         /// Sets focus on the component.
         /// </summary>

--- a/src/components/Blazor/Combo.cs
+++ b/src/components/Blazor/Combo.cs
@@ -831,7 +831,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbComboChangeEventArgs args);
         private EventCallback<IgbComboChangeEventArgs>? _change = null;
 
         /// <summary>
@@ -853,8 +852,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbComboChangeEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(T[]);
 
                             {
@@ -941,7 +938,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _focus = null;
 
         /// <summary>
@@ -961,11 +957,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _focus, ref eventCallbacksCache))
                     {
                         _focus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value, (args) =>
-                        {
-                            OnHandlingFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value);
                         this.OnRefChanged("Focus", null, "nativeEvent:::Focus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._focusRef = refName;
@@ -1018,7 +1010,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _blur = null;
 
         /// <summary>
@@ -1038,11 +1029,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _blur, ref eventCallbacksCache))
                     {
                         _blur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value, (args) =>
-                        {
-                            OnHandlingBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value);
                         this.OnRefChanged("Blur", null, "nativeEvent:::Blur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._blurRef = refName;
@@ -1095,7 +1082,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpening(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opening = null;
 
         /// <summary>
@@ -1115,11 +1101,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opening, ref eventCallbacksCache))
                     {
                         _opening = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value, (args) =>
-                        {
-                            OnHandlingOpening(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value);
                         this.OnRefChanged("Opening", null, "event:::Opening", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openingRef = refName;
@@ -1172,7 +1154,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpened(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opened = null;
 
         /// <summary>
@@ -1192,11 +1173,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opened, ref eventCallbacksCache))
                     {
                         _opened = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value, (args) =>
-                        {
-                            OnHandlingOpened(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value);
                         this.OnRefChanged("Opened", null, "event:::Opened", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openedRef = refName;
@@ -1249,7 +1226,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -1269,11 +1245,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -1326,7 +1298,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -1346,11 +1317,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;

--- a/src/components/Blazor/Combo.cs
+++ b/src/components/Blazor/Combo.cs
@@ -1423,13 +1423,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(T[] oldValue, ref T[] newValue);
 
-        partial void SerializeCoreIgbCombo(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCombo(ser);
 
             if (IsPropDirty("DataRef"))
             { ser.AddStringProp("dataRef", this._dataRef); }

--- a/src/components/Blazor/Combo.cs
+++ b/src/components/Blazor/Combo.cs
@@ -907,8 +907,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (T[])(DowncastArray<T>(args.Detail.NewValue));
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -1420,8 +1418,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingValue(T[] oldValue, ref T[] newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/Combo.cs
+++ b/src/components/Blazor/Combo.cs
@@ -40,7 +40,6 @@ namespace IgniteUI.Blazor.Controls
         private string _dataRef;
         private Object _data;
 
-        partial void OnDataChanging(ref Object newValue);
         /// <summary>
         /// The data source used to generate the list of options.
         /// </summary>
@@ -52,7 +51,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._data;
-                OnDataChanging(ref value);
 
                 if (oldValue != value || !IsPropDirty("Data"))
                 {
@@ -92,7 +90,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _outlined = false;
 
-        partial void OnOutlinedChanging(ref bool newValue);
         /// <summary>
         /// Whether the control has an outlined appearance.
         /// </summary>
@@ -112,7 +109,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _singleSelect = false;
 
-        partial void OnSingleSelectChanging(ref bool newValue);
         /// <summary>
         /// Enables single selection mode and moves item filtering to the main input.
         /// </summary>
@@ -132,7 +128,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _autofocus = false;
 
-        partial void OnAutofocusChanging(ref bool newValue);
         /// <summary>
         /// The autofocus attribute of the control.
         /// </summary>
@@ -152,7 +147,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _autofocusList = false;
 
-        partial void OnAutofocusListChanging(ref bool newValue);
         /// <summary>
         /// Focuses the list of options when the menu opens.
         /// </summary>
@@ -172,7 +166,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _locale;
 
-        partial void OnLocaleChanging(ref string newValue);
         /// <summary>
         /// Gets/Sets the locale used for getting language, affecting resource strings.
         /// </summary>
@@ -192,7 +185,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The label of the control.
         /// </summary>
@@ -212,7 +204,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholder;
 
-        partial void OnPlaceholderChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the control.
         /// </summary>
@@ -232,7 +223,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholderSearch;
 
-        partial void OnPlaceholderSearchChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the search input.
         /// </summary>
@@ -252,7 +242,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _valueKey;
 
-        partial void OnValueKeyChanging(ref string? newValue);
         /// <summary>
         /// The key in the data source used when selecting items.
         /// </summary>
@@ -272,7 +261,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _displayKey;
 
-        partial void OnDisplayKeyChanging(ref string? newValue);
         /// <summary>
         /// The key in the data source used to display items in the list.
         /// </summary>
@@ -292,7 +280,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _groupKey;
 
-        partial void OnGroupKeyChanging(ref string newValue);
         /// <summary>
         /// The key in the data source used to group items in the list.
         /// </summary>
@@ -312,7 +299,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private GroupingDirection _groupSorting = GroupingDirection.Asc;
 
-        partial void OnGroupSortingChanging(ref GroupingDirection newValue);
         /// <summary>
         /// Sorts the items in each group by ascending or descending order.
         /// </summary>
@@ -332,7 +318,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbFilteringOptions _filteringOptions;
 
-        partial void OnFilteringOptionsChanging(ref IgbFilteringOptions newValue);
         /// <summary>
         /// An object that configures the filtering of the combo.
         /// </summary>
@@ -342,7 +327,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._filteringOptions; }
             set
             {
-                OnFilteringOptionsChanging(ref value);
                 MarkPropDirty("FilteringOptions");
                 if (this._filteringOptions != null)
                 {
@@ -358,7 +342,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _caseSensitiveIcon = false;
 
-        partial void OnCaseSensitiveIconChanging(ref bool newValue);
         /// <summary>
         /// Enables the case sensitive search icon in the filtering input.
         /// </summary>
@@ -378,7 +361,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableFiltering = false;
 
-        partial void OnDisableFilteringChanging(ref bool newValue);
         /// <summary>
         /// Disables the filtering of the list of options.
         /// </summary>
@@ -398,7 +380,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableClear = false;
 
-        partial void OnDisableClearChanging(ref bool newValue);
         /// <summary>
         /// Hides the clear button.
         /// </summary>
@@ -418,7 +399,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private T[] _value;
 
-        partial void OnValueChanging(ref T[] newValue);
         /// <summary>
         /// The value of the control, that is the currently selected items.
         /// If the data source is an array of complex objects, <see cref="ValueKey"/> must be set.
@@ -482,7 +462,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -502,7 +481,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a required field in a form context.
         /// </summary>
@@ -522,7 +500,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>
@@ -543,8 +520,6 @@ namespace IgniteUI.Blazor.Controls
         private string _itemTemplateRef;
         private RenderFragment<object> _itemTemplate;
 
-        partial void OnItemTemplateChanging(ref RenderFragment<object> newValue);
-
         /// <summary>
         /// The template used for the content of each combo item.
         /// </summary>
@@ -556,7 +531,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._itemTemplate;
-                OnItemTemplateChanging(ref value);
                 if (oldValue != value || !IsPropDirty("ItemTemplate"))
                 {
                     MarkPropDirty("ItemTemplate");
@@ -605,8 +579,6 @@ namespace IgniteUI.Blazor.Controls
         private string _groupHeaderTemplateRef;
         private RenderFragment<object> _groupHeaderTemplate;
 
-        partial void OnGroupHeaderTemplateChanging(ref RenderFragment<object> newValue);
-
         /// <summary>
         /// The template used for the content of each combo group header.
         /// </summary>
@@ -618,7 +590,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._groupHeaderTemplate;
-                OnGroupHeaderTemplateChanging(ref value);
                 if (oldValue != value || !IsPropDirty("GroupHeaderTemplate"))
                 {
                     MarkPropDirty("GroupHeaderTemplate");

--- a/src/components/Blazor/ComboBoxBaseLike.cs
+++ b/src/components/Blazor/ComboBoxBaseLike.cs
@@ -76,13 +76,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbComboBoxBaseLike(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbComboBoxBaseLike(ser);
 
             if (IsPropDirty("KeepOpenOnSelect"))
             { ser.AddBooleanProp("keepOpenOnSelect", this._keepOpenOnSelect); }

--- a/src/components/Blazor/ComboBoxBaseLike.cs
+++ b/src/components/Blazor/ComboBoxBaseLike.cs
@@ -17,7 +17,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _keepOpenOnSelect = false;
 
-        partial void OnKeepOpenOnSelectChanging(ref bool newValue);
         /// <summary>
         /// Whether the component dropdown should be kept open on selection.
         /// </summary>
@@ -37,7 +36,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _keepOpenOnOutsideClick = false;
 
-        partial void OnKeepOpenOnOutsideClickChanging(ref bool newValue);
         /// <summary>
         /// Whether the component dropdown should be kept open on clicking outside of it.
         /// </summary>

--- a/src/components/Blazor/ComboBoxBaseLike.cs
+++ b/src/components/Blazor/ComboBoxBaseLike.cs
@@ -54,26 +54,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameComboBoxBaseLike(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameComboBoxBaseLike(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ComboChangeEventArgs.cs
+++ b/src/components/Blazor/ComboChangeEventArgs.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbComboChangeEventArgsDetail _detail;
 
-        partial void OnDetailChanging(ref IgbComboChangeEventArgsDetail newValue);
-
         /// <summary>
         /// Describes the selection change: the new value, the items it affected and the kind of change.
         /// </summary>
@@ -24,7 +22,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/ComboChangeEventArgs.cs
+++ b/src/components/Blazor/ComboChangeEventArgs.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbComboChangeEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbComboChangeEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/ComboChangeEventArgs.cs
+++ b/src/components/Blazor/ComboChangeEventArgs.cs
@@ -36,26 +36,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameComboChangeEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameComboChangeEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ComboChangeEventArgsDetail.cs
+++ b/src/components/Blazor/ComboChangeEventArgsDetail.cs
@@ -122,25 +122,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameComboChangeEventArgsDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameComboChangeEventArgsDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ComboChangeEventArgsDetail.cs
+++ b/src/components/Blazor/ComboChangeEventArgsDetail.cs
@@ -155,13 +155,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbComboChangeEventArgsDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbComboChangeEventArgsDetail(ser);
 
             if (IsPropDirty("NewValue"))
             { ser.AddArrayProp("newValue", this._newValue); }

--- a/src/components/Blazor/ComboChangeEventArgsDetail.cs
+++ b/src/components/Blazor/ComboChangeEventArgsDetail.cs
@@ -11,7 +11,6 @@ namespace IgniteUI.Blazor.Controls
         private string _newValueRef;
         private object[] _newValue;
 
-        partial void OnNewValueChanging(ref object[] newValue);
         [Parameter]
         public object[] NewValue
         {
@@ -20,7 +19,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._newValue;
-                OnNewValueChanging(ref value);
 
                 if (oldValue != value || !IsPropDirty("NewValue"))
                 {
@@ -61,7 +59,6 @@ namespace IgniteUI.Blazor.Controls
         private string _itemsRef;
         private object[] _items;
 
-        partial void OnItemsChanging(ref object[] newValue);
         [Parameter]
         public object[] Items
         {
@@ -70,7 +67,6 @@ namespace IgniteUI.Blazor.Controls
             set
             {
                 var oldValue = this._items;
-                OnItemsChanging(ref value);
 
                 if (oldValue != value || !IsPropDirty("Items"))
                 {
@@ -110,7 +106,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ComboChangeType _changeType = ComboChangeType.Selection;
 
-        partial void OnChangeTypeChanging(ref ComboChangeType newValue);
         [Parameter]
         [WCWidgetMemberName("Type")]
         public ComboChangeType ChangeType

--- a/src/components/Blazor/ComponentBoolValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentBoolValueChangedEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _detail = false;
 
-        partial void OnDetailChanging(ref bool newValue);
-
         /// <summary>
         /// The Boolean value carried by the event.
         /// </summary>

--- a/src/components/Blazor/ComponentBoolValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentBoolValueChangedEventArgs.cs
@@ -32,26 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameComponentBoolValueChangedEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameComponentBoolValueChangedEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ComponentBoolValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentBoolValueChangedEventArgs.cs
@@ -54,13 +54,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbComponentBoolValueChangedEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbComponentBoolValueChangedEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddBooleanProp("detail", this._detail); }

--- a/src/components/Blazor/ComponentDataValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentDataValueChangedEventArgs.cs
@@ -30,26 +30,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameComponentDataValueChangedEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameComponentDataValueChangedEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ComponentDataValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentDataValueChangedEventArgs.cs
@@ -12,8 +12,6 @@ namespace IgniteUI.Blazor.Controls
 
         private object _detail;
 
-        partial void OnDetailChanging(ref object newValue);
-
         /// <summary>
         /// The value carried by the event.
         /// </summary>

--- a/src/components/Blazor/ComponentDataValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentDataValueChangedEventArgs.cs
@@ -52,13 +52,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbComponentDataValueChangedEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbComponentDataValueChangedEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddPrimitiveProp("detail", this._detail); }

--- a/src/components/Blazor/ComponentDateValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentDateValueChangedEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private DateTime _detail = DateTime.MinValue;
 
-        partial void OnDetailChanging(ref DateTime newValue);
-
         /// <summary>
         /// The date value carried by the event.
         /// </summary>

--- a/src/components/Blazor/ComponentDateValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentDateValueChangedEventArgs.cs
@@ -32,26 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameComponentDateValueChangedEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameComponentDateValueChangedEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ComponentDateValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentDateValueChangedEventArgs.cs
@@ -54,13 +54,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbComponentDateValueChangedEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbComponentDateValueChangedEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddDateTimeProp("detail", this._detail); }

--- a/src/components/Blazor/ComponentValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentValueChangedEventArgs.cs
@@ -54,13 +54,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbComponentValueChangedEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbComponentValueChangedEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddStringProp("detail", this._detail); }

--- a/src/components/Blazor/ComponentValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentValueChangedEventArgs.cs
@@ -32,26 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameComponentValueChangedEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameComponentValueChangedEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ComponentValueChangedEventArgs.cs
+++ b/src/components/Blazor/ComponentValueChangedEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _detail;
 
-        partial void OnDetailChanging(ref string newValue);
-
         /// <summary>
         /// The string value carried by the event.
         /// </summary>

--- a/src/components/Blazor/CustomDateRange.cs
+++ b/src/components/Blazor/CustomDateRange.cs
@@ -53,25 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameCustomDateRange(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameCustomDateRange(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/CustomDateRange.cs
+++ b/src/components/Blazor/CustomDateRange.cs
@@ -11,8 +11,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
-
         /// <summary>
         /// The text rendered in the chip for this range.
         /// </summary>
@@ -32,8 +30,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDateRangeValue _dateRange;
 
-        partial void OnDateRangeChanging(ref IgbDateRangeValue newValue);
-
         /// <summary>
         /// The date range applied when the chip is selected.
         /// </summary>
@@ -43,7 +39,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._dateRange; }
             set
             {
-                OnDateRangeChanging(ref value);
                 MarkPropDirty("DateRange");
                 if (this._dateRange != null)
                 {

--- a/src/components/Blazor/CustomDateRange.cs
+++ b/src/components/Blazor/CustomDateRange.cs
@@ -86,13 +86,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbCustomDateRange(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbCustomDateRange(ser);
 
             if (IsPropDirty("Label"))
             { ser.AddStringProp("label", this._label); }

--- a/src/components/Blazor/DatePartDeltas.cs
+++ b/src/components/Blazor/DatePartDeltas.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _date = 0;
 
-        partial void OnDateChanging(ref double newValue);
-
         /// <summary>
         /// The number of days the date part is spun by.
         /// </summary>
@@ -33,8 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private double _month = 0;
-
-        partial void OnMonthChanging(ref double newValue);
 
         /// <summary>
         /// The number of months the month part is spun by.
@@ -55,8 +51,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _year = 0;
 
-        partial void OnYearChanging(ref double newValue);
-
         /// <summary>
         /// The number of years the year part is spun by.
         /// </summary>
@@ -75,8 +69,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private double _hours = 0;
-
-        partial void OnHoursChanging(ref double newValue);
 
         /// <summary>
         /// The number of hours the hours part is spun by.
@@ -97,8 +89,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _minutes = 0;
 
-        partial void OnMinutesChanging(ref double newValue);
-
         /// <summary>
         /// The number of minutes the minutes part is spun by.
         /// </summary>
@@ -117,8 +107,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private double _seconds = 0;
-
-        partial void OnSecondsChanging(ref double newValue);
 
         /// <summary>
         /// The number of seconds the seconds part is spun by.

--- a/src/components/Blazor/DatePartDeltas.cs
+++ b/src/components/Blazor/DatePartDeltas.cs
@@ -126,26 +126,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDatePartDeltas(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDatePartDeltas(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/DatePartDeltas.cs
+++ b/src/components/Blazor/DatePartDeltas.cs
@@ -158,13 +158,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbDatePartDeltas(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDatePartDeltas(ser);
 
             if (IsPropDirty("Date"))
             { ser.AddNumberProp("date", this._date); }

--- a/src/components/Blazor/DatePicker.cs
+++ b/src/components/Blazor/DatePicker.cs
@@ -749,7 +749,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpening(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opening = null;
 
         /// <summary>
@@ -769,11 +768,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opening, ref eventCallbacksCache))
                     {
                         _opening = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value, (args) =>
-                        {
-                            OnHandlingOpening(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value);
                         this.OnRefChanged("Opening", null, "event:::Opening", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openingRef = refName;
@@ -826,7 +821,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpened(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opened = null;
 
         /// <summary>
@@ -846,11 +840,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opened, ref eventCallbacksCache))
                     {
                         _opened = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value, (args) =>
-                        {
-                            OnHandlingOpened(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value);
                         this.OnRefChanged("Opened", null, "event:::Opened", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openedRef = refName;
@@ -903,7 +893,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -923,11 +912,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -980,7 +965,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -1000,11 +984,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;
@@ -1057,7 +1037,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbComponentDateValueChangedEventArgs args);
         private EventCallback<IgbComponentDateValueChangedEventArgs>? _change = null;
 
         /// <summary>
@@ -1079,8 +1058,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbComponentDateValueChangedEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(DateTime?);
 
                             {
@@ -1167,7 +1144,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInput(IgbComponentDateValueChangedEventArgs args);
         private EventCallback<IgbComponentDateValueChangedEventArgs>? _input = null;
 
         /// <summary>
@@ -1187,11 +1163,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _input, ref eventCallbacksCache))
                     {
                         _input = value;
-                        this.SetHandler<IgbComponentDateValueChangedEventArgs>(this.Name, "Input", value, (args) =>
-                        {
-                            OnHandlingInput(args);
-
-                        });
+                        this.SetHandler<IgbComponentDateValueChangedEventArgs>(this.Name, "Input", value);
                         this.OnRefChanged("Input", null, "event:::Input", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputRef = refName;

--- a/src/components/Blazor/DatePicker.cs
+++ b/src/components/Blazor/DatePicker.cs
@@ -1263,13 +1263,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(DateTime? oldValue, ref DateTime? newValue);
 
-        partial void SerializeCoreIgbDatePicker(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDatePicker(ser);
 
             if (IsPropDirty("Label"))
             { ser.AddStringProp("label", this._label); }

--- a/src/components/Blazor/DatePicker.cs
+++ b/src/components/Blazor/DatePicker.cs
@@ -33,7 +33,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The label of the datepicker.
         /// </summary>
@@ -53,7 +52,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private PickerMode _mode = PickerMode.Dropdown;
 
-        partial void OnModeChanging(ref PickerMode newValue);
         /// <summary>
         /// Determines whether the calendar is opened in a dropdown or a modal dialog.
         /// </summary>
@@ -73,7 +71,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _nonEditable = false;
 
-        partial void OnNonEditableChanging(ref bool newValue);
         /// <summary>
         /// Whether to allow typing in the input.
         /// </summary>
@@ -93,7 +90,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _readOnly = false;
 
-        partial void OnReadOnlyChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a readonly field.
         /// </summary>
@@ -114,7 +110,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime? _value = DateTime.MinValue;
 
-        partial void OnValueChanging(ref DateTime? newValue);
         /// <summary>
         /// The value of the picker.
         /// </summary>
@@ -152,7 +147,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime _activeDate = DateTime.MinValue;
 
-        partial void OnActiveDateChanging(ref DateTime newValue);
         /// <summary>
         /// Gets/Sets the date which is shown in the calendar picker and is highlighted.
         /// By default it is the current date.
@@ -173,7 +167,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime? _min = DateTime.MinValue;
 
-        partial void OnMinChanging(ref DateTime? newValue);
         /// <summary>
         /// The minimum value required for the date picker to remain valid.
         /// </summary>
@@ -193,7 +186,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime? _max = DateTime.MinValue;
 
-        partial void OnMaxChanging(ref DateTime? newValue);
         /// <summary>
         /// The maximum value required for the date picker to remain valid.
         /// </summary>
@@ -213,7 +205,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private CalendarHeaderOrientation _headerOrientation = CalendarHeaderOrientation.Horizontal;
 
-        partial void OnHeaderOrientationChanging(ref CalendarHeaderOrientation newValue);
         /// <summary>
         /// The orientation of the calendar header.
         /// </summary>
@@ -233,7 +224,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ContentOrientation _orientation = ContentOrientation.Horizontal;
 
-        partial void OnOrientationChanging(ref ContentOrientation newValue);
         /// <summary>
         /// The orientation of the multiple months displayed in the calendar's days view.
         /// </summary>
@@ -253,7 +243,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideHeader = false;
 
-        partial void OnHideHeaderChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the calendar hides its header.
         /// </summary>
@@ -273,7 +262,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideOutsideDays = false;
 
-        partial void OnHideOutsideDaysChanging(ref bool newValue);
         /// <summary>
         /// Controls the visibility of the dates that do not belong to the current month.
         /// </summary>
@@ -293,7 +281,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDateRangeDescriptor[] _disabledDates;
 
-        partial void OnDisabledDatesChanging(ref IgbDateRangeDescriptor[] newValue);
         /// <summary>
         /// Gets/sets disabled dates.
         /// </summary>
@@ -313,7 +300,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDateRangeDescriptor[] _specialDates;
 
-        partial void OnSpecialDatesChanging(ref IgbDateRangeDescriptor[] newValue);
         /// <summary>
         /// Gets/sets special dates.
         /// </summary>
@@ -333,7 +319,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _outlined = false;
 
-        partial void OnOutlinedChanging(ref bool newValue);
         /// <summary>
         /// Whether the control will have outlined appearance.
         /// </summary>
@@ -353,7 +338,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholder;
 
-        partial void OnPlaceholderChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the control.
         /// </summary>
@@ -373,7 +357,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _visibleMonths = 1;
 
-        partial void OnVisibleMonthsChanging(ref double newValue);
         /// <summary>
         /// The number of months displayed in the calendar.
         /// </summary>
@@ -393,7 +376,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _showWeekNumbers = false;
 
-        partial void OnShowWeekNumbersChanging(ref bool newValue);
         /// <summary>
         /// Whether to show the number of the week in the calendar.
         /// </summary>
@@ -413,7 +395,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _displayFormat;
 
-        partial void OnDisplayFormatChanging(ref string newValue);
         /// <summary>
         /// Format to display the value in when not editing.
         /// Defaults to the locale format if not set.
@@ -434,7 +415,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _inputFormat;
 
-        partial void OnInputFormatChanging(ref string newValue);
         /// <summary>
         /// The date format to apply on the input.
         /// Defaults to the current locale of the client <c>Intl.DateTimeFormat</c>
@@ -455,7 +435,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _prompt;
 
-        partial void OnPromptChanging(ref string newValue);
         /// <summary>
         /// The prompt symbol to use for unfilled parts of the mask.
         /// </summary>
@@ -475,7 +454,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _locale;
 
-        partial void OnLocaleChanging(ref string newValue);
         /// <summary>
         /// Gets/Sets the locale used for formatting the display value.
         /// </summary>
@@ -495,7 +473,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbCalendarResourceStrings _resourceStrings;
 
-        partial void OnResourceStringsChanging(ref IgbCalendarResourceStrings newValue);
         /// <summary>
         /// The resource strings for localization.
         /// </summary>
@@ -505,7 +482,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._resourceStrings; }
             set
             {
-                OnResourceStringsChanging(ref value);
                 MarkPropDirty("ResourceStrings");
                 if (this._resourceStrings != null)
                 {
@@ -521,7 +497,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private WeekDays _weekStart = WeekDays.Sunday;
 
-        partial void OnWeekStartChanging(ref WeekDays newValue);
         /// <summary>
         /// Sets the start day of the week for the calendar.
         /// </summary>
@@ -541,7 +516,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -561,7 +535,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a required field in a form context.
         /// </summary>
@@ -581,7 +554,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/DatePicker.cs
+++ b/src/components/Blazor/DatePicker.cs
@@ -572,25 +572,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDatePicker(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDatePicker(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         /// <summary>
         /// Clears the input part of the component of any user input.
         /// </summary>

--- a/src/components/Blazor/DatePicker.cs
+++ b/src/components/Blazor/DatePicker.cs
@@ -1132,8 +1132,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (DateTime?)(args.Detail);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -1260,8 +1258,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingValue(DateTime? oldValue, ref DateTime? newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/DateRangeDescriptor.cs
+++ b/src/components/Blazor/DateRangeDescriptor.cs
@@ -53,26 +53,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDateRangeDescriptor(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDateRangeDescriptor(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/DateRangeDescriptor.cs
+++ b/src/components/Blazor/DateRangeDescriptor.cs
@@ -77,13 +77,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbDateRangeDescriptor(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDateRangeDescriptor(ser);
 
             if (IsPropDirty("RangeType"))
             { ser.AddEnumProp("rangeType", this._rangeType); }

--- a/src/components/Blazor/DateRangeDescriptor.cs
+++ b/src/components/Blazor/DateRangeDescriptor.cs
@@ -11,8 +11,6 @@ namespace IgniteUI.Blazor.Controls
 
         private DateRangeType _rangeType = DateRangeType.After;
 
-        partial void OnRangeTypeChanging(ref DateRangeType newValue);
-
         /// <summary>
         /// The kind of range being described, which determines how <see cref="DateRange"/> is matched.
         /// </summary>
@@ -32,8 +30,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private object _dateRange;
-
-        partial void OnDateRangeChanging(ref object newValue);
 
         /// <summary>
         /// The date or dates the descriptor applies to, interpreted according to <see cref="RangeType"/>.

--- a/src/components/Blazor/DateRangePicker.cs
+++ b/src/components/Blazor/DateRangePicker.cs
@@ -1406,13 +1406,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(IgbDateRangeValue? oldValue, ref IgbDateRangeValue? newValue);
 
-        partial void SerializeCoreIgbDateRangePicker(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDateRangePicker(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddSerializableProp("value", this._value); }

--- a/src/components/Blazor/DateRangePicker.cs
+++ b/src/components/Blazor/DateRangePicker.cs
@@ -733,25 +733,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDateRangePicker(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDateRangePicker(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         /// <summary>
         /// Clears the input parts of the component of any user input.
         /// </summary>

--- a/src/components/Blazor/DateRangePicker.cs
+++ b/src/components/Blazor/DateRangePicker.cs
@@ -34,7 +34,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbDateRangeValue? _value;
 
-        partial void OnValueChanging(ref IgbDateRangeValue? newValue);
         /// <summary>
         /// The value of the picker.
         /// </summary>
@@ -44,7 +43,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._value; }
             set
             {
-                OnValueChanging(ref value);
                 MarkPropDirty("Value");
                 if (this._value != null)
                 {
@@ -100,7 +98,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbCustomDateRange[] _customRanges;
 
-        partial void OnCustomRangesChanging(ref IgbCustomDateRange[] newValue);
         /// <summary>
         /// Renders chips with custom ranges based on the elements of the array.
         /// </summary>
@@ -120,7 +117,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private PickerMode _mode = PickerMode.Dropdown;
 
-        partial void OnModeChanging(ref PickerMode newValue);
         /// <summary>
         /// Determines whether the calendar is opened in a dropdown or a modal dialog.
         /// </summary>
@@ -140,7 +136,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _useTwoInputs = false;
 
-        partial void OnUseTwoInputsChanging(ref bool newValue);
         /// <summary>
         /// Use two inputs to display the date range values. Makes the input editable in dropdown mode.
         /// </summary>
@@ -160,7 +155,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _usePredefinedRanges = false;
 
-        partial void OnUsePredefinedRangesChanging(ref bool newValue);
         /// <summary>
         /// Whether the control will show chips with predefined ranges.
         /// </summary>
@@ -180,7 +174,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _locale;
 
-        partial void OnLocaleChanging(ref string newValue);
         /// <summary>
         /// The locale settings used to display the value.
         /// </summary>
@@ -200,7 +193,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDateRangePickerResourceStrings _resourceStrings;
 
-        partial void OnResourceStringsChanging(ref IgbDateRangePickerResourceStrings newValue);
         /// <summary>
         /// The resource strings of the date range picker.
         /// </summary>
@@ -210,7 +202,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._resourceStrings; }
             set
             {
-                OnResourceStringsChanging(ref value);
                 MarkPropDirty("ResourceStrings");
                 if (this._resourceStrings != null)
                 {
@@ -226,7 +217,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _readOnly = false;
 
-        partial void OnReadOnlyChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a readonly field.
         /// </summary>
@@ -247,7 +237,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _nonEditable = false;
 
-        partial void OnNonEditableChanging(ref bool newValue);
         /// <summary>
         /// Whether to allow typing in the input.
         /// </summary>
@@ -267,7 +256,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _outlined = false;
 
-        partial void OnOutlinedChanging(ref bool newValue);
         /// <summary>
         /// Whether the control will have outlined appearance.
         /// </summary>
@@ -287,7 +275,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The label of the control (single input).
         /// </summary>
@@ -307,7 +294,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _labelStart;
 
-        partial void OnLabelStartChanging(ref string newValue);
         /// <summary>
         /// The label of the start input.
         /// </summary>
@@ -327,7 +313,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _labelEnd;
 
-        partial void OnLabelEndChanging(ref string newValue);
         /// <summary>
         /// The label of the end input.
         /// </summary>
@@ -347,7 +332,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholder;
 
-        partial void OnPlaceholderChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the control (single input).
         /// </summary>
@@ -367,7 +351,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholderStart;
 
-        partial void OnPlaceholderStartChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the start input.
         /// </summary>
@@ -387,7 +370,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholderEnd;
 
-        partial void OnPlaceholderEndChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the end input.
         /// </summary>
@@ -407,7 +389,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _prompt;
 
-        partial void OnPromptChanging(ref string newValue);
         /// <summary>
         /// The prompt symbol to use for unfilled parts of the mask.
         /// </summary>
@@ -427,7 +408,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _displayFormat;
 
-        partial void OnDisplayFormatChanging(ref string newValue);
         /// <summary>
         /// Format to display the value in when not editing.
         /// Defaults to the locale format if not set.
@@ -448,7 +428,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _inputFormat;
 
-        partial void OnInputFormatChanging(ref string newValue);
         /// <summary>
         /// The date format to apply on the inputs.
         /// Defaults to the current locale of the client <c>Intl.DateTimeFormat</c>
@@ -469,7 +448,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime? _min = DateTime.MinValue;
 
-        partial void OnMinChanging(ref DateTime? newValue);
         /// <summary>
         /// The minimum value required for the date range picker to remain valid.
         /// </summary>
@@ -489,7 +467,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime? _max = DateTime.MinValue;
 
-        partial void OnMaxChanging(ref DateTime? newValue);
         /// <summary>
         /// The maximum value required for the date range picker to remain valid.
         /// </summary>
@@ -509,7 +486,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDateRangeDescriptor[] _disabledDates;
 
-        partial void OnDisabledDatesChanging(ref IgbDateRangeDescriptor[] newValue);
         /// <summary>
         /// Gets/sets disabled dates.
         /// </summary>
@@ -528,8 +504,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private double _visibleMonths = 2;
-
-        partial void OnVisibleMonthsChanging(ref double newValue);
 
         /// <summary>
         /// The number of months displayed in the calendar.
@@ -550,7 +524,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ContentOrientation _headerOrientation = ContentOrientation.Horizontal;
 
-        partial void OnHeaderOrientationChanging(ref ContentOrientation newValue);
         /// <summary>
         /// The orientation of the calendar header.
         /// </summary>
@@ -570,7 +543,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ContentOrientation _orientation = ContentOrientation.Horizontal;
 
-        partial void OnOrientationChanging(ref ContentOrientation newValue);
         /// <summary>
         /// The orientation of the multiple months displayed in the calendar's days view.
         /// </summary>
@@ -590,7 +562,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideHeader = false;
 
-        partial void OnHideHeaderChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the calendar hides its header.
         /// </summary>
@@ -610,7 +581,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime _activeDate = DateTime.MinValue;
 
-        partial void OnActiveDateChanging(ref DateTime newValue);
         /// <summary>
         /// Gets/Sets the date which is shown in the calendar picker and is highlighted.
         /// By default it is the current date.
@@ -631,7 +601,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _showWeekNumbers = false;
 
-        partial void OnShowWeekNumbersChanging(ref bool newValue);
         /// <summary>
         /// Whether to show the number of the week in the calendar.
         /// </summary>
@@ -651,7 +620,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideOutsideDays = false;
 
-        partial void OnHideOutsideDaysChanging(ref bool newValue);
         /// <summary>
         /// Controls the visibility of the dates that do not belong to the current month.
         /// </summary>
@@ -671,7 +639,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDateRangeDescriptor[] _specialDates;
 
-        partial void OnSpecialDatesChanging(ref IgbDateRangeDescriptor[] newValue);
         /// <summary>
         /// Gets/sets special dates.
         /// </summary>
@@ -691,7 +658,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private WeekDays _weekStart = WeekDays.Sunday;
 
-        partial void OnWeekStartChanging(ref WeekDays newValue);
         /// <summary>
         /// Sets the start day of the week for the calendar.
         /// </summary>
@@ -711,7 +677,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -731,7 +696,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a required field in a form context.
         /// </summary>
@@ -751,7 +715,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/DateRangePicker.cs
+++ b/src/components/Blazor/DateRangePicker.cs
@@ -878,7 +878,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpening(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opening = null;
 
         /// <summary>
@@ -898,11 +897,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opening, ref eventCallbacksCache))
                     {
                         _opening = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value, (args) =>
-                        {
-                            OnHandlingOpening(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value);
                         this.OnRefChanged("Opening", null, "event:::Opening", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openingRef = refName;
@@ -955,7 +950,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpened(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opened = null;
 
         /// <summary>
@@ -975,11 +969,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opened, ref eventCallbacksCache))
                     {
                         _opened = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value, (args) =>
-                        {
-                            OnHandlingOpened(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value);
                         this.OnRefChanged("Opened", null, "event:::Opened", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openedRef = refName;
@@ -1032,7 +1022,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -1052,11 +1041,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -1109,7 +1094,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -1129,11 +1113,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;
@@ -1186,7 +1166,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbDateRangeValueEventArgs args);
         private EventCallback<IgbDateRangeValueEventArgs>? _change = null;
 
         /// <summary>
@@ -1208,8 +1187,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbDateRangeValueEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(IgbDateRangeValue?);
 
                             {
@@ -1301,7 +1278,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInput(IgbDateRangeValueEventArgs args);
         private EventCallback<IgbDateRangeValueEventArgs>? _input = null;
 
         /// <summary>
@@ -1321,11 +1297,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _input, ref eventCallbacksCache))
                     {
                         _input = value;
-                        this.SetHandler<IgbDateRangeValueEventArgs>(this.Name, "Input", value, (args) =>
-                        {
-                            OnHandlingInput(args);
-
-                        });
+                        this.SetHandler<IgbDateRangeValueEventArgs>(this.Name, "Input", value);
                         this.OnRefChanged("Input", null, "event:::Input", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputRef = refName;

--- a/src/components/Blazor/DateRangePicker.cs
+++ b/src/components/Blazor/DateRangePicker.cs
@@ -1275,8 +1275,6 @@ namespace IgniteUI.Blazor.Controls
                                 {
                                     this.AttachChild(newValueValue);
                                 }
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -1403,8 +1401,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingValue(IgbDateRangeValue? oldValue, ref IgbDateRangeValue? newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/DateRangePickerResourceStrings.cs
+++ b/src/components/Blazor/DateRangePickerResourceStrings.cs
@@ -24,15 +24,5 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbDateRangePickerResourceStrings(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbDateRangePickerResourceStrings(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/DateRangePickerResourceStrings.cs
+++ b/src/components/Blazor/DateRangePickerResourceStrings.cs
@@ -4,25 +4,5 @@ namespace IgniteUI.Blazor.Controls
     {
         public override string Type { get { return "WebDateRangePickerResourceStrings"; } }
 
-        partial void FindByNameDateRangePickerResourceStrings(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDateRangePickerResourceStrings(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
     }
 }

--- a/src/components/Blazor/DateRangeValue.cs
+++ b/src/components/Blazor/DateRangeValue.cs
@@ -80,13 +80,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbDateRangeValue(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDateRangeValue(ser);
 
             if (IsPropDirty("Start"))
             { ser.AddDateTimeProp("start", this._start); }

--- a/src/components/Blazor/DateRangeValue.cs
+++ b/src/components/Blazor/DateRangeValue.cs
@@ -48,25 +48,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDateRangeValue(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDateRangeValue(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/DateRangeValue.cs
+++ b/src/components/Blazor/DateRangeValue.cs
@@ -11,8 +11,6 @@ namespace IgniteUI.Blazor.Controls
 
         private DateTime _start = DateTime.MinValue;
 
-        partial void OnStartChanging(ref DateTime newValue);
-
         /// <summary>
         /// The first date of the range.
         /// </summary>
@@ -31,8 +29,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private DateTime _end = DateTime.MinValue;
-
-        partial void OnEndChanging(ref DateTime newValue);
 
         /// <summary>
         /// The last date of the range.

--- a/src/components/Blazor/DateRangeValueDetail.cs
+++ b/src/components/Blazor/DateRangeValueDetail.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private DateTime _start = DateTime.MinValue;
 
-        partial void OnStartChanging(ref DateTime newValue);
-
         /// <summary>
         /// The first date of the range.
         /// </summary>
@@ -34,8 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private DateTime _end = DateTime.MinValue;
-
-        partial void OnEndChanging(ref DateTime newValue);
 
         /// <summary>
         /// The last date of the range.

--- a/src/components/Blazor/DateRangeValueDetail.cs
+++ b/src/components/Blazor/DateRangeValueDetail.cs
@@ -83,13 +83,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbDateRangeValueDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDateRangeValueDetail(ser);
 
             if (IsPropDirty("Start"))
             { ser.AddDateTimeProp("start", this._start); }

--- a/src/components/Blazor/DateRangeValueDetail.cs
+++ b/src/components/Blazor/DateRangeValueDetail.cs
@@ -51,25 +51,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDateRangeValueDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDateRangeValueDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/DateRangeValueEventArgs.cs
+++ b/src/components/Blazor/DateRangeValueEventArgs.cs
@@ -36,26 +36,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameDateRangeValueEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDateRangeValueEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/DateRangeValueEventArgs.cs
+++ b/src/components/Blazor/DateRangeValueEventArgs.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbDateRangeValueEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDateRangeValueEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/DateRangeValueEventArgs.cs
+++ b/src/components/Blazor/DateRangeValueEventArgs.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbDateRangeValueDetail _detail;
 
-        partial void OnDetailChanging(ref IgbDateRangeValueDetail newValue);
-
         /// <summary>
         /// The date range carried by the event.
         /// </summary>
@@ -24,7 +22,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/DateTimeInput.cs
+++ b/src/components/Blazor/DateTimeInput.cs
@@ -69,26 +69,6 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToDate(iv);
         }
 
-        partial void FindByNameDateTimeInput(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDateTimeInput(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         /// <summary>
         /// Increments a date/time portion.
         /// </summary>

--- a/src/components/Blazor/DateTimeInput.cs
+++ b/src/components/Blazor/DateTimeInput.cs
@@ -33,7 +33,6 @@ namespace IgniteUI.Blazor.Controls
 
         private DateTime? _value = DateTime.MinValue;
 
-        partial void OnValueChanging(ref DateTime? newValue);
         /// <summary>
         /// The value of the input.
         /// </summary>

--- a/src/components/Blazor/DateTimeInput.cs
+++ b/src/components/Blazor/DateTimeInput.cs
@@ -513,13 +513,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(DateTime? oldValue, ref DateTime? newValue);
 
-        partial void SerializeCoreIgbDateTimeInput(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDateTimeInput(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddDateTimeProp("value", this._value); }

--- a/src/components/Blazor/DateTimeInput.cs
+++ b/src/components/Blazor/DateTimeInput.cs
@@ -305,8 +305,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (DateTime?)(args.Detail);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -510,8 +508,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingValue(DateTime? oldValue, ref DateTime? newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/DateTimeInput.cs
+++ b/src/components/Blazor/DateTimeInput.cs
@@ -179,7 +179,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInputOcurred(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _inputOcurred = null;
 
         /// <summary>
@@ -199,11 +198,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _inputOcurred, ref eventCallbacksCache))
                     {
                         _inputOcurred = value;
-                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "InputOcurred", value, (args) =>
-                        {
-                            OnHandlingInputOcurred(args);
-
-                        });
+                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "InputOcurred", value);
                         this.OnRefChanged("InputOcurred", null, "event:::InputOcurred", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputOcurredRef = refName;
@@ -256,7 +251,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbComponentDateValueChangedEventArgs args);
         private EventCallback<IgbComponentDateValueChangedEventArgs>? _change = null;
 
         /// <summary>
@@ -278,8 +272,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbComponentDateValueChangedEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(DateTime?);
 
                             {
@@ -366,7 +358,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _focus = null;
 
         /// <summary>
@@ -386,11 +377,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _focus, ref eventCallbacksCache))
                     {
                         _focus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value, (args) =>
-                        {
-                            OnHandlingFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value);
                         this.OnRefChanged("Focus", null, "nativeEvent:::Focus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._focusRef = refName;
@@ -443,7 +430,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _blur = null;
 
         /// <summary>
@@ -463,11 +449,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _blur, ref eventCallbacksCache))
                     {
                         _blur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value, (args) =>
-                        {
-                            OnHandlingBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value);
                         this.OnRefChanged("Blur", null, "nativeEvent:::Blur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._blurRef = refName;

--- a/src/components/Blazor/DateTimeInputBase.cs
+++ b/src/components/Blazor/DateTimeInputBase.cs
@@ -555,13 +555,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setCustomValidity", new object[] { StringToString(message) }, new string[] { "String" });
         }
 
-        partial void SerializeCoreIgbDateTimeInputBase(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDateTimeInputBase(ser);
 
             if (IsPropDirty("Outlined"))
             { ser.AddBooleanProp("outlined", this._outlined); }

--- a/src/components/Blazor/DateTimeInputBase.cs
+++ b/src/components/Blazor/DateTimeInputBase.cs
@@ -340,25 +340,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDateTimeInputBase(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDateTimeInputBase(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/DateTimeInputBase.cs
+++ b/src/components/Blazor/DateTimeInputBase.cs
@@ -29,7 +29,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _outlined = false;
 
-        partial void OnOutlinedChanging(ref bool newValue);
         /// <summary>
         /// Whether the control will have outlined appearance.
         /// </summary>
@@ -49,7 +48,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholder;
 
-        partial void OnPlaceholderChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the control.
         /// </summary>
@@ -69,7 +67,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The label for the control.
         /// </summary>
@@ -88,8 +85,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _inputFormat;
-
-        partial void OnInputFormatChanging(ref string newValue);
 
         /// <summary>
         /// The date format to apply on the input.
@@ -110,7 +105,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime? _min = DateTime.MinValue;
 
-        partial void OnMinChanging(ref DateTime? newValue);
         /// <summary>
         /// The minimum value required for the input to remain valid.
         /// </summary>
@@ -130,7 +124,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DateTime? _max = DateTime.MinValue;
 
-        partial void OnMaxChanging(ref DateTime? newValue);
         /// <summary>
         /// The maximum value required for the input to remain valid.
         /// </summary>
@@ -150,7 +143,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _displayFormat;
 
-        partial void OnDisplayFormatChanging(ref string newValue);
         /// <summary>
         /// Format to display the value in when not editing.
         /// Defaults to the locale format if not set.
@@ -171,7 +163,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbDatePartDeltas _spinDelta;
 
-        partial void OnSpinDeltaChanging(ref IgbDatePartDeltas newValue);
         /// <summary>
         /// Delta values used to increment or decrement each date part on step actions.
         /// All values default to <c>1</c>.
@@ -182,7 +173,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._spinDelta; }
             set
             {
-                OnSpinDeltaChanging(ref value);
                 MarkPropDirty("SpinDelta");
                 if (this._spinDelta != null)
                 {
@@ -198,7 +188,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _spinLoop = true;
 
-        partial void OnSpinLoopChanging(ref bool newValue);
         /// <summary>
         /// Sets whether to loop over the currently spun segment.
         /// </summary>
@@ -218,7 +207,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _locale;
 
-        partial void OnLocaleChanging(ref string newValue);
         /// <summary>
         /// Gets/Sets the locale used for formatting the display value.
         /// </summary>
@@ -238,7 +226,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _readOnly = false;
 
-        partial void OnReadOnlyChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a readonly field.
         /// </summary>
@@ -258,7 +245,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _mask;
 
-        partial void OnMaskChanging(ref string newValue);
         /// <summary>
         /// The mask pattern of the component.
         /// </summary>
@@ -278,7 +264,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _prompt;
 
-        partial void OnPromptChanging(ref string newValue);
         /// <summary>
         /// The prompt symbol to use for unfilled parts of the mask pattern.
         /// Defaults to <c>_</c>.
@@ -299,7 +284,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -319,7 +303,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a required field in a form context.
         /// </summary>
@@ -339,7 +322,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/Dialog.cs
+++ b/src/components/Blazor/Dialog.cs
@@ -190,25 +190,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDialog(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDialog(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Dialog.cs
+++ b/src/components/Blazor/Dialog.cs
@@ -62,7 +62,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _keepOpenOnEscape = false;
 
-        partial void OnKeepOpenOnEscapeChanging(ref bool newValue);
         /// <summary>
         /// When set, pressing the <c>Escape</c> key will not close the dialog.
         /// By default the browser closes a modal dialog on <c>Escape</c>. Enable this
@@ -85,7 +84,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _closeOnOutsideClick = false;
 
-        partial void OnCloseOnOutsideClickChanging(ref bool newValue);
         /// <summary>
         /// When set, clicking on the backdrop area outside the dialog surface
         /// will close it (emitting close events).
@@ -107,7 +105,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideDefaultAction = false;
 
-        partial void OnHideDefaultActionChanging(ref bool newValue);
         /// <summary>
         /// When set, the built-in "OK" close button in the footer is not rendered.
         /// Has no effect when content is projected into the <c>footer</c> slot, since
@@ -129,7 +126,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _open = false;
 
-        partial void OnOpenChanging(ref bool newValue);
         /// <summary>
         /// Whether the dialog is open.
         /// Setting this property programmatically will open or close the dialog
@@ -153,7 +149,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _title;
 
-        partial void OnTitleChanging(ref string newValue);
         /// <summary>
         /// The title displayed in the dialog header.
         /// Overridden by any content projected into the <c>title</c> slot.
@@ -173,8 +168,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _returnValue;
-
-        partial void OnReturnValueChanging(ref string newValue);
 
         /// <summary>
         /// The return value of the dialog.

--- a/src/components/Blazor/Dialog.cs
+++ b/src/components/Blazor/Dialog.cs
@@ -294,7 +294,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -314,11 +313,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -371,7 +366,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -391,11 +385,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;

--- a/src/components/Blazor/Dialog.cs
+++ b/src/components/Blazor/Dialog.cs
@@ -442,13 +442,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbDialog(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDialog(ser);
 
             if (IsPropDirty("KeepOpenOnEscape"))
             { ser.AddBooleanProp("keepOpenOnEscape", this._keepOpenOnEscape); }

--- a/src/components/Blazor/Divider.cs
+++ b/src/components/Blazor/Divider.cs
@@ -111,25 +111,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDivider(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDivider(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Divider.cs
+++ b/src/components/Blazor/Divider.cs
@@ -142,13 +142,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbDivider(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDivider(ser);
 
             if (IsPropDirty("Vertical"))
             { ser.AddBooleanProp("vertical", this._vertical); }

--- a/src/components/Blazor/Divider.cs
+++ b/src/components/Blazor/Divider.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _vertical = false;
 
-        partial void OnVerticalChanging(ref bool newValue);
         /// <summary>
         /// Whether to render a vertical divider line.
         /// </summary>
@@ -74,7 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _middle = false;
 
-        partial void OnMiddleChanging(ref bool newValue);
         /// <summary>
         /// When set and inset is provided, it will shrink the divider line from both sides.
         /// </summary>
@@ -94,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private DividerType _lineType = DividerType.Solid;
 
-        partial void OnLineTypeChanging(ref DividerType newValue);
         /// <summary>
         /// Whether to render a solid or a dashed divider line.
         /// </summary>

--- a/src/components/Blazor/Dropdown.cs
+++ b/src/components/Blazor/Dropdown.cs
@@ -778,13 +778,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbDropdown(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDropdown(ser);
 
             if (IsPropDirty("Placement"))
             { ser.AddEnumProp("placement", this._placement); }

--- a/src/components/Blazor/Dropdown.cs
+++ b/src/components/Blazor/Dropdown.cs
@@ -419,7 +419,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpening(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opening = null;
 
         /// <summary>
@@ -439,11 +438,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opening, ref eventCallbacksCache))
                     {
                         _opening = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value, (args) =>
-                        {
-                            OnHandlingOpening(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value);
                         this.OnRefChanged("Opening", null, "event:::Opening", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openingRef = refName;
@@ -496,7 +491,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpened(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opened = null;
 
         /// <summary>
@@ -516,11 +510,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opened, ref eventCallbacksCache))
                     {
                         _opened = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value, (args) =>
-                        {
-                            OnHandlingOpened(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value);
                         this.OnRefChanged("Opened", null, "event:::Opened", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openedRef = refName;
@@ -573,7 +563,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -593,11 +582,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -650,7 +635,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -670,11 +654,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;
@@ -727,7 +707,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbDropdownItemComponentEventArgs args);
         private EventCallback<IgbDropdownItemComponentEventArgs>? _change = null;
 
         /// <summary>
@@ -747,11 +726,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _change, ref eventCallbacksCache))
                     {
                         _change = value;
-                        this.SetHandler<IgbDropdownItemComponentEventArgs>(this.Name, "Change", value, (args) =>
-                        {
-                            OnHandlingChange(args);
-
-                        });
+                        this.SetHandler<IgbDropdownItemComponentEventArgs>(this.Name, "Change", value);
                         this.OnRefChanged("Change", null, "event:::Change", true, false, (refName, oldValue, newValue) =>
                         {
                             this._changeRef = refName;

--- a/src/components/Blazor/Dropdown.cs
+++ b/src/components/Blazor/Dropdown.cs
@@ -48,7 +48,6 @@ namespace IgniteUI.Blazor.Controls
 
         private PopoverPlacement _placement = PopoverPlacement.BottomStart;
 
-        partial void OnPlacementChanging(ref PopoverPlacement newValue);
         /// <summary>
         /// The preferred placement of the component around the target element.
         /// </summary>
@@ -68,7 +67,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private PopoverScrollStrategy _scrollStrategy = PopoverScrollStrategy.Scroll;
 
-        partial void OnScrollStrategyChanging(ref PopoverScrollStrategy newValue);
         /// <summary>
         /// Determines the behavior of the component during scrolling of the parent container.
         /// </summary>
@@ -88,7 +86,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _flip = false;
 
-        partial void OnFlipChanging(ref bool newValue);
         /// <summary>
         /// Whether the component should be flipped to the opposite side of the target once it's about to overflow the visible area.
         /// When <see langword="true"/>, once enough space is detected on its preferred side, it will flip back.
@@ -109,7 +106,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _distance = 0;
 
-        partial void OnDistanceChanging(ref double newValue);
         /// <summary>
         /// The distance from the target element.
         /// </summary>
@@ -129,7 +125,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _sameWidth = false;
 
-        partial void OnSameWidthChanging(ref bool newValue);
         /// <summary>
         /// Whether the dropdown's width should be the same as the target's one.
         /// </summary>

--- a/src/components/Blazor/Dropdown.cs
+++ b/src/components/Blazor/Dropdown.cs
@@ -263,21 +263,20 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameDropdown(string name, ref object item);
         public override object FindByName(string name)
         {
-
             var baseResult = base.FindByName(name);
             if (baseResult != null)
             {
                 return baseResult;
             }
 
-            object item = null;
-            FindByNameDropdown(name, ref item);
-            if (item != null)
+            foreach (var item in ContentItems)
             {
-                return item;
+                if (item.Name == name || item.ContainerId == name)
+                {
+                    return item;
+                }
             }
 
             return null;

--- a/src/components/Blazor/DropdownGroup.cs
+++ b/src/components/Blazor/DropdownGroup.cs
@@ -77,15 +77,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbDropdownGroup(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbDropdownGroup(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/DropdownGroup.cs
+++ b/src/components/Blazor/DropdownGroup.cs
@@ -49,25 +49,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameDropdownGroup(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDropdownGroup(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/DropdownHeader.cs
+++ b/src/components/Blazor/DropdownHeader.cs
@@ -49,25 +49,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameDropdownHeader(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDropdownHeader(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/DropdownHeader.cs
+++ b/src/components/Blazor/DropdownHeader.cs
@@ -77,15 +77,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbDropdownHeader(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbDropdownHeader(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/DropdownItem.cs
+++ b/src/components/Blazor/DropdownItem.cs
@@ -44,25 +44,5 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDropdownItem(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDropdownItem(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
     }
 }

--- a/src/components/Blazor/DropdownItem.cs
+++ b/src/components/Blazor/DropdownItem.cs
@@ -64,15 +64,5 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbDropdownItem(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbDropdownItem(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/DropdownItemComponentEventArgs.cs
+++ b/src/components/Blazor/DropdownItemComponentEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbDropdownItem _detail;
 
-        partial void OnDetailChanging(ref IgbDropdownItem newValue);
-
         /// <summary>
         /// The dropdown item that became selected.
         /// </summary>

--- a/src/components/Blazor/DropdownItemComponentEventArgs.cs
+++ b/src/components/Blazor/DropdownItemComponentEventArgs.cs
@@ -54,13 +54,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbDropdownItemComponentEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbDropdownItemComponentEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/DropdownItemComponentEventArgs.cs
+++ b/src/components/Blazor/DropdownItemComponentEventArgs.cs
@@ -32,26 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDropdownItemComponentEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameDropdownItemComponentEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ExpansionPanel.cs
+++ b/src/components/Blazor/ExpansionPanel.cs
@@ -55,7 +55,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _open = false;
 
-        partial void OnOpenChanging(ref bool newValue);
         /// <summary>
         /// Indicates whether the contents of the control should be visible.
         /// </summary>
@@ -75,7 +74,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Whether the expansion panel is disabled.
         /// Disabled panels are ignored for user interactions.
@@ -96,7 +94,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ExpansionPanelIndicatorPosition _indicatorPosition = ExpansionPanelIndicatorPosition.Start;
 
-        partial void OnIndicatorPositionChanging(ref ExpansionPanelIndicatorPosition newValue);
         /// <summary>
         /// The indicator position of the expansion panel.
         /// </summary>

--- a/src/components/Blazor/ExpansionPanel.cs
+++ b/src/components/Blazor/ExpansionPanel.cs
@@ -112,25 +112,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameExpansionPanel(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameExpansionPanel(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ExpansionPanel.cs
+++ b/src/components/Blazor/ExpansionPanel.cs
@@ -512,13 +512,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbExpansionPanel(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbExpansionPanel(ser);
 
             if (IsPropDirty("Open"))
             { ser.AddBooleanProp("open", this._open); }

--- a/src/components/Blazor/ExpansionPanel.cs
+++ b/src/components/Blazor/ExpansionPanel.cs
@@ -214,7 +214,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpening(IgbExpansionPanelComponentEventArgs args);
         private EventCallback<IgbExpansionPanelComponentEventArgs>? _opening = null;
 
         /// <summary>
@@ -234,11 +233,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opening, ref eventCallbacksCache))
                     {
                         _opening = value;
-                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opening", value, (args) =>
-                        {
-                            OnHandlingOpening(args);
-
-                        });
+                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opening", value);
                         this.OnRefChanged("Opening", null, "event:::Opening", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openingRef = refName;
@@ -291,7 +286,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpened(IgbExpansionPanelComponentEventArgs args);
         private EventCallback<IgbExpansionPanelComponentEventArgs>? _opened = null;
 
         /// <summary>
@@ -311,11 +305,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opened, ref eventCallbacksCache))
                     {
                         _opened = value;
-                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opened", value, (args) =>
-                        {
-                            OnHandlingOpened(args);
-
-                        });
+                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opened", value);
                         this.OnRefChanged("Opened", null, "event:::Opened", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openedRef = refName;
@@ -368,7 +358,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbExpansionPanelComponentEventArgs args);
         private EventCallback<IgbExpansionPanelComponentEventArgs>? _closing = null;
 
         /// <summary>
@@ -388,11 +377,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -445,7 +430,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbExpansionPanelComponentEventArgs args);
         private EventCallback<IgbExpansionPanelComponentEventArgs>? _closed = null;
 
         /// <summary>
@@ -465,11 +449,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;

--- a/src/components/Blazor/ExpansionPanelComponentEventArgs.cs
+++ b/src/components/Blazor/ExpansionPanelComponentEventArgs.cs
@@ -56,13 +56,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbExpansionPanelComponentEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbExpansionPanelComponentEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/ExpansionPanelComponentEventArgs.cs
+++ b/src/components/Blazor/ExpansionPanelComponentEventArgs.cs
@@ -34,26 +34,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameExpansionPanelComponentEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameExpansionPanelComponentEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/ExpansionPanelComponentEventArgs.cs
+++ b/src/components/Blazor/ExpansionPanelComponentEventArgs.cs
@@ -16,8 +16,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbExpansionPanel _detail;
 
-        partial void OnDetailChanging(ref IgbExpansionPanel newValue);
-
         /// <summary>
         /// The expansion panel the event was raised for.
         /// </summary>

--- a/src/components/Blazor/FilteringOptions.cs
+++ b/src/components/Blazor/FilteringOptions.cs
@@ -98,13 +98,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbFilteringOptions(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbFilteringOptions(ser);
 
             if (IsPropDirty("FilterKey"))
             { ser.AddStringProp("filterKey", this._filterKey); }

--- a/src/components/Blazor/FilteringOptions.cs
+++ b/src/components/Blazor/FilteringOptions.cs
@@ -67,25 +67,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameFilteringOptions(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameFilteringOptions(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/FilteringOptions.cs
+++ b/src/components/Blazor/FilteringOptions.cs
@@ -11,7 +11,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _filterKey;
 
-        partial void OnFilterKeyChanging(ref string newValue);
         /// <summary>
         /// The key in the data source used when filtering the list of options.
         /// </summary>
@@ -31,7 +30,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _caseSensitive = false;
 
-        partial void OnCaseSensitiveChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the filtering operation should be case sensitive.
         /// </summary>
@@ -51,7 +49,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _matchDiacritics = false;
 
-        partial void OnMatchDiacriticsChanging(ref bool newValue);
         /// <summary>
         /// When <see langword="true"/>, the filter distinguishes between accented letters and their base letters.
         /// </summary>

--- a/src/components/Blazor/FocusOptions.cs
+++ b/src/components/Blazor/FocusOptions.cs
@@ -31,26 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameFocusOptions(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameFocusOptions(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/FocusOptions.cs
+++ b/src/components/Blazor/FocusOptions.cs
@@ -12,8 +12,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _preventScroll = false;
 
-        partial void OnPreventScrollChanging(ref bool newValue);
-
         /// <summary>
         /// Whether the browser should keep the current scroll position instead of scrolling the newly
         /// focused component into view. Defaults to <see langword="false"/>.

--- a/src/components/Blazor/FocusOptions.cs
+++ b/src/components/Blazor/FocusOptions.cs
@@ -53,13 +53,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbFocusOptions(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbFocusOptions(ser);
 
             if (IsPropDirty("PreventScroll"))
             { ser.AddBooleanProp("preventScroll", this._preventScroll); }

--- a/src/components/Blazor/FormatSpecifier.cs
+++ b/src/components/Blazor/FormatSpecifier.cs
@@ -18,25 +18,6 @@ namespace IgniteUI.Blazor.Controls
 
         private static bool _marshalByValue = true;
 
-        partial void FindByNameFormatSpecifier(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameFormatSpecifier(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         /// <summary>
         /// Gets the culture of the browser, expanded to a culture with a region when the browser
         /// reports a bare language code.

--- a/src/components/Blazor/FormatSpecifier.cs
+++ b/src/components/Blazor/FormatSpecifier.cs
@@ -58,16 +58,6 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToString(iv);
         }
 
-        partial void SerializeCoreIgbFormatSpecifier(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbFormatSpecifier(ser);
-
-        }
-
         protected internal override void ToEventJson(BaseRendererControl control, Dictionary<string, object> args)
         {
             base.ToEventJson(control, args);

--- a/src/components/Blazor/Highlight.cs
+++ b/src/components/Blazor/Highlight.cs
@@ -141,25 +141,6 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToDouble(iv);
         }
 
-        partial void FindByNameHighlight(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameHighlight(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Highlight.cs
+++ b/src/components/Blazor/Highlight.cs
@@ -57,7 +57,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _caseSensitive = false;
 
-        partial void OnCaseSensitiveChanging(ref bool newValue);
         /// <summary>
         /// Whether to match the searched text with case sensitivity in mind.
         /// When <see langword="true"/>, only exact-case occurrences of <see cref="SearchText"/> are highlighted.
@@ -78,7 +77,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _searchText;
 
-        partial void OnSearchTextChanging(ref string newValue);
         /// <summary>
         /// The string to search and highlight in the DOM content of the component.
         /// Setting this property triggers a new search automatically.

--- a/src/components/Blazor/Highlight.cs
+++ b/src/components/Blazor/Highlight.cs
@@ -262,13 +262,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("search", new object[] { }, new string[] { });
         }
 
-        partial void SerializeCoreIgbHighlight(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbHighlight(ser);
 
             if (IsPropDirty("CaseSensitive"))
             { ser.AddBooleanProp("caseSensitive", this._caseSensitive); }

--- a/src/components/Blazor/HighlightNavigation.cs
+++ b/src/components/Blazor/HighlightNavigation.cs
@@ -13,7 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _preventScroll = false;
 
-        partial void OnPreventScrollChanging(ref bool newValue);
         /// <summary>
         /// When <see langword="true"/>, prevents the component from scrolling the new active match into view.
         /// </summary>

--- a/src/components/Blazor/HighlightNavigation.cs
+++ b/src/components/Blazor/HighlightNavigation.cs
@@ -31,25 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameHighlightNavigation(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameHighlightNavigation(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/HighlightNavigation.cs
+++ b/src/components/Blazor/HighlightNavigation.cs
@@ -60,13 +60,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbHighlightNavigation(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbHighlightNavigation(ser);
 
             if (IsPropDirty("PreventScroll"))
             { ser.AddBooleanProp("preventScroll", this._preventScroll); }

--- a/src/components/Blazor/Icon.cs
+++ b/src/components/Blazor/Icon.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _iconName;
 
-        partial void OnIconNameChanging(ref string newValue);
         /// <summary>
         /// The name of the icon glyph to draw.
         /// </summary>
@@ -74,7 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _collection;
 
-        partial void OnCollectionChanging(ref string newValue);
         /// <summary>
         /// The name of the registered collection for look up of icons.
         /// </summary>
@@ -94,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _mirrored = false;
 
-        partial void OnMirroredChanging(ref bool newValue);
         /// <summary>
         /// Whether to flip the icon horizontally. Useful for RTL (right-to-left) layouts.
         /// </summary>

--- a/src/components/Blazor/Icon.cs
+++ b/src/components/Blazor/Icon.cs
@@ -207,13 +207,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setIconRef", new object[] { StringToString(name), StringToString(collection), ObjectToParam(icon) }, new string[] { "String", "String", "Json" });
         }
 
-        partial void SerializeCoreIgbIcon(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbIcon(ser);
 
             if (IsPropDirty("IconName"))
             { ser.AddStringProp("iconName", this._iconName); }

--- a/src/components/Blazor/Icon.cs
+++ b/src/components/Blazor/Icon.cs
@@ -110,25 +110,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameIcon(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameIcon(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/IconButton.cs
+++ b/src/components/Blazor/IconButton.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _iconName;
 
-        partial void OnIconNameChanging(ref string newValue);
         /// <summary>
         /// The name of the icon to display.
         /// </summary>
@@ -74,7 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _collection;
 
-        partial void OnCollectionChanging(ref string newValue);
         /// <summary>
         /// The collection the icon belongs to.
         /// </summary>
@@ -94,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _mirrored = false;
 
-        partial void OnMirroredChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the icon should be mirrored in right-to-left contexts.
         /// </summary>
@@ -114,7 +111,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IconButtonVariant _variant = IconButtonVariant.Contained;
 
-        partial void OnVariantChanging(ref IconButtonVariant newValue);
         /// <summary>
         /// The variant of the button which determines its visual appearance.
         /// <list type="bullet">

--- a/src/components/Blazor/IconButton.cs
+++ b/src/components/Blazor/IconButton.cs
@@ -137,26 +137,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameIconButton(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameIconButton(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         /// <summary>
         /// Registers an icon by fetching it from a URL.
         /// </summary>

--- a/src/components/Blazor/IconButton.cs
+++ b/src/components/Blazor/IconButton.cs
@@ -205,13 +205,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("registerIconFromText", new object[] { StringToString(name), StringToString(iconText), StringToString(collection) }, new string[] { "String", "String", "String" });
         }
 
-        partial void SerializeCoreIgbIconButton(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbIconButton(ser);
 
             if (IsPropDirty("IconName"))
             { ser.AddStringProp("iconName", this._iconName); }

--- a/src/components/Blazor/IconMeta.cs
+++ b/src/components/Blazor/IconMeta.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _collection;
 
-        partial void OnCollectionChanging(ref string newValue);
-
         /// <summary>
         /// The name of the collection the icon is registered in.
         /// </summary>

--- a/src/components/Blazor/IconMeta.cs
+++ b/src/components/Blazor/IconMeta.cs
@@ -31,26 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameIconMeta(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameIconMeta(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/IconMeta.cs
+++ b/src/components/Blazor/IconMeta.cs
@@ -53,13 +53,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbIconMeta(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbIconMeta(ser);
 
             if (IsPropDirty("Collection"))
             { ser.AddStringProp("collection", this._collection); }

--- a/src/components/Blazor/Input.cs
+++ b/src/components/Blazor/Input.cs
@@ -530,13 +530,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(string oldValue, ref string newValue);
 
-        partial void SerializeCoreIgbInput(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbInput(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddStringProp("value", this._value); }

--- a/src/components/Blazor/Input.cs
+++ b/src/components/Blazor/Input.cs
@@ -322,25 +322,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameInput(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameInput(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         /// <summary>
         /// Increments the numeric value of the input by one or more steps.
         /// </summary>

--- a/src/components/Blazor/Input.cs
+++ b/src/components/Blazor/Input.cs
@@ -49,7 +49,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The value of the control.
         /// </summary>
@@ -87,7 +86,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private InputType _displayType = InputType.Text;
 
-        partial void OnDisplayTypeChanging(ref InputType newValue);
         /// <summary>
         /// The type attribute of the control.
         /// </summary>
@@ -108,7 +106,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _readOnly = false;
 
-        partial void OnReadOnlyChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a readonly field.
         /// </summary>
@@ -129,7 +126,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _inputMode;
 
-        partial void OnInputModeChanging(ref string newValue);
         /// <summary>
         /// The input mode attribute of the control.
         /// See the relevant MDN article on
@@ -152,7 +148,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _pattern;
 
-        partial void OnPatternChanging(ref string? newValue);
         /// <summary>
         /// The pattern attribute of the control.
         /// </summary>
@@ -172,7 +167,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double? _minLength = 0;
 
-        partial void OnMinLengthChanging(ref double? newValue);
         /// <summary>
         /// The minimum string length required by the control.
         /// </summary>
@@ -193,7 +187,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double? _maxLength = 0;
 
-        partial void OnMaxLengthChanging(ref double? newValue);
         /// <summary>
         /// The maximum string length of the control.
         /// </summary>
@@ -214,7 +207,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double? _min = 0;
 
-        partial void OnMinChanging(ref double? newValue);
         /// <summary>
         /// The min attribute of the control.
         /// </summary>
@@ -234,7 +226,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double? _max = 0;
 
-        partial void OnMaxChanging(ref double? newValue);
         /// <summary>
         /// The max attribute of the control.
         /// </summary>
@@ -254,7 +245,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double? _step = 0;
 
-        partial void OnStepChanging(ref double? newValue);
         /// <summary>
         /// The step attribute of the control.
         /// </summary>
@@ -274,7 +264,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _autofocus = false;
 
-        partial void OnAutofocusChanging(ref bool newValue);
         /// <summary>
         /// The autofocus attribute of the control.
         /// </summary>
@@ -294,7 +283,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _autocomplete;
 
-        partial void OnAutocompleteChanging(ref string newValue);
         /// <summary>
         /// The autocomplete attribute of the control.
         /// </summary>
@@ -314,7 +302,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _validateOnly = false;
 
-        partial void OnValidateOnlyChanging(ref bool newValue);
         /// <summary>
         /// Enables validation rules to be evaluated without restricting user input.
         /// This applies to the <see cref="MaxLength"/> property for string-type inputs, or allows spin buttons

--- a/src/components/Blazor/Input.cs
+++ b/src/components/Blazor/Input.cs
@@ -476,8 +476,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (string)(args.Detail);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -527,8 +525,6 @@ namespace IgniteUI.Blazor.Controls
                 this._change = null;
             }
         }
-
-        partial void OnEventUpdatingValue(string oldValue, ref string newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/Input.cs
+++ b/src/components/Blazor/Input.cs
@@ -416,7 +416,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _change = null;
 
         /// <summary>
@@ -438,8 +437,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(string);
 
                             {

--- a/src/components/Blazor/InputBase.cs
+++ b/src/components/Blazor/InputBase.cs
@@ -506,13 +506,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbInputBase(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbInputBase(ser);
 
             if (IsPropDirty("Outlined"))
             { ser.AddBooleanProp("outlined", this._outlined); }

--- a/src/components/Blazor/InputBase.cs
+++ b/src/components/Blazor/InputBase.cs
@@ -282,7 +282,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInputOcurred(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _inputOcurred = null;
 
         /// <summary>
@@ -304,8 +303,7 @@ namespace IgniteUI.Blazor.Controls
                         _inputOcurred = value;
                         this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "InputOcurred", value, (args) =>
                         {
-                            OnHandlingInputOcurred(args);
-
+                            RaiseValueChanging(args);
                         });
                         this.OnRefChanged("InputOcurred", null, "event:::InputOcurred", true, false, (refName, oldValue, newValue) =>
                         {
@@ -359,7 +357,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _focus = null;
 
         /// <summary>
@@ -379,11 +376,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _focus, ref eventCallbacksCache))
                     {
                         _focus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value, (args) =>
-                        {
-                            OnHandlingFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value);
                         this.OnRefChanged("Focus", null, "nativeEvent:::Focus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._focusRef = refName;
@@ -436,7 +429,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _blur = null;
 
         /// <summary>
@@ -456,11 +448,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _blur, ref eventCallbacksCache))
                     {
                         _blur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value, (args) =>
-                        {
-                            OnHandlingBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value);
                         this.OnRefChanged("Blur", null, "nativeEvent:::Blur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._blurRef = refName;

--- a/src/components/Blazor/InputBase.cs
+++ b/src/components/Blazor/InputBase.cs
@@ -26,7 +26,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _outlined = false;
 
-        partial void OnOutlinedChanging(ref bool newValue);
         /// <summary>
         /// Whether the control will have outlined appearance.
         /// </summary>
@@ -46,7 +45,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholder;
 
-        partial void OnPlaceholderChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the control.
         /// </summary>
@@ -66,7 +64,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The label for the control.
         /// </summary>
@@ -86,7 +83,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -106,7 +102,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a required field in a form context.
         /// </summary>
@@ -126,7 +121,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/InputBase.cs
+++ b/src/components/Blazor/InputBase.cs
@@ -139,25 +139,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameInputBase(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameInputBase(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/LinearProgress.cs
+++ b/src/components/Blazor/LinearProgress.cs
@@ -108,13 +108,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbLinearProgress(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbLinearProgress(ser);
 
             if (IsPropDirty("Striped"))
             { ser.AddBooleanProp("striped", this._striped); }

--- a/src/components/Blazor/LinearProgress.cs
+++ b/src/components/Blazor/LinearProgress.cs
@@ -49,7 +49,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _striped = false;
 
-        partial void OnStripedChanging(ref bool newValue);
         /// <summary>
         /// Sets the striped look of the control.
         /// </summary>
@@ -69,7 +68,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private LinearProgressLabelAlign _labelAlign = LinearProgressLabelAlign.TopStart;
 
-        partial void OnLabelAlignChanging(ref LinearProgressLabelAlign newValue);
         /// <summary>
         /// The position for the default label of the control.
         /// </summary>

--- a/src/components/Blazor/LinearProgress.cs
+++ b/src/components/Blazor/LinearProgress.cs
@@ -86,26 +86,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameLinearProgress(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameLinearProgress(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/List.cs
+++ b/src/components/Blazor/List.cs
@@ -49,25 +49,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameList(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameList(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/List.cs
+++ b/src/components/Blazor/List.cs
@@ -77,15 +77,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbList(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbList(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/ListHeader.cs
+++ b/src/components/Blazor/ListHeader.cs
@@ -49,25 +49,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameListHeader(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameListHeader(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ListHeader.cs
+++ b/src/components/Blazor/ListHeader.cs
@@ -77,15 +77,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbListHeader(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbListHeader(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/ListItem.cs
+++ b/src/components/Blazor/ListItem.cs
@@ -72,25 +72,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameListItem(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameListItem(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ListItem.cs
+++ b/src/components/Blazor/ListItem.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _selected = false;
 
-        partial void OnSelectedChanging(ref bool newValue);
         /// <summary>
         /// Defines if the list item is selected or not.
         /// </summary>

--- a/src/components/Blazor/ListItem.cs
+++ b/src/components/Blazor/ListItem.cs
@@ -101,13 +101,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbListItem(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbListItem(ser);
 
             if (IsPropDirty("Selected"))
             { ser.AddBooleanProp("selected", this._selected); }

--- a/src/components/Blazor/MaskInput.cs
+++ b/src/components/Blazor/MaskInput.cs
@@ -306,8 +306,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (string)(args.Detail);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -357,8 +355,6 @@ namespace IgniteUI.Blazor.Controls
                 this._change = null;
             }
         }
-
-        partial void OnEventUpdatingValue(string oldValue, ref string newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/MaskInput.cs
+++ b/src/components/Blazor/MaskInput.cs
@@ -360,13 +360,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(string oldValue, ref string newValue);
 
-        partial void SerializeCoreIgbMaskInput(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbMaskInput(ser);
 
             if (IsPropDirty("ValueMode"))
             { ser.AddEnumProp("valueMode", this._valueMode); }

--- a/src/components/Blazor/MaskInput.cs
+++ b/src/components/Blazor/MaskInput.cs
@@ -158,26 +158,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameMaskInput(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameMaskInput(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         /// <summary>
         /// Sets the text selection range of the control.
         /// </summary>

--- a/src/components/Blazor/MaskInput.cs
+++ b/src/components/Blazor/MaskInput.cs
@@ -33,7 +33,6 @@ namespace IgniteUI.Blazor.Controls
 
         private MaskInputValueMode _valueMode = MaskInputValueMode.Raw;
 
-        partial void OnValueModeChanging(ref MaskInputValueMode newValue);
         /// <summary>
         /// Dictates the behavior when retrieving the value of the control.
         /// <list type="bullet">
@@ -63,7 +62,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The value of the input.
         /// Regardless of the current <see cref="ValueMode"/>, an empty value returns an empty string.
@@ -104,7 +102,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _mask;
 
-        partial void OnMaskChanging(ref string newValue);
         /// <summary>
         /// The masked pattern of the component.
         /// </summary>
@@ -124,7 +121,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _prompt;
 
-        partial void OnPromptChanging(ref string newValue);
         /// <summary>
         /// The prompt symbol to use for unfilled parts of the mask pattern.
         /// </summary>
@@ -144,7 +140,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _readOnly = false;
 
-        partial void OnReadOnlyChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a readonly field.
         /// </summary>

--- a/src/components/Blazor/MaskInput.cs
+++ b/src/components/Blazor/MaskInput.cs
@@ -253,7 +253,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _change = null;
 
         /// <summary>
@@ -275,8 +274,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(string);
 
                             {

--- a/src/components/Blazor/NavDrawer.cs
+++ b/src/components/Blazor/NavDrawer.cs
@@ -276,7 +276,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -296,11 +295,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -353,7 +348,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -373,11 +367,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;

--- a/src/components/Blazor/NavDrawer.cs
+++ b/src/components/Blazor/NavDrawer.cs
@@ -68,7 +68,6 @@ namespace IgniteUI.Blazor.Controls
 
         private NavDrawerPosition _position = NavDrawerPosition.Start;
 
-        partial void OnPositionChanging(ref NavDrawerPosition newValue);
         /// <summary>
         /// Sets the position of the drawer.
         /// <list type="bullet">
@@ -105,7 +104,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _open = false;
 
-        partial void OnOpenChanging(ref bool newValue);
         /// <summary>
         /// Whether the drawer is open.
         /// </summary>
@@ -125,7 +123,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _keepOpenOnEscape = false;
 
-        partial void OnKeepOpenOnEscapeChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the drawer should remain open when the Escape key is pressed.
         /// This is only applicable when the drawer is in a non-relative position,
@@ -146,8 +143,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _label;
-
-        partial void OnLabelChanging(ref string newValue);
 
         /// <summary>
         /// Sets an accessible label for the drawer.

--- a/src/components/Blazor/NavDrawer.cs
+++ b/src/components/Blazor/NavDrawer.cs
@@ -422,13 +422,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbNavDrawer(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbNavDrawer(ser);
 
             if (IsPropDirty("Position"))
             { ser.AddEnumProp("position", this._position); }

--- a/src/components/Blazor/NavDrawer.cs
+++ b/src/components/Blazor/NavDrawer.cs
@@ -166,25 +166,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameNavDrawer(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameNavDrawer(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/NavDrawerHeaderItem.cs
+++ b/src/components/Blazor/NavDrawerHeaderItem.cs
@@ -77,15 +77,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbNavDrawerHeaderItem(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbNavDrawerHeaderItem(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/NavDrawerHeaderItem.cs
+++ b/src/components/Blazor/NavDrawerHeaderItem.cs
@@ -49,25 +49,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameNavDrawerHeaderItem(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameNavDrawerHeaderItem(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/NavDrawerItem.cs
+++ b/src/components/Blazor/NavDrawerItem.cs
@@ -120,13 +120,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbNavDrawerItem(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbNavDrawerItem(ser);
 
             if (IsPropDirty("Disabled"))
             { ser.AddBooleanProp("disabled", this._disabled); }

--- a/src/components/Blazor/NavDrawerItem.cs
+++ b/src/components/Blazor/NavDrawerItem.cs
@@ -90,25 +90,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameNavDrawerItem(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameNavDrawerItem(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/NavDrawerItem.cs
+++ b/src/components/Blazor/NavDrawerItem.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the drawer item is disabled.
         /// </summary>
@@ -73,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _active = false;
 
-        partial void OnActiveChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the drawer item is active.
         /// </summary>

--- a/src/components/Blazor/Navbar.cs
+++ b/src/components/Blazor/Navbar.cs
@@ -78,15 +78,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbNavbar(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbNavbar(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/Navbar.cs
+++ b/src/components/Blazor/Navbar.cs
@@ -50,25 +50,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameNavbar(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameNavbar(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/NumberEventArgs.cs
+++ b/src/components/Blazor/NumberEventArgs.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _detail = 0;
 
-        partial void OnDetailChanging(ref double newValue);
-
         /// <summary>
         /// The numeric payload of the event. Its meaning depends on the event that carries it, for
         /// example the new value of the control or the index of the affected item.

--- a/src/components/Blazor/NumberEventArgs.cs
+++ b/src/components/Blazor/NumberEventArgs.cs
@@ -54,13 +54,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbNumberEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbNumberEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddNumberProp("detail", this._detail); }

--- a/src/components/Blazor/NumberEventArgs.cs
+++ b/src/components/Blazor/NumberEventArgs.cs
@@ -32,26 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameNumberEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameNumberEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/NumberFormatSpecifier.cs
+++ b/src/components/Blazor/NumberFormatSpecifier.cs
@@ -389,26 +389,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameNumberFormatSpecifier(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameNumberFormatSpecifier(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/NumberFormatSpecifier.cs
+++ b/src/components/Blazor/NumberFormatSpecifier.cs
@@ -447,13 +447,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbNumberFormatSpecifier(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbNumberFormatSpecifier(ser);
 
             if (IsPropDirty("Locale"))
             { ser.AddStringProp("locale", this._locale); }

--- a/src/components/Blazor/NumberFormatSpecifier.cs
+++ b/src/components/Blazor/NumberFormatSpecifier.cs
@@ -22,8 +22,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _locale;
 
-        partial void OnLocaleChanging(ref string newValue);
-
         /// <summary>
         /// The culture used to format the number. When not set, the browser culture returned by
         /// <see cref="IgbFormatSpecifier.GetLocalCulture"/> is used.
@@ -43,8 +41,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _compactDisplay;
-
-        partial void OnCompactDisplayChanging(ref string newValue);
 
         /// <summary>
         /// The form of the compact notation, either <c>short</c> or <c>long</c>. Applies only when
@@ -66,8 +62,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _currency;
 
-        partial void OnCurrencyChanging(ref string newValue);
-
         /// <summary>
         /// The currency used in currency formatting, given as an ISO 4217 currency code.
         /// </summary>
@@ -86,8 +80,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _currencyDisplay;
-
-        partial void OnCurrencyDisplayChanging(ref string newValue);
 
         /// <summary>
         /// How the currency is shown, one of <c>symbol</c>, <c>narrowSymbol</c>, <c>code</c> or
@@ -109,8 +101,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _currencySign;
 
-        partial void OnCurrencySignChanging(ref string newValue);
-
         /// <summary>
         /// How negative currency amounts are rendered, either <c>standard</c> or <c>accounting</c>.
         /// </summary>
@@ -129,8 +119,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _currencyCode;
-
-        partial void OnCurrencyCodeChanging(ref string newValue);
 
         /// <summary>
         /// The currency code applied when <see cref="Style"/> is <c>currency</c>. It takes precedence
@@ -152,8 +140,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _localeMatcher;
 
-        partial void OnLocaleMatcherChanging(ref string newValue);
-
         /// <summary>
         /// The locale matching algorithm, either <c>lookup</c> or <c>best fit</c>.
         /// </summary>
@@ -172,8 +158,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _notation;
-
-        partial void OnNotationChanging(ref string newValue);
 
         /// <summary>
         /// The formatting notation, one of <c>standard</c>, <c>scientific</c>, <c>engineering</c> or
@@ -195,8 +179,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _numberingSystem;
 
-        partial void OnNumberingSystemChanging(ref string newValue);
-
         /// <summary>
         /// The numbering system used to render the digits.
         /// </summary>
@@ -215,8 +197,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _signDisplay;
-
-        partial void OnSignDisplayChanging(ref string newValue);
 
         /// <summary>
         /// When the sign is shown, one of <c>auto</c>, <c>never</c>, <c>always</c> or
@@ -238,8 +218,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _style;
 
-        partial void OnStyleChanging(ref string newValue);
-
         /// <summary>
         /// The formatting style, one of <c>decimal</c>, <c>currency</c>, <c>percent</c> or
         /// <c>unit</c>.
@@ -260,8 +238,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _unit;
 
-        partial void OnUnitChanging(ref string newValue);
-
         /// <summary>
         /// The unit used when <see cref="Style"/> is <c>unit</c>.
         /// </summary>
@@ -280,8 +256,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _unitDisplay;
-
-        partial void OnUnitDisplayChanging(ref string newValue);
 
         /// <summary>
         /// How the unit is shown, one of <c>short</c>, <c>narrow</c> or <c>long</c>.
@@ -302,8 +276,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _useGrouping = false;
 
-        partial void OnUseGroupingChanging(ref bool newValue);
-
         /// <summary>
         /// Whether grouping separators, such as thousands separators, are used.
         /// </summary>
@@ -322,8 +294,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private int _minimumIntegerDigits = 0;
-
-        partial void OnMinimumIntegerDigitsChanging(ref int newValue);
 
         /// <summary>
         /// The minimum number of integer digits to use.
@@ -344,8 +314,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private int _minimumFractionDigits = 0;
 
-        partial void OnMinimumFractionDigitsChanging(ref int newValue);
-
         /// <summary>
         /// The minimum number of fraction digits to use.
         /// </summary>
@@ -364,8 +332,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private int _maximumFractionDigits = 0;
-
-        partial void OnMaximumFractionDigitsChanging(ref int newValue);
 
         /// <summary>
         /// The maximum number of fraction digits to use.
@@ -386,8 +352,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private int _minimumSignificantDigits = 0;
 
-        partial void OnMinimumSignificantDigitsChanging(ref int newValue);
-
         /// <summary>
         /// The minimum number of significant digits to use.
         /// </summary>
@@ -406,8 +370,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private int _maximumSignificantDigits = 0;
-
-        partial void OnMaximumSignificantDigitsChanging(ref int newValue);
 
         /// <summary>
         /// The maximum number of significant digits to use.

--- a/src/components/Blazor/ProgressBase.cs
+++ b/src/components/Blazor/ProgressBase.cs
@@ -45,7 +45,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _max = 100;
 
-        partial void OnMaxChanging(ref double newValue);
         /// <summary>
         /// Maximum value of the control.
         /// </summary>
@@ -65,7 +64,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _value = 0;
 
-        partial void OnValueChanging(ref double newValue);
         /// <summary>
         /// The value of the control.
         /// </summary>
@@ -85,7 +83,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private StyleVariant _variant = StyleVariant.Primary;
 
-        partial void OnVariantChanging(ref StyleVariant newValue);
         /// <summary>
         /// The variant of the control.
         /// </summary>
@@ -105,7 +102,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _animationDuration = 500;
 
-        partial void OnAnimationDurationChanging(ref double newValue);
         /// <summary>
         /// Animation duration in milliseconds.
         /// </summary>
@@ -125,7 +121,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _indeterminate = false;
 
-        partial void OnIndeterminateChanging(ref bool newValue);
         /// <summary>
         /// The indeterminate state of the control.
         /// </summary>
@@ -145,7 +140,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideLabel = false;
 
-        partial void OnHideLabelChanging(ref bool newValue);
         /// <summary>
         /// Shows/hides the label of the control.
         /// </summary>
@@ -165,7 +159,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _labelFormat;
 
-        partial void OnLabelFormatChanging(ref string newValue);
         /// <summary>
         /// Format string for the default label of the control. Placeholders:
         /// <list type="bullet">

--- a/src/components/Blazor/ProgressBase.cs
+++ b/src/components/Blazor/ProgressBase.cs
@@ -216,13 +216,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbProgressBase(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbProgressBase(ser);
 
             if (IsPropDirty("Max"))
             { ser.AddNumberProp("max", this._max); }

--- a/src/components/Blazor/ProgressBase.cs
+++ b/src/components/Blazor/ProgressBase.cs
@@ -181,25 +181,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameProgressBase(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameProgressBase(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Radio.cs
+++ b/src/components/Blazor/Radio.cs
@@ -184,25 +184,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameRadio(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRadio(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Radio.cs
+++ b/src/components/Blazor/Radio.cs
@@ -412,8 +412,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueChecked = (bool)(args.Detail.Checked);
-                                ;
-                                OnEventUpdatingChecked(this._checked, ref newValueChecked);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -617,8 +615,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingChecked(bool oldValue, ref bool newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/Radio.cs
+++ b/src/components/Blazor/Radio.cs
@@ -53,8 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
-
         /// <summary>
         /// When set, makes the component a required field for validation.
         /// </summary>
@@ -74,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The value of the control.
         /// </summary>
@@ -94,7 +91,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _checked = false;
 
-        partial void OnCheckedChanging(ref bool newValue);
         /// <summary>
         /// The checked state of the control.
         /// </summary>
@@ -132,7 +128,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ToggleLabelPosition _labelPosition = ToggleLabelPosition.After;
 
-        partial void OnLabelPositionChanging(ref ToggleLabelPosition newValue);
         /// <summary>
         /// The label position of the radio control.
         /// </summary>
@@ -152,7 +147,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -172,7 +166,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/Radio.cs
+++ b/src/components/Blazor/Radio.cs
@@ -358,7 +358,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbRadioChangeEventArgs args);
         private EventCallback<IgbRadioChangeEventArgs>? _change = null;
 
         /// <summary>
@@ -380,8 +379,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbRadioChangeEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueChecked = default(bool);
 
                             {
@@ -468,7 +465,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _focus = null;
 
         /// <summary>
@@ -488,11 +484,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _focus, ref eventCallbacksCache))
                     {
                         _focus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value, (args) =>
-                        {
-                            OnHandlingFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value);
                         this.OnRefChanged("Focus", null, "nativeEvent:::Focus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._focusRef = refName;
@@ -545,7 +537,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _blur = null;
 
         /// <summary>
@@ -565,11 +556,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _blur, ref eventCallbacksCache))
                     {
                         _blur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value, (args) =>
-                        {
-                            OnHandlingBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value);
                         this.OnRefChanged("Blur", null, "nativeEvent:::Blur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._blurRef = refName;

--- a/src/components/Blazor/Radio.cs
+++ b/src/components/Blazor/Radio.cs
@@ -620,13 +620,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingChecked(bool oldValue, ref bool newValue);
 
-        partial void SerializeCoreIgbRadio(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbRadio(ser);
 
             if (IsPropDirty("Required"))
             { ser.AddBooleanProp("required", this._required); }

--- a/src/components/Blazor/RadioChangeEventArgs.cs
+++ b/src/components/Blazor/RadioChangeEventArgs.cs
@@ -60,13 +60,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbRadioChangeEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbRadioChangeEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/RadioChangeEventArgs.cs
+++ b/src/components/Blazor/RadioChangeEventArgs.cs
@@ -37,26 +37,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameRadioChangeEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRadioChangeEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/RadioChangeEventArgs.cs
+++ b/src/components/Blazor/RadioChangeEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbRadioChangeEventArgsDetail _detail;
 
-        partial void OnDetailChanging(ref IgbRadioChangeEventArgsDetail newValue);
-
         /// <summary>
         /// The payload of the event, carrying the new checked state and the value of the radio button.
         /// </summary>
@@ -25,7 +23,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/RadioChangeEventArgsDetail.cs
+++ b/src/components/Blazor/RadioChangeEventArgsDetail.cs
@@ -50,25 +50,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameRadioChangeEventArgsDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRadioChangeEventArgsDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/RadioChangeEventArgsDetail.cs
+++ b/src/components/Blazor/RadioChangeEventArgsDetail.cs
@@ -82,13 +82,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbRadioChangeEventArgsDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbRadioChangeEventArgsDetail(ser);
 
             if (IsPropDirty("Checked"))
             { ser.AddBooleanProp("checked", this._checked); }

--- a/src/components/Blazor/RadioChangeEventArgsDetail.cs
+++ b/src/components/Blazor/RadioChangeEventArgsDetail.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _checked = false;
 
-        partial void OnCheckedChanging(ref bool newValue);
-
         /// <summary>
         /// The checked state of the radio button after the change.
         /// </summary>
@@ -33,8 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private string _value;
-
-        partial void OnValueChanging(ref string newValue);
 
         /// <summary>
         /// The value of the radio button.

--- a/src/components/Blazor/RadioGroup.cs
+++ b/src/components/Blazor/RadioGroup.cs
@@ -111,25 +111,6 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToString(iv);
         }
 
-        partial void FindByNameRadioGroup(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRadioGroup(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/RadioGroup.cs
+++ b/src/components/Blazor/RadioGroup.cs
@@ -183,7 +183,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbRadioChangeEventArgs args);
         private EventCallback<IgbRadioChangeEventArgs>? _change = null;
 
         /// <summary>
@@ -205,8 +204,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbRadioChangeEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(string);
 
                             {

--- a/src/components/Blazor/RadioGroup.cs
+++ b/src/components/Blazor/RadioGroup.cs
@@ -286,13 +286,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(string oldValue, ref string newValue);
 
-        partial void SerializeCoreIgbRadioGroup(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbRadioGroup(ser);
 
             if (IsPropDirty("Alignment"))
             { ser.AddEnumProp("alignment", this._alignment); }

--- a/src/components/Blazor/RadioGroup.cs
+++ b/src/components/Blazor/RadioGroup.cs
@@ -232,8 +232,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (string)(args.Detail.Value);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -283,8 +281,6 @@ namespace IgniteUI.Blazor.Controls
                 this._change = null;
             }
         }
-
-        partial void OnEventUpdatingValue(string oldValue, ref string newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/RadioGroup.cs
+++ b/src/components/Blazor/RadioGroup.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private ContentOrientation _alignment = ContentOrientation.Vertical;
 
-        partial void OnAlignmentChanging(ref ContentOrientation newValue);
         /// <summary>
         /// Alignment of the radio controls inside this group.
         /// </summary>
@@ -73,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The value of the group, reflecting the value of the currently checked <see cref="IgbRadio"/> button.
         /// Setting it checks the <see cref="IgbRadio"/> button in the group with a matching value.

--- a/src/components/Blazor/RangeSlider.cs
+++ b/src/components/Blazor/RangeSlider.cs
@@ -155,7 +155,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInput(IgbRangeSliderValueEventArgs args);
         private EventCallback<IgbRangeSliderValueEventArgs>? _input = null;
 
         /// <summary>
@@ -175,11 +174,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _input, ref eventCallbacksCache))
                     {
                         _input = value;
-                        this.SetHandler<IgbRangeSliderValueEventArgs>(this.Name, "Input", value, (args) =>
-                        {
-                            OnHandlingInput(args);
-
-                        });
+                        this.SetHandler<IgbRangeSliderValueEventArgs>(this.Name, "Input", value);
                         this.OnRefChanged("Input", null, "event:::Input", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputRef = refName;
@@ -232,7 +227,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbRangeSliderValueEventArgs args);
         private EventCallback<IgbRangeSliderValueEventArgs>? _change = null;
 
         /// <summary>
@@ -252,11 +246,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _change, ref eventCallbacksCache))
                     {
                         _change = value;
-                        this.SetHandler<IgbRangeSliderValueEventArgs>(this.Name, "Change", value, (args) =>
-                        {
-                            OnHandlingChange(args);
-
-                        });
+                        this.SetHandler<IgbRangeSliderValueEventArgs>(this.Name, "Change", value);
                         this.OnRefChanged("Change", null, "event:::Change", true, false, (refName, oldValue, newValue) =>
                         {
                             this._changeRef = refName;

--- a/src/components/Blazor/RangeSlider.cs
+++ b/src/components/Blazor/RangeSlider.cs
@@ -123,26 +123,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameRangeSlider(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRangeSlider(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         private string _inputRef = null;
         private string _inputScript = null;
 

--- a/src/components/Blazor/RangeSlider.cs
+++ b/src/components/Blazor/RangeSlider.cs
@@ -301,13 +301,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbRangeSlider(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbRangeSlider(ser);
 
             if (IsPropDirty("Lower"))
             { ser.AddNumberProp("lower", this._lower); }

--- a/src/components/Blazor/RangeSlider.cs
+++ b/src/components/Blazor/RangeSlider.cs
@@ -48,7 +48,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _lower = 0;
 
-        partial void OnLowerChanging(ref double newValue);
         /// <summary>
         /// The current value of the lower thumb.
         /// </summary>
@@ -68,7 +67,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _upper = 0;
 
-        partial void OnUpperChanging(ref double newValue);
         /// <summary>
         /// The current value of the upper thumb.
         /// </summary>
@@ -88,7 +86,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _thumbLabelLower;
 
-        partial void OnThumbLabelLowerChanging(ref string newValue);
         /// <summary>
         /// The aria label for the lower thumb.
         /// </summary>
@@ -108,7 +105,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _thumbLabelUpper;
 
-        partial void OnThumbLabelUpperChanging(ref string newValue);
         /// <summary>
         /// The aria label for the upper thumb.
         /// </summary>

--- a/src/components/Blazor/RangeSliderValue.cs
+++ b/src/components/Blazor/RangeSliderValue.cs
@@ -74,13 +74,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbRangeSliderValue(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbRangeSliderValue(ser);
 
             if (IsPropDirty("Lower"))
             { ser.AddNumberProp("lower", this._lower); }

--- a/src/components/Blazor/RangeSliderValue.cs
+++ b/src/components/Blazor/RangeSliderValue.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _lower = 0;
 
-        partial void OnLowerChanging(ref double newValue);
-
         /// <summary>
         /// The value of the lower thumb.
         /// </summary>
@@ -33,8 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private double _upper = 0;
-
-        partial void OnUpperChanging(ref double newValue);
 
         /// <summary>
         /// The value of the upper thumb.

--- a/src/components/Blazor/RangeSliderValue.cs
+++ b/src/components/Blazor/RangeSliderValue.cs
@@ -50,26 +50,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameRangeSliderValue(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRangeSliderValue(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/RangeSliderValueEventArgs.cs
+++ b/src/components/Blazor/RangeSliderValueEventArgs.cs
@@ -58,13 +58,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbRangeSliderValueEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbRangeSliderValueEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/RangeSliderValueEventArgs.cs
+++ b/src/components/Blazor/RangeSliderValueEventArgs.cs
@@ -35,26 +35,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameRangeSliderValueEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRangeSliderValueEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/RangeSliderValueEventArgs.cs
+++ b/src/components/Blazor/RangeSliderValueEventArgs.cs
@@ -12,8 +12,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbRangeSliderValue _detail;
 
-        partial void OnDetailChanging(ref IgbRangeSliderValue newValue);
-
         /// <summary>
         /// The lower and upper thumb values of the range slider.
         /// </summary>
@@ -23,7 +21,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/Rating.cs
+++ b/src/components/Blazor/Rating.cs
@@ -444,7 +444,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbNumberEventArgs args);
         private EventCallback<IgbNumberEventArgs>? _change = null;
 
         /// <summary>
@@ -466,8 +465,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbNumberEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(double);
 
                             {
@@ -554,7 +551,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingHover(IgbNumberEventArgs args);
         private EventCallback<IgbNumberEventArgs>? _hover = null;
 
         /// <summary>
@@ -574,11 +570,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _hover, ref eventCallbacksCache))
                     {
                         _hover = value;
-                        this.SetHandler<IgbNumberEventArgs>(this.Name, "Hover", value, (args) =>
-                        {
-                            OnHandlingHover(args);
-
-                        });
+                        this.SetHandler<IgbNumberEventArgs>(this.Name, "Hover", value);
                         this.OnRefChanged("Hover", null, "event:::Hover", true, false, (refName, oldValue, newValue) =>
                         {
                             this._hoverRef = refName;

--- a/src/components/Blazor/Rating.cs
+++ b/src/components/Blazor/Rating.cs
@@ -502,8 +502,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (double)(args.Detail);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -630,8 +628,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingValue(double oldValue, ref double newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/Rating.cs
+++ b/src/components/Blazor/Rating.cs
@@ -633,13 +633,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(double oldValue, ref double newValue);
 
-        partial void SerializeCoreIgbRating(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbRating(ser);
 
             if (IsPropDirty("Max"))
             { ser.AddNumberProp("max", this._max); }

--- a/src/components/Blazor/Rating.cs
+++ b/src/components/Blazor/Rating.cs
@@ -55,7 +55,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _max = 5;
 
-        partial void OnMaxChanging(ref double newValue);
         /// <summary>
         /// The maximum value for the rating.
         /// If there are projected symbols, the maximum value will be resolved
@@ -77,7 +76,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _step = 1;
 
-        partial void OnStepChanging(ref double newValue);
         /// <summary>
         /// The minimum value change allowed.
         /// Valid values are in the interval between 0 and 1 inclusive.
@@ -98,7 +96,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The label of the control.
         /// </summary>
@@ -118,7 +115,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _valueFormat;
 
-        partial void OnValueFormatChanging(ref string newValue);
         /// <summary>
         /// A format string which sets aria-valuetext. Instances of <c>{0}</c> will be replaced
         /// with the current value of the control and instances of <c>{1}</c> with the maximum value for the control.
@@ -140,7 +136,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _value = 0;
 
-        partial void OnValueChanging(ref double newValue);
         /// <summary>
         /// The value of the component.
         /// </summary>
@@ -178,7 +173,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hoverPreview = false;
 
-        partial void OnHoverPreviewChanging(ref bool newValue);
         /// <summary>
         /// Sets hover preview behavior for the component.
         /// </summary>
@@ -198,7 +192,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _readOnly = false;
 
-        partial void OnReadOnlyChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a readonly field.
         /// </summary>
@@ -219,7 +212,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _single = false;
 
-        partial void OnSingleChanging(ref bool newValue);
         /// <summary>
         /// Toggles single selection visual mode.
         /// </summary>
@@ -239,7 +231,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _allowReset = false;
 
-        partial void OnAllowResetChanging(ref bool newValue);
         /// <summary>
         /// Whether to reset the rating when the user selects the same value.
         /// </summary>
@@ -259,7 +250,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -279,7 +269,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/Rating.cs
+++ b/src/components/Blazor/Rating.cs
@@ -287,25 +287,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameRating(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRating(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/RatingSymbol.cs
+++ b/src/components/Blazor/RatingSymbol.cs
@@ -49,25 +49,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameRatingSymbol(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRatingSymbol(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/RatingSymbol.cs
+++ b/src/components/Blazor/RatingSymbol.cs
@@ -85,15 +85,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("connectedCallback", new object[] { }, new string[] { });
         }
 
-        partial void SerializeCoreIgbRatingSymbol(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbRatingSymbol(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/Ripple.cs
+++ b/src/components/Blazor/Ripple.cs
@@ -50,25 +50,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameRipple(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameRipple(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Ripple.cs
+++ b/src/components/Blazor/Ripple.cs
@@ -78,15 +78,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbRipple(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbRipple(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/Select.cs
+++ b/src/components/Blazor/Select.cs
@@ -394,21 +394,20 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSelect(string name, ref object item);
         public override object FindByName(string name)
         {
-
             var baseResult = base.FindByName(name);
             if (baseResult != null)
             {
                 return baseResult;
             }
 
-            object item = null;
-            FindByNameSelect(name, ref item);
-            if (item != null)
+            foreach (var item in ContentItems)
             {
-                return item;
+                if (item.Name == name || item.ContainerId == name)
+                {
+                    return item;
+                }
             }
 
             return null;

--- a/src/components/Blazor/Select.cs
+++ b/src/components/Blazor/Select.cs
@@ -48,7 +48,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string? _value;
 
-        partial void OnValueChanging(ref string? newValue);
         /// <summary>
         /// The value of the control.
         /// </summary>
@@ -86,7 +85,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _outlined = false;
 
-        partial void OnOutlinedChanging(ref bool newValue);
         /// <summary>
         /// Whether the control has an outlined appearance.
         /// </summary>
@@ -106,7 +104,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _autofocus = false;
 
-        partial void OnAutofocusChanging(ref bool newValue);
         /// <summary>
         /// Whether the control should receive focus automatically.
         /// </summary>
@@ -126,7 +123,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _distance = 0;
 
-        partial void OnDistanceChanging(ref double newValue);
         /// <summary>
         /// The distance of the select dropdown from its input.
         /// </summary>
@@ -146,7 +142,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The label of the control.
         /// </summary>
@@ -166,7 +161,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholder;
 
-        partial void OnPlaceholderChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the control.
         /// </summary>
@@ -186,7 +180,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private PopoverPlacement _placement = PopoverPlacement.BottomStart;
 
-        partial void OnPlacementChanging(ref PopoverPlacement newValue);
         /// <summary>
         /// The preferred placement of the select dropdown around its input.
         /// </summary>
@@ -206,7 +199,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private PopoverScrollStrategy _scrollStrategy = PopoverScrollStrategy.Scroll;
 
-        partial void OnScrollStrategyChanging(ref PopoverScrollStrategy newValue);
         /// <summary>
         /// Determines the behavior of the component during scrolling of the parent container.
         /// </summary>
@@ -346,7 +338,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -366,7 +357,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a required field in a form context.
         /// </summary>
@@ -386,7 +376,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/Select.cs
+++ b/src/components/Blazor/Select.cs
@@ -1134,13 +1134,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(string? oldValue, ref string? newValue);
 
-        partial void SerializeCoreIgbSelect(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSelect(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddStringProp("value", this._value); }

--- a/src/components/Blazor/Select.cs
+++ b/src/components/Blazor/Select.cs
@@ -618,8 +618,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (string?)(args.Detail.Value);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -1131,8 +1129,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingValue(string? oldValue, ref string? newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/Select.cs
+++ b/src/components/Blazor/Select.cs
@@ -578,7 +578,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbSelectItemComponentEventArgs args);
         private EventCallback<IgbSelectItemComponentEventArgs>? _change = null;
 
         /// <summary>
@@ -600,8 +599,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbSelectItemComponentEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(string?);
 
                             {
@@ -688,7 +685,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _focus = null;
 
         /// <summary>
@@ -708,11 +704,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _focus, ref eventCallbacksCache))
                     {
                         _focus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value, (args) =>
-                        {
-                            OnHandlingFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value);
                         this.OnRefChanged("Focus", null, "nativeEvent:::Focus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._focusRef = refName;
@@ -765,7 +757,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _blur = null;
 
         /// <summary>
@@ -785,11 +776,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _blur, ref eventCallbacksCache))
                     {
                         _blur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value, (args) =>
-                        {
-                            OnHandlingBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value);
                         this.OnRefChanged("Blur", null, "nativeEvent:::Blur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._blurRef = refName;
@@ -842,7 +829,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpening(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opening = null;
 
         /// <summary>
@@ -862,11 +848,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opening, ref eventCallbacksCache))
                     {
                         _opening = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value, (args) =>
-                        {
-                            OnHandlingOpening(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value);
                         this.OnRefChanged("Opening", null, "event:::Opening", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openingRef = refName;
@@ -919,7 +901,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpened(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opened = null;
 
         /// <summary>
@@ -939,11 +920,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opened, ref eventCallbacksCache))
                     {
                         _opened = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value, (args) =>
-                        {
-                            OnHandlingOpened(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value);
                         this.OnRefChanged("Opened", null, "event:::Opened", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openedRef = refName;
@@ -996,7 +973,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -1016,11 +992,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -1073,7 +1045,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -1093,11 +1064,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;

--- a/src/components/Blazor/SelectGroup.cs
+++ b/src/components/Blazor/SelectGroup.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbSelectItem[] _items;
 
-        partial void OnItemsChanging(ref IgbSelectItem[] newValue);
         /// <summary>
         /// All child <see cref="IgbSelectItem"/> components.
         /// </summary>
@@ -73,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Whether the group item and all its children are disabled.
         /// </summary>

--- a/src/components/Blazor/SelectGroup.cs
+++ b/src/components/Blazor/SelectGroup.cs
@@ -120,13 +120,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbSelectGroup(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSelectGroup(ser);
 
             if (IsPropDirty("Items"))
             { ser.AddSerializableArrayProp("items", this._items); }

--- a/src/components/Blazor/SelectGroup.cs
+++ b/src/components/Blazor/SelectGroup.cs
@@ -90,25 +90,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSelectGroup(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSelectGroup(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/SelectHeader.cs
+++ b/src/components/Blazor/SelectHeader.cs
@@ -77,15 +77,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbSelectHeader(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbSelectHeader(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/SelectHeader.cs
+++ b/src/components/Blazor/SelectHeader.cs
@@ -49,25 +49,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameSelectHeader(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSelectHeader(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/SelectItem.cs
+++ b/src/components/Blazor/SelectItem.cs
@@ -64,15 +64,5 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbSelectItem(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbSelectItem(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/SelectItem.cs
+++ b/src/components/Blazor/SelectItem.cs
@@ -44,25 +44,5 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSelectItem(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSelectItem(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
     }
 }

--- a/src/components/Blazor/SelectItemComponentEventArgs.cs
+++ b/src/components/Blazor/SelectItemComponentEventArgs.cs
@@ -32,26 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSelectItemComponentEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSelectItemComponentEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/SelectItemComponentEventArgs.cs
+++ b/src/components/Blazor/SelectItemComponentEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbSelectItem _detail;
 
-        partial void OnDetailChanging(ref IgbSelectItem newValue);
-
         /// <summary>
         /// The select item that became selected.
         /// </summary>

--- a/src/components/Blazor/SelectItemComponentEventArgs.cs
+++ b/src/components/Blazor/SelectItemComponentEventArgs.cs
@@ -54,13 +54,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbSelectItemComponentEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSelectItemComponentEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/Slider.cs
+++ b/src/components/Blazor/Slider.cs
@@ -436,13 +436,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(double oldValue, ref double newValue);
 
-        partial void SerializeCoreIgbSlider(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSlider(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddNumberProp("value", this._value); }

--- a/src/components/Blazor/Slider.cs
+++ b/src/components/Blazor/Slider.cs
@@ -103,25 +103,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSlider(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSlider(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         /// <summary>
         /// Increments the value of the slider by <c>stepIncrement * step</c>, where
         /// <paramref name="stepIncrement"/> defaults to 1.

--- a/src/components/Blazor/Slider.cs
+++ b/src/components/Blazor/Slider.cs
@@ -256,7 +256,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInput(IgbNumberEventArgs args);
         private EventCallback<IgbNumberEventArgs>? _input = null;
 
         /// <summary>
@@ -276,11 +275,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _input, ref eventCallbacksCache))
                     {
                         _input = value;
-                        this.SetHandler<IgbNumberEventArgs>(this.Name, "Input", value, (args) =>
-                        {
-                            OnHandlingInput(args);
-
-                        });
+                        this.SetHandler<IgbNumberEventArgs>(this.Name, "Input", value);
                         this.OnRefChanged("Input", null, "event:::Input", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputRef = refName;
@@ -333,7 +328,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbNumberEventArgs args);
         private EventCallback<IgbNumberEventArgs>? _change = null;
 
         /// <summary>
@@ -355,8 +349,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbNumberEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(double);
 
                             {

--- a/src/components/Blazor/Slider.cs
+++ b/src/components/Blazor/Slider.cs
@@ -48,7 +48,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _value = 0;
 
-        partial void OnValueChanging(ref double newValue);
         /// <summary>
         /// The current value of the component.
         /// </summary>
@@ -86,7 +85,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/Slider.cs
+++ b/src/components/Blazor/Slider.cs
@@ -382,8 +382,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (double)(args.Detail);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -433,8 +431,6 @@ namespace IgniteUI.Blazor.Controls
                 this._change = null;
             }
         }
-
-        partial void OnEventUpdatingValue(double oldValue, ref double newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/SliderBase.cs
+++ b/src/components/Blazor/SliderBase.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _min = 0;
 
-        partial void OnMinChanging(ref double newValue);
         /// <summary>
         /// The minimum value of the slider scale. Defaults to 0.
         /// If <see cref="Min"/> is greater than <see cref="Max"/> the assignment is a no-op.
@@ -77,7 +76,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _max = 100;
 
-        partial void OnMaxChanging(ref double newValue);
         /// <summary>
         /// The maximum value of the slider scale. Defaults to 100.
         /// If <see cref="Max"/> is less than <see cref="Min"/> the assignment is a no-op.
@@ -102,7 +100,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _lowerBound = 0;
 
-        partial void OnLowerBoundChanging(ref double newValue);
         /// <summary>
         /// The lower bound of the slider value. If not set, the <see cref="Min"/> value is applied.
         /// </summary>
@@ -122,7 +119,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _upperBound = 0;
 
-        partial void OnUpperBoundChanging(ref double newValue);
         /// <summary>
         /// The upper bound of the slider value. If not set, the <see cref="Max"/> value is applied.
         /// </summary>
@@ -142,7 +138,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Disables the UI interactions of the slider.
         /// </summary>
@@ -162,7 +157,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _discreteTrack = false;
 
-        partial void OnDiscreteTrackChanging(ref bool newValue);
         /// <summary>
         /// Marks the slider track as discrete so it displays the steps.
         /// If <see cref="Step"/> is 0, the slider remains continuous even if <see cref="DiscreteTrack"/>
@@ -184,7 +178,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideTooltip = false;
 
-        partial void OnHideTooltipChanging(ref bool newValue);
         /// <summary>
         /// Hides the thumb tooltip.
         /// </summary>
@@ -204,7 +197,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _step = 1;
 
-        partial void OnStepChanging(ref double newValue);
         /// <summary>
         /// Specifies the granularity that the value must adhere to.
         /// If set to 0 no stepping is implied and any value in the range is allowed.
@@ -227,7 +219,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _primaryTicks = 0;
 
-        partial void OnPrimaryTicksChanging(ref double newValue);
         /// <summary>
         /// The number of primary ticks. It defaults to 0 which means no primary ticks are displayed.
         /// </summary>
@@ -247,7 +238,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _secondaryTicks = 0;
 
-        partial void OnSecondaryTicksChanging(ref double newValue);
         /// <summary>
         /// The number of secondary ticks. It defaults to 0 which means no secondary ticks are displayed.
         /// </summary>
@@ -267,7 +257,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private SliderTickOrientation _tickOrientation = SliderTickOrientation.End;
 
-        partial void OnTickOrientationChanging(ref SliderTickOrientation newValue);
         /// <summary>
         /// Changes the orientation of the ticks.
         /// </summary>
@@ -287,7 +276,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hidePrimaryLabels = false;
 
-        partial void OnHidePrimaryLabelsChanging(ref bool newValue);
         /// <summary>
         /// Hides the primary tick labels.
         /// </summary>
@@ -307,7 +295,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideSecondaryLabels = false;
 
-        partial void OnHideSecondaryLabelsChanging(ref bool newValue);
         /// <summary>
         /// Hides the secondary tick labels.
         /// </summary>
@@ -327,7 +314,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _locale;
 
-        partial void OnLocaleChanging(ref string newValue);
         /// <summary>
         /// The locale used to format the thumb and tick label values in the slider.
         /// </summary>
@@ -347,7 +333,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _valueFormat;
 
-        partial void OnValueFormatChanging(ref string newValue);
         /// <summary>
         /// String format used for the thumb and tick label values in the slider.
         /// </summary>
@@ -367,7 +352,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private SliderTickLabelRotation _tickLabelRotation = SliderTickLabelRotation.Zero;
 
-        partial void OnTickLabelRotationChanging(ref SliderTickLabelRotation newValue);
         /// <summary>
         /// The degrees for the rotation of the tick labels. Defaults to 0.
         /// </summary>
@@ -387,7 +371,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private IgbNumberFormatSpecifier _valueFormatOptions;
 
-        partial void OnValueFormatOptionsChanging(ref IgbNumberFormatSpecifier newValue);
         /// <summary>
         /// Number format options used for the thumb and tick label values in the slider.
         /// </summary>

--- a/src/components/Blazor/SliderBase.cs
+++ b/src/components/Blazor/SliderBase.cs
@@ -389,25 +389,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSliderBase(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSliderBase(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/SliderBase.cs
+++ b/src/components/Blazor/SliderBase.cs
@@ -434,13 +434,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbSliderBase(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSliderBase(ser);
 
             if (IsPropDirty("Min"))
             { ser.AddNumberProp("min", this._min); }

--- a/src/components/Blazor/SliderLabel.cs
+++ b/src/components/Blazor/SliderLabel.cs
@@ -78,15 +78,5 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbSliderLabel(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbSliderLabel(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/SliderLabel.cs
+++ b/src/components/Blazor/SliderLabel.cs
@@ -50,25 +50,6 @@ namespace IgniteUI.Blazor.Controls
             get { return ControlEventBehavior.Immediate; }
         }
 
-        partial void FindByNameSliderLabel(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSliderLabel(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Snackbar.cs
+++ b/src/components/Blazor/Snackbar.cs
@@ -104,7 +104,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingAction(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _action = null;
 
         /// <summary>
@@ -124,11 +123,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _action, ref eventCallbacksCache))
                     {
                         _action = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Action", value, (args) =>
-                        {
-                            OnHandlingAction(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Action", value);
                         this.OnRefChanged("Action", null, "event:::Action", true, false, (refName, oldValue, newValue) =>
                         {
                             this._actionRef = refName;

--- a/src/components/Blazor/Snackbar.cs
+++ b/src/components/Blazor/Snackbar.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _actionText;
 
-        partial void OnActionTextChanging(ref string newValue);
         /// <summary>
         /// The text of the action button.
         /// </summary>

--- a/src/components/Blazor/Snackbar.cs
+++ b/src/components/Blazor/Snackbar.cs
@@ -72,26 +72,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSnackbar(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSnackbar(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         private string _actionRef = null;
         private string _actionScript = null;
 

--- a/src/components/Blazor/Snackbar.cs
+++ b/src/components/Blazor/Snackbar.cs
@@ -170,13 +170,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbSnackbar(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSnackbar(ser);
 
             if (IsPropDirty("ActionText"))
             { ser.AddStringProp("actionText", this._actionText); }

--- a/src/components/Blazor/Splitter.cs
+++ b/src/components/Blazor/Splitter.cs
@@ -57,7 +57,6 @@ namespace IgniteUI.Blazor.Controls
 
         private SplitterOrientation _orientation = SplitterOrientation.Horizontal;
 
-        partial void OnOrientationChanging(ref SplitterOrientation newValue);
         /// <summary>
         /// The orientation of the splitter, which determines the direction of resizing and collapsing.
         /// </summary>
@@ -77,7 +76,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableCollapse = false;
 
-        partial void OnDisableCollapseChanging(ref bool newValue);
         /// <summary>
         /// When <see langword="true"/>, prevents the user from collapsing either pane.
         /// This also hides the expand/collapse buttons on the splitter bar.
@@ -98,7 +96,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableResize = false;
 
-        partial void OnDisableResizeChanging(ref bool newValue);
         /// <summary>
         /// When <see langword="true"/>, prevents the user from resizing the panes by dragging the splitter bar
         /// or using keyboard shortcuts.
@@ -120,7 +117,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideCollapseButtons = false;
 
-        partial void OnHideCollapseButtonsChanging(ref bool newValue);
         /// <summary>
         /// When <see langword="true"/>, hides the expand/collapse buttons on the splitter bar.
         /// Note that the buttons will also be hidden if <see cref="DisableCollapse"/> is
@@ -142,7 +138,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _hideDragHandle = false;
 
-        partial void OnHideDragHandleChanging(ref bool newValue);
         /// <summary>
         /// When <see langword="true"/>, hides the drag handle on the splitter bar.
         /// Note that the drag handle will also be hidden if <see cref="DisableResize"/>
@@ -164,7 +159,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _startMinSize;
 
-        partial void OnStartMinSizeChanging(ref string? newValue);
         /// <summary>
         /// The minimum size of the start pane.
         /// </summary>
@@ -184,7 +178,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _endMinSize;
 
-        partial void OnEndMinSizeChanging(ref string? newValue);
         /// <summary>
         /// The minimum size of the end pane.
         /// </summary>
@@ -204,7 +197,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _startMaxSize;
 
-        partial void OnStartMaxSizeChanging(ref string? newValue);
         /// <summary>
         /// The maximum size of the start pane.
         /// </summary>
@@ -224,7 +216,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _endMaxSize;
 
-        partial void OnEndMaxSizeChanging(ref string? newValue);
         /// <summary>
         /// The maximum size of the end pane.
         /// </summary>
@@ -244,7 +235,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _startSize;
 
-        partial void OnStartSizeChanging(ref string? newValue);
         /// <summary>
         /// The size of the start pane.
         /// </summary>
@@ -264,7 +254,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _endSize;
 
-        partial void OnEndSizeChanging(ref string? newValue);
         /// <summary>
         /// The size of the end pane.
         /// </summary>

--- a/src/components/Blazor/Splitter.cs
+++ b/src/components/Blazor/Splitter.cs
@@ -557,13 +557,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbSplitter(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSplitter(ser);
 
             if (IsPropDirty("Orientation"))
             { ser.AddEnumProp("orientation", this._orientation); }

--- a/src/components/Blazor/Splitter.cs
+++ b/src/components/Blazor/Splitter.cs
@@ -328,7 +328,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingResizeStart(IgbSplitterResizeEventArgs args);
         private EventCallback<IgbSplitterResizeEventArgs>? _resizeStart = null;
 
         /// <summary>
@@ -348,11 +347,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _resizeStart, ref eventCallbacksCache))
                     {
                         _resizeStart = value;
-                        this.SetHandler<IgbSplitterResizeEventArgs>(this.Name, "ResizeStart", value, (args) =>
-                        {
-                            OnHandlingResizeStart(args);
-
-                        });
+                        this.SetHandler<IgbSplitterResizeEventArgs>(this.Name, "ResizeStart", value);
                         this.OnRefChanged("ResizeStart", null, "event:::ResizeStart", true, false, (refName, oldValue, newValue) =>
                         {
                             this._resizeStartRef = refName;
@@ -405,7 +400,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingResizing(IgbSplitterResizeEventArgs args);
         private EventCallback<IgbSplitterResizeEventArgs>? _resizing = null;
 
         /// <summary>
@@ -425,11 +419,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _resizing, ref eventCallbacksCache))
                     {
                         _resizing = value;
-                        this.SetHandler<IgbSplitterResizeEventArgs>(this.Name, "Resizing", value, (args) =>
-                        {
-                            OnHandlingResizing(args);
-
-                        });
+                        this.SetHandler<IgbSplitterResizeEventArgs>(this.Name, "Resizing", value);
                         this.OnRefChanged("Resizing", null, "event:::Resizing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._resizingRef = refName;
@@ -482,7 +472,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingResizeEnd(IgbSplitterResizeEventArgs args);
         private EventCallback<IgbSplitterResizeEventArgs>? _resizeEnd = null;
 
         /// <summary>
@@ -502,11 +491,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _resizeEnd, ref eventCallbacksCache))
                     {
                         _resizeEnd = value;
-                        this.SetHandler<IgbSplitterResizeEventArgs>(this.Name, "ResizeEnd", value, (args) =>
-                        {
-                            OnHandlingResizeEnd(args);
-
-                        });
+                        this.SetHandler<IgbSplitterResizeEventArgs>(this.Name, "ResizeEnd", value);
                         this.OnRefChanged("ResizeEnd", null, "event:::ResizeEnd", true, false, (refName, oldValue, newValue) =>
                         {
                             this._resizeEndRef = refName;

--- a/src/components/Blazor/Splitter.cs
+++ b/src/components/Blazor/Splitter.cs
@@ -272,25 +272,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSplitter(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSplitter(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/SplitterResizeEventArgs.cs
+++ b/src/components/Blazor/SplitterResizeEventArgs.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbSplitterResizeEventArgsDetail _detail;
 
-        partial void OnDetailChanging(ref IgbSplitterResizeEventArgsDetail newValue);
-
         /// <summary>
         /// The current sizes of the panes adjacent to the resized splitter bar.
         /// </summary>
@@ -24,7 +22,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/SplitterResizeEventArgs.cs
+++ b/src/components/Blazor/SplitterResizeEventArgs.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbSplitterResizeEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSplitterResizeEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/SplitterResizeEventArgs.cs
+++ b/src/components/Blazor/SplitterResizeEventArgs.cs
@@ -36,26 +36,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameSplitterResizeEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSplitterResizeEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/SplitterResizeEventArgsDetail.cs
+++ b/src/components/Blazor/SplitterResizeEventArgsDetail.cs
@@ -102,13 +102,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbSplitterResizeEventArgsDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbSplitterResizeEventArgsDetail(ser);
 
             if (IsPropDirty("StartPanelSize"))
             { ser.AddNumberProp("startPanelSize", this._startPanelSize); }

--- a/src/components/Blazor/SplitterResizeEventArgsDetail.cs
+++ b/src/components/Blazor/SplitterResizeEventArgsDetail.cs
@@ -14,7 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _startPanelSize = 0;
 
-        partial void OnStartPanelSizeChanging(ref double newValue);
         /// <summary>
         /// The current size of the start panel in pixels.
         /// </summary>
@@ -34,7 +33,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _endPanelSize = 0;
 
-        partial void OnEndPanelSizeChanging(ref double newValue);
         /// <summary>
         /// The current size of the end panel in pixels.
         /// </summary>
@@ -54,7 +52,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _delta = 0;
 
-        partial void OnDeltaChanging(ref double newValue);
         /// <summary>
         /// The change in size since the resize operation started. Only set for
         /// <see cref="IgbSplitter.Resizing"/> and <see cref="IgbSplitter.ResizeEnd"/>.

--- a/src/components/Blazor/SplitterResizeEventArgsDetail.cs
+++ b/src/components/Blazor/SplitterResizeEventArgsDetail.cs
@@ -71,25 +71,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSplitterResizeEventArgsDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSplitterResizeEventArgsDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Step.cs
+++ b/src/components/Blazor/Step.cs
@@ -187,13 +187,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbStep(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbStep(ser);
 
             if (IsPropDirty("Invalid"))
             { ser.AddBooleanProp("invalid", this._invalid); }

--- a/src/components/Blazor/Step.cs
+++ b/src/components/Blazor/Step.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Whether the step is invalid.
         /// Invalid steps are styled with an error state and are not
@@ -76,7 +75,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _active = false;
 
-        partial void OnActiveChanging(ref bool newValue);
         /// <summary>
         /// Whether the step is active.
         /// Active steps are styled with an active state and their content is visible.
@@ -97,7 +95,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _optional = false;
 
-        partial void OnOptionalChanging(ref bool newValue);
         /// <summary>
         /// Whether the step is optional.
         /// Optional steps validity does not affect the default behavior when the stepper is in linear mode i.e.
@@ -119,7 +116,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Whether the step is disabled.
         /// Disabled steps are styled with a disabled state and are not interactive.
@@ -140,7 +136,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _complete = false;
 
-        partial void OnCompleteChanging(ref bool newValue);
         /// <summary>
         /// Whether the step is completed.
         /// </summary>

--- a/src/components/Blazor/Step.cs
+++ b/src/components/Blazor/Step.cs
@@ -154,25 +154,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameStep(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameStep(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Stepper.cs
+++ b/src/components/Blazor/Stepper.cs
@@ -493,13 +493,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbStepper(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbStepper(ser);
 
             if (IsPropDirty("Orientation"))
             { ser.AddEnumProp("orientation", this._orientation); }

--- a/src/components/Blazor/Stepper.cs
+++ b/src/components/Blazor/Stepper.cs
@@ -243,25 +243,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameStepper(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameStepper(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Stepper.cs
+++ b/src/components/Blazor/Stepper.cs
@@ -344,7 +344,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingActiveStepChanging(IgbActiveStepChangingEventArgs args);
         private EventCallback<IgbActiveStepChangingEventArgs>? _activeStepChanging = null;
 
         /// <summary>
@@ -364,11 +363,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _activeStepChanging, ref eventCallbacksCache))
                     {
                         _activeStepChanging = value;
-                        this.SetHandler<IgbActiveStepChangingEventArgs>(this.Name, "ActiveStepChanging", value, (args) =>
-                        {
-                            OnHandlingActiveStepChanging(args);
-
-                        });
+                        this.SetHandler<IgbActiveStepChangingEventArgs>(this.Name, "ActiveStepChanging", value);
                         this.OnRefChanged("ActiveStepChanging", null, "event:::ActiveStepChanging", true, false, (refName, oldValue, newValue) =>
                         {
                             this._activeStepChangingRef = refName;
@@ -421,7 +416,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingActiveStepChanged(IgbActiveStepChangedEventArgs args);
         private EventCallback<IgbActiveStepChangedEventArgs>? _activeStepChanged = null;
 
         /// <summary>
@@ -441,11 +435,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _activeStepChanged, ref eventCallbacksCache))
                     {
                         _activeStepChanged = value;
-                        this.SetHandler<IgbActiveStepChangedEventArgs>(this.Name, "ActiveStepChanged", value, (args) =>
-                        {
-                            OnHandlingActiveStepChanged(args);
-
-                        });
+                        this.SetHandler<IgbActiveStepChangedEventArgs>(this.Name, "ActiveStepChanged", value);
                         this.OnRefChanged("ActiveStepChanged", null, "event:::ActiveStepChanged", true, false, (refName, oldValue, newValue) =>
                         {
                             this._activeStepChangedRef = refName;

--- a/src/components/Blazor/Stepper.cs
+++ b/src/components/Blazor/Stepper.cs
@@ -92,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private StepperOrientation _orientation = StepperOrientation.Horizontal;
 
-        partial void OnOrientationChanging(ref StepperOrientation newValue);
         /// <summary>
         /// The orientation of the stepper.
         /// </summary>
@@ -112,7 +111,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private StepperStepType _stepType = StepperStepType.Full;
 
-        partial void OnStepTypeChanging(ref StepperStepType newValue);
         /// <summary>
         /// The visual type of the steps.
         /// </summary>
@@ -132,7 +130,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _linear = false;
 
-        partial void OnLinearChanging(ref bool newValue);
         /// <summary>
         /// Whether the stepper is linear.
         /// </summary>
@@ -152,7 +149,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _contentTop = false;
 
-        partial void OnContentTopChanging(ref bool newValue);
         /// <summary>
         /// Whether the content is displayed above the steps.
         /// </summary>
@@ -172,7 +168,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private StepperVerticalAnimation _verticalAnimation = StepperVerticalAnimation.Grow;
 
-        partial void OnVerticalAnimationChanging(ref StepperVerticalAnimation newValue);
         /// <summary>
         /// The animation type when in vertical mode.
         /// </summary>
@@ -192,7 +187,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private HorizontalTransitionAnimation _horizontalAnimation = HorizontalTransitionAnimation.Slide;
 
-        partial void OnHorizontalAnimationChanging(ref HorizontalTransitionAnimation newValue);
         /// <summary>
         /// The animation type when in horizontal mode.
         /// </summary>
@@ -212,7 +206,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _animationDuration = 320;
 
-        partial void OnAnimationDurationChanging(ref double newValue);
         /// <summary>
         /// The animation duration in either vertical or horizontal mode in milliseconds.
         /// </summary>
@@ -232,7 +225,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private StepperTitlePosition _titlePosition = StepperTitlePosition.Auto;
 
-        partial void OnTitlePositionChanging(ref StepperTitlePosition newValue);
         /// <summary>
         /// The position of the steps title.
         /// </summary>

--- a/src/components/Blazor/Switch.cs
+++ b/src/components/Blazor/Switch.cs
@@ -64,15 +64,5 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbSwitch(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbSwitch(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/Switch.cs
+++ b/src/components/Blazor/Switch.cs
@@ -44,25 +44,5 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSwitch(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameSwitch(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
     }
 }

--- a/src/components/Blazor/Tab.cs
+++ b/src/components/Blazor/Tab.cs
@@ -141,25 +141,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTab(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTab(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Tab.cs
+++ b/src/components/Blazor/Tab.cs
@@ -172,13 +172,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbTab(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTab(ser);
 
             if (IsPropDirty("Label"))
             { ser.AddStringProp("label", this._label); }

--- a/src/components/Blazor/Tab.cs
+++ b/src/components/Blazor/Tab.cs
@@ -57,11 +57,8 @@ namespace IgniteUI.Blazor.Controls
             get; set;
         }
 
-        partial void OnIgbTabDisposing();
         public void Dispose()
         {
-            OnIgbTabDisposing();
-
             if (TabsParent != null)
             {
                 var sv = (IgbTabs)TabsParent;
@@ -70,11 +67,8 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void OnIgbTabInitializing();
         protected override async Task OnInitializedAsync()
         {
-            OnIgbTabInitializing();
-
             if (TabsParent != null)
             {
                 var sv = (IgbTabs)TabsParent;

--- a/src/components/Blazor/Tab.cs
+++ b/src/components/Blazor/Tab.cs
@@ -85,7 +85,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The tab item label.
         /// </summary>
@@ -105,7 +104,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _selected = false;
 
-        partial void OnSelectedChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the tab is selected.
         /// </summary>
@@ -125,7 +123,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the tab is disabled.
         /// </summary>

--- a/src/components/Blazor/TabComponentEventArgs.cs
+++ b/src/components/Blazor/TabComponentEventArgs.cs
@@ -54,13 +54,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbTabComponentEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTabComponentEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/TabComponentEventArgs.cs
+++ b/src/components/Blazor/TabComponentEventArgs.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbTab _detail;
 
-        partial void OnDetailChanging(ref IgbTab newValue);
-
         /// <summary>
         /// The tab that became selected.
         /// </summary>

--- a/src/components/Blazor/TabComponentEventArgs.cs
+++ b/src/components/Blazor/TabComponentEventArgs.cs
@@ -32,26 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTabComponentEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTabComponentEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/Tabs.cs
+++ b/src/components/Blazor/Tabs.cs
@@ -125,8 +125,6 @@ namespace IgniteUI.Blazor.Controls
 
         partial void GetSerializableTabsCollection(ref IgbTabs_TabCollection value);
 
-        partial void OnTabsCollectionChanging(ref IgbTabs_TabCollection newValue);
-
         public IgbTabs_TabCollection TabsCollection
         {
 
@@ -150,7 +148,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private TabsAlignment _alignment = TabsAlignment.Start;
 
-        partial void OnAlignmentChanging(ref TabsAlignment newValue);
         /// <summary>
         /// Sets the alignment for the tab headers.
         /// </summary>
@@ -170,7 +167,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private TabsActivation _activation = TabsActivation.Auto;
 
-        partial void OnActivationChanging(ref TabsActivation newValue);
         /// <summary>
         /// Determines the tab activation. When set to <see cref="TabsActivation.Auto"/>,
         /// the tab is instantly selected while navigating with the Left/Right Arrows, Home or End keys

--- a/src/components/Blazor/Tabs.cs
+++ b/src/components/Blazor/Tabs.cs
@@ -278,7 +278,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbTabComponentEventArgs args);
         private EventCallback<IgbTabComponentEventArgs>? _change = null;
 
         /// <summary>
@@ -300,8 +299,7 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbTabComponentEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
+                            SyncSelectedTab(args);
                         });
                         this.OnRefChanged("Change", null, "event:::Change", true, false, (refName, oldValue, newValue) =>
                         {

--- a/src/components/Blazor/Tabs.cs
+++ b/src/components/Blazor/Tabs.cs
@@ -335,13 +335,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbTabs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTabs(ser);
 
             if (IsPropDirty("TabsCollection"))
             { var coll = this._tabsCollection; GetSerializableTabsCollection(ref coll); ser.AddCollectionProp("tabsCollection", coll); }

--- a/src/components/Blazor/Tabs.cs
+++ b/src/components/Blazor/Tabs.cs
@@ -79,10 +79,6 @@ namespace IgniteUI.Blazor.Controls
                 return this._contentTabsCollection;
             }
         }
-        partial void GetSerializableTabsCollection(ref IgbTabs_TabCollection value)
-        {
-            value = ActualTabsCollection;
-        }
         private IgbTabs_TabCollection _actualTabsCollection = null;
 
         public IgbTabs_TabCollection ActualTabsCollection
@@ -122,8 +118,6 @@ namespace IgniteUI.Blazor.Controls
         }
 
         private IgbTabs_TabCollection _tabsCollection = null;
-
-        partial void GetSerializableTabsCollection(ref IgbTabs_TabCollection value);
 
         public IgbTabs_TabCollection TabsCollection
         {
@@ -326,7 +320,7 @@ namespace IgniteUI.Blazor.Controls
             base.SerializeCore(ser);
 
             if (IsPropDirty("TabsCollection"))
-            { var coll = this._tabsCollection; GetSerializableTabsCollection(ref coll); ser.AddCollectionProp("tabsCollection", coll); }
+            { ser.AddCollectionProp("tabsCollection", ActualTabsCollection); }
             if (IsPropDirty("Alignment"))
             { ser.AddEnumProp("alignment", this._alignment); }
             if (IsPropDirty("Activation"))

--- a/src/components/Blazor/Tabs.cs
+++ b/src/components/Blazor/Tabs.cs
@@ -209,22 +209,14 @@ namespace IgniteUI.Blazor.Controls
             return ReturnToString(iv);
         }
 
-        partial void FindByNameTabs(string name, ref object item);
         public override object FindByName(string name)
         {
-
             var baseResult = base.FindByName(name);
             if (baseResult != null)
             {
                 return baseResult;
             }
 
-            object item = null;
-            FindByNameTabs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
             if (_actualTabsCollection != null && _actualTabsCollection.HasName(name))
             { return _actualTabsCollection.FindByName(name); }
 

--- a/src/components/Blazor/Textarea.cs
+++ b/src/components/Blazor/Textarea.cs
@@ -573,7 +573,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInput(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _input = null;
 
         /// <summary>
@@ -593,11 +592,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _input, ref eventCallbacksCache))
                     {
                         _input = value;
-                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Input", value, (args) =>
-                        {
-                            OnHandlingInput(args);
-
-                        });
+                        this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Input", value);
                         this.OnRefChanged("Input", null, "event:::Input", true, false, (refName, oldValue, newValue) =>
                         {
                             this._inputRef = refName;
@@ -650,7 +645,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingChange(IgbComponentValueChangedEventArgs args);
         private EventCallback<IgbComponentValueChangedEventArgs>? _change = null;
 
         /// <summary>
@@ -672,8 +666,6 @@ namespace IgniteUI.Blazor.Controls
                         _change = value;
                         this.SetHandler<IgbComponentValueChangedEventArgs>(this.Name, "Change", value, (args) =>
                         {
-                            OnHandlingChange(args);
-
                             var newValueValue = default(string);
 
                             {
@@ -760,7 +752,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingFocus(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _focus = null;
 
         /// <summary>
@@ -780,11 +771,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _focus, ref eventCallbacksCache))
                     {
                         _focus = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value, (args) =>
-                        {
-                            OnHandlingFocus(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Focus", value);
                         this.OnRefChanged("Focus", null, "nativeEvent:::Focus", true, false, (refName, oldValue, newValue) =>
                         {
                             this._focusRef = refName;
@@ -837,7 +824,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingBlur(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _blur = null;
 
         /// <summary>
@@ -857,11 +843,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _blur, ref eventCallbacksCache))
                     {
                         _blur = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value, (args) =>
-                        {
-                            OnHandlingBlur(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Blur", value);
                         this.OnRefChanged("Blur", null, "nativeEvent:::Blur", true, false, (refName, oldValue, newValue) =>
                         {
                             this._blurRef = refName;

--- a/src/components/Blazor/Textarea.cs
+++ b/src/components/Blazor/Textarea.cs
@@ -435,25 +435,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTextarea(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTextarea(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Textarea.cs
+++ b/src/components/Blazor/Textarea.cs
@@ -923,13 +923,9 @@ namespace IgniteUI.Blazor.Controls
 
         partial void OnEventUpdatingValue(string oldValue, ref string newValue);
 
-        partial void SerializeCoreIgbTextarea(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTextarea(ser);
 
             if (IsPropDirty("Autocomplete"))
             { ser.AddStringProp("autocomplete", this._autocomplete); }

--- a/src/components/Blazor/Textarea.cs
+++ b/src/components/Blazor/Textarea.cs
@@ -715,8 +715,6 @@ namespace IgniteUI.Blazor.Controls
 
                             {
                                 newValueValue = (string)(args.Detail);
-                                ;
-                                OnEventUpdatingValue(this._value, ref newValueValue);
                                 if (UseDirectRender)
                                 {
                                     //TODO: maybe we should be doing this for everything. Need to make sure we don't infinity bounce though.
@@ -920,8 +918,6 @@ namespace IgniteUI.Blazor.Controls
                 }
             }
         }
-
-        partial void OnEventUpdatingValue(string oldValue, ref string newValue);
 
         internal override void SerializeCore(RendererSerializer ser)
         {

--- a/src/components/Blazor/Textarea.cs
+++ b/src/components/Blazor/Textarea.cs
@@ -55,7 +55,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _autocomplete;
 
-        partial void OnAutocompleteChanging(ref string newValue);
         /// <summary>
         /// Specifies what permission, if any, the browser has to provide automated assistance in filling
         /// out form field values, as well as guidance to the browser as to the type of information
@@ -79,7 +78,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _autocapitalize;
 
-        partial void OnAutocapitalizeChanging(ref string newValue);
         /// <summary>
         /// Controls whether and how text input is automatically capitalized as it is entered/edited by the user.
         /// <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize">
@@ -101,7 +99,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _inputMode;
 
-        partial void OnInputModeChanging(ref string newValue);
         /// <summary>
         /// Hints at the type of data that might be entered by the user while editing the control or its contents.
         /// This allows a browser to display an appropriate virtual keyboard.
@@ -125,7 +122,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The label for the control.
         /// </summary>
@@ -145,7 +141,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _maxLength = 0;
 
-        partial void OnMaxLengthChanging(ref double newValue);
         /// <summary>
         /// The maximum number of characters (UTF-16 code units) that the user can enter.
         /// If this value isn't specified, the user can enter an unlimited number of characters.
@@ -167,7 +162,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _minLength = 0;
 
-        partial void OnMinLengthChanging(ref double newValue);
         /// <summary>
         /// The minimum number of characters (UTF-16 code units) that the user is required to enter.
         /// </summary>
@@ -188,7 +182,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _outlined = false;
 
-        partial void OnOutlinedChanging(ref bool newValue);
         /// <summary>
         /// Whether the control will have outlined appearance.
         /// </summary>
@@ -208,7 +201,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _placeholder;
 
-        partial void OnPlaceholderChanging(ref string newValue);
         /// <summary>
         /// The placeholder text of the control.
         /// </summary>
@@ -228,7 +220,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _readOnly = false;
 
-        partial void OnReadOnlyChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a readonly field.
         /// </summary>
@@ -249,7 +240,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private TextareaResize _resize = TextareaResize.Vertical;
 
-        partial void OnResizeChanging(ref TextareaResize newValue);
         /// <summary>
         /// Controls whether the control can be resized.
         /// When <see cref="TextareaResize.Auto"/> is set, the control will try to expand and fit its content.
@@ -270,7 +260,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _rows = 3;
 
-        partial void OnRowsChanging(ref double newValue);
         /// <summary>
         /// The number of visible text lines for the control. If it is specified, it must be a positive integer.
         /// If it is not specified, the default value is 3.
@@ -291,7 +280,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The value of the component.
         /// </summary>
@@ -329,7 +317,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _spellcheck = true;
 
-        partial void OnSpellcheckChanging(ref bool newValue);
         /// <summary>
         /// Controls whether the control may be checked for spelling errors.
         /// </summary>
@@ -349,7 +336,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private TextareaWrap _wrap = TextareaWrap.Soft;
 
-        partial void OnWrapChanging(ref TextareaWrap newValue);
         /// <summary>
         /// Indicates how the control should wrap the value for form submission.
         /// Refer to
@@ -373,7 +359,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _validateOnly = false;
 
-        partial void OnValidateOnlyChanging(ref bool newValue);
         /// <summary>
         /// Enables validation rules to be evaluated without restricting user input. This applies to the
         /// <see cref="MaxLength"/> property when it is defined.
@@ -394,7 +379,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// The disabled state of the component.
         /// </summary>
@@ -414,7 +398,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _required = false;
 
-        partial void OnRequiredChanging(ref bool newValue);
         /// <summary>
         /// Makes the control a required field in a form context.
         /// </summary>
@@ -434,7 +417,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _invalid = false;
 
-        partial void OnInvalidChanging(ref bool newValue);
         /// <summary>
         /// Sets the control into invalid state (visual state only).
         /// </summary>

--- a/src/components/Blazor/ThemeProvider.cs
+++ b/src/components/Blazor/ThemeProvider.cs
@@ -94,25 +94,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameThemeProvider(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameThemeProvider(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ThemeProvider.cs
+++ b/src/components/Blazor/ThemeProvider.cs
@@ -57,7 +57,6 @@ namespace IgniteUI.Blazor.Controls
 
         private Theme _theme = Theme.Bootstrap;
 
-        partial void OnThemeChanging(ref Theme newValue);
         /// <summary>
         /// The theme to provide to descendant components.
         /// </summary>
@@ -77,7 +76,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private ThemeVariant _variant = ThemeVariant.Light;
 
-        partial void OnVariantChanging(ref ThemeVariant newValue);
         /// <summary>
         /// The theme variant to provide to descendant components.
         /// </summary>

--- a/src/components/Blazor/ThemeProvider.cs
+++ b/src/components/Blazor/ThemeProvider.cs
@@ -124,13 +124,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbThemeProvider(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbThemeProvider(ser);
 
             if (IsPropDirty("Theme"))
             { ser.AddEnumProp("theme", this._theme); }

--- a/src/components/Blazor/Tile.cs
+++ b/src/components/Blazor/Tile.cs
@@ -246,25 +246,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTile(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTile(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Tile.cs
+++ b/src/components/Blazor/Tile.cs
@@ -899,13 +899,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbTile(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTile(ser);
 
             if (IsPropDirty("ColSpan"))
             { ser.AddNumberProp("colSpan", this._colSpan); }

--- a/src/components/Blazor/Tile.cs
+++ b/src/components/Blazor/Tile.cs
@@ -54,7 +54,6 @@ namespace IgniteUI.Blazor.Controls
 
         private double _colSpan = 1;
 
-        partial void OnColSpanChanging(ref double newValue);
         /// <summary>
         /// The number of columns the tile will span.
         /// </summary>
@@ -74,7 +73,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _rowSpan = 1;
 
-        partial void OnRowSpanChanging(ref double newValue);
         /// <summary>
         /// The number of rows the tile will span.
         /// </summary>
@@ -94,7 +92,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double? _colStart = 0;
 
-        partial void OnColStartChanging(ref double? newValue);
         /// <summary>
         /// The starting column for the tile.
         /// </summary>
@@ -114,7 +111,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double? _rowStart = 0;
 
-        partial void OnRowStartChanging(ref double? newValue);
         /// <summary>
         /// The starting row for the tile.
         /// </summary>
@@ -152,7 +148,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _maximized = false;
 
-        partial void OnMaximizedChanging(ref bool newValue);
         /// <summary>
         /// Indicates whether the tile occupies all available space within the layout.
         /// </summary>
@@ -172,7 +167,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableResize = false;
 
-        partial void OnDisableResizeChanging(ref bool newValue);
         /// <summary>
         /// Indicates whether to disable tile resize behavior regardless
         /// of its tile manager parent settings.
@@ -193,7 +187,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableFullscreen = false;
 
-        partial void OnDisableFullscreenChanging(ref bool newValue);
         /// <summary>
         /// Whether to disable the rendering of the tile <c>fullscreen-action</c> slot and its
         /// default fullscreen action button.
@@ -214,7 +207,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disableMaximize = false;
 
-        partial void OnDisableMaximizeChanging(ref bool newValue);
         /// <summary>
         /// Whether to disable the rendering of the tile <c>maximize-action</c> slot and its
         /// default maximize action button.
@@ -235,7 +227,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _position = -1;
 
-        partial void OnPositionChanging(ref double newValue);
         /// <summary>
         /// Gets/sets the tile's visual position in the layout.
         /// Corresponds to the CSS <c>order</c> property.

--- a/src/components/Blazor/Tile.cs
+++ b/src/components/Blazor/Tile.cs
@@ -287,7 +287,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileFullscreen(IgbTileChangeStateEventArgs args);
         private EventCallback<IgbTileChangeStateEventArgs>? _tileFullscreen = null;
 
         /// <summary>
@@ -307,11 +306,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileFullscreen, ref eventCallbacksCache))
                     {
                         _tileFullscreen = value;
-                        this.SetHandler<IgbTileChangeStateEventArgs>(this.Name, "TileFullscreen", value, (args) =>
-                        {
-                            OnHandlingTileFullscreen(args);
-
-                        });
+                        this.SetHandler<IgbTileChangeStateEventArgs>(this.Name, "TileFullscreen", value);
                         this.OnRefChanged("TileFullscreen", null, "event:::TileFullscreen", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileFullscreenRef = refName;
@@ -364,7 +359,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileMaximize(IgbTileChangeStateEventArgs args);
         private EventCallback<IgbTileChangeStateEventArgs>? _tileMaximize = null;
 
         /// <summary>
@@ -384,11 +378,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileMaximize, ref eventCallbacksCache))
                     {
                         _tileMaximize = value;
-                        this.SetHandler<IgbTileChangeStateEventArgs>(this.Name, "TileMaximize", value, (args) =>
-                        {
-                            OnHandlingTileMaximize(args);
-
-                        });
+                        this.SetHandler<IgbTileChangeStateEventArgs>(this.Name, "TileMaximize", value);
                         this.OnRefChanged("TileMaximize", null, "event:::TileMaximize", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileMaximizeRef = refName;
@@ -441,7 +431,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileDragStart(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileDragStart = null;
 
         /// <summary>
@@ -461,11 +450,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileDragStart, ref eventCallbacksCache))
                     {
                         _tileDragStart = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragStart", value, (args) =>
-                        {
-                            OnHandlingTileDragStart(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragStart", value);
                         this.OnRefChanged("TileDragStart", null, "event:::TileDragStart", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileDragStartRef = refName;
@@ -518,7 +503,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileDragEnd(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileDragEnd = null;
 
         /// <summary>
@@ -538,11 +522,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileDragEnd, ref eventCallbacksCache))
                     {
                         _tileDragEnd = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragEnd", value, (args) =>
-                        {
-                            OnHandlingTileDragEnd(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragEnd", value);
                         this.OnRefChanged("TileDragEnd", null, "event:::TileDragEnd", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileDragEndRef = refName;
@@ -595,7 +575,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileDragCancel(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileDragCancel = null;
 
         /// <summary>
@@ -615,11 +594,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileDragCancel, ref eventCallbacksCache))
                     {
                         _tileDragCancel = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragCancel", value, (args) =>
-                        {
-                            OnHandlingTileDragCancel(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragCancel", value);
                         this.OnRefChanged("TileDragCancel", null, "event:::TileDragCancel", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileDragCancelRef = refName;
@@ -672,7 +647,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileResizeStart(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileResizeStart = null;
 
         /// <summary>
@@ -692,11 +666,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileResizeStart, ref eventCallbacksCache))
                     {
                         _tileResizeStart = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeStart", value, (args) =>
-                        {
-                            OnHandlingTileResizeStart(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeStart", value);
                         this.OnRefChanged("TileResizeStart", null, "event:::TileResizeStart", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileResizeStartRef = refName;
@@ -749,7 +719,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileResizeEnd(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileResizeEnd = null;
 
         /// <summary>
@@ -769,11 +738,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileResizeEnd, ref eventCallbacksCache))
                     {
                         _tileResizeEnd = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeEnd", value, (args) =>
-                        {
-                            OnHandlingTileResizeEnd(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeEnd", value);
                         this.OnRefChanged("TileResizeEnd", null, "event:::TileResizeEnd", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileResizeEndRef = refName;
@@ -826,7 +791,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileResizeCancel(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileResizeCancel = null;
 
         /// <summary>
@@ -846,11 +810,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileResizeCancel, ref eventCallbacksCache))
                     {
                         _tileResizeCancel = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeCancel", value, (args) =>
-                        {
-                            OnHandlingTileResizeCancel(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeCancel", value);
                         this.OnRefChanged("TileResizeCancel", null, "event:::TileResizeCancel", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileResizeCancelRef = refName;

--- a/src/components/Blazor/TileChangeStateEventArgs.cs
+++ b/src/components/Blazor/TileChangeStateEventArgs.cs
@@ -38,26 +38,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameTileChangeStateEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTileChangeStateEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/TileChangeStateEventArgs.cs
+++ b/src/components/Blazor/TileChangeStateEventArgs.cs
@@ -15,8 +15,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbTileChangeStateEventArgsDetail _detail;
 
-        partial void OnDetailChanging(ref IgbTileChangeStateEventArgsDetail newValue);
-
         /// <summary>
         /// The affected tile and the state it is changing to.
         /// </summary>
@@ -26,7 +24,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/TileChangeStateEventArgs.cs
+++ b/src/components/Blazor/TileChangeStateEventArgs.cs
@@ -61,13 +61,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbTileChangeStateEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTileChangeStateEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/TileChangeStateEventArgsDetail.cs
+++ b/src/components/Blazor/TileChangeStateEventArgsDetail.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbTile _tile;
 
-        partial void OnTileChanging(ref IgbTile newValue);
-
         /// <summary>
         /// The tile whose state is changing.
         /// </summary>
@@ -33,8 +31,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private bool _state = false;
-
-        partial void OnStateChanging(ref bool newValue);
 
         /// <summary>
         /// The state the tile is changing to; <see langword="true"/> when it is being maximized or

--- a/src/components/Blazor/TileChangeStateEventArgsDetail.cs
+++ b/src/components/Blazor/TileChangeStateEventArgsDetail.cs
@@ -83,13 +83,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });
         }
 
-        partial void SerializeCoreIgbTileChangeStateEventArgsDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTileChangeStateEventArgsDetail(ser);
 
             if (IsPropDirty("Tile"))
             { ser.AddSerializableProp("tile", this._tile); }

--- a/src/components/Blazor/TileChangeStateEventArgsDetail.cs
+++ b/src/components/Blazor/TileChangeStateEventArgsDetail.cs
@@ -51,25 +51,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTileChangeStateEventArgsDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTileChangeStateEventArgsDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/TileComponentEventArgs.cs
+++ b/src/components/Blazor/TileComponentEventArgs.cs
@@ -15,8 +15,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbTile _detail;
 
-        partial void OnDetailChanging(ref IgbTile newValue);
-
         /// <summary>
         /// The tile the operation applies to.
         /// </summary>

--- a/src/components/Blazor/TileComponentEventArgs.cs
+++ b/src/components/Blazor/TileComponentEventArgs.cs
@@ -33,26 +33,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTileComponentEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTileComponentEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/TileComponentEventArgs.cs
+++ b/src/components/Blazor/TileComponentEventArgs.cs
@@ -55,13 +55,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbTileComponentEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTileComponentEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/TileManager.cs
+++ b/src/components/Blazor/TileManager.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private TileManagerResizeMode _resizeMode = TileManagerResizeMode.None;
 
-        partial void OnResizeModeChanging(ref TileManagerResizeMode newValue);
         /// <summary>
         /// Whether resize operations are enabled.
         /// </summary>
@@ -73,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private TileManagerDragMode _dragMode = TileManagerDragMode.None;
 
-        partial void OnDragModeChanging(ref TileManagerDragMode newValue);
         /// <summary>
         /// Whether drag and drop operations are enabled.
         /// </summary>
@@ -92,8 +90,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
         private double _columnCount = 0;
-
-        partial void OnColumnCountChanging(ref double newValue);
 
         /// <summary>
         /// Sets the number of columns for the tile manager.
@@ -115,7 +111,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _minColumnWidth;
 
-        partial void OnMinColumnWidthChanging(ref string? newValue);
         /// <summary>
         /// Sets the minimum width for a column unit in the tile manager.
         /// </summary>
@@ -135,7 +130,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _minRowHeight;
 
-        partial void OnMinRowHeightChanging(ref string? newValue);
         /// <summary>
         /// Sets the minimum height for a row unit in the tile manager.
         /// </summary>
@@ -155,7 +149,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string? _gap;
 
-        partial void OnGapChanging(ref string? newValue);
         /// <summary>
         /// Sets the gap size between tiles in the tile manager.
         /// </summary>

--- a/src/components/Blazor/TileManager.cs
+++ b/src/components/Blazor/TileManager.cs
@@ -207,21 +207,20 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameTileManager(string name, ref object item);
         public override object FindByName(string name)
         {
-
             var baseResult = base.FindByName(name);
             if (baseResult != null)
             {
                 return baseResult;
             }
 
-            object item = null;
-            FindByNameTileManager(name, ref item);
-            if (item != null)
+            foreach (var item in ContentItems)
             {
-                return item;
+                if (item.Name == name || item.ContainerId == name)
+                {
+                    return item;
+                }
             }
 
             return null;

--- a/src/components/Blazor/TileManager.cs
+++ b/src/components/Blazor/TileManager.cs
@@ -298,7 +298,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileFullscreen(IgbTileChangeStateEventArgs args);
         private EventCallback<IgbTileChangeStateEventArgs>? _tileFullscreen = null;
 
         /// <summary>
@@ -318,11 +317,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileFullscreen, ref eventCallbacksCache))
                     {
                         _tileFullscreen = value;
-                        this.SetHandler<IgbTileChangeStateEventArgs>(this.Name, "TileFullscreen", value, (args) =>
-                        {
-                            OnHandlingTileFullscreen(args);
-
-                        });
+                        this.SetHandler<IgbTileChangeStateEventArgs>(this.Name, "TileFullscreen", value);
                         this.OnRefChanged("TileFullscreen", null, "event:::TileFullscreen", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileFullscreenRef = refName;
@@ -375,7 +370,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileMaximize(IgbTileChangeStateEventArgs args);
         private EventCallback<IgbTileChangeStateEventArgs>? _tileMaximize = null;
 
         /// <summary>
@@ -395,11 +389,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileMaximize, ref eventCallbacksCache))
                     {
                         _tileMaximize = value;
-                        this.SetHandler<IgbTileChangeStateEventArgs>(this.Name, "TileMaximize", value, (args) =>
-                        {
-                            OnHandlingTileMaximize(args);
-
-                        });
+                        this.SetHandler<IgbTileChangeStateEventArgs>(this.Name, "TileMaximize", value);
                         this.OnRefChanged("TileMaximize", null, "event:::TileMaximize", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileMaximizeRef = refName;
@@ -452,7 +442,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileDragStart(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileDragStart = null;
 
         /// <summary>
@@ -472,11 +461,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileDragStart, ref eventCallbacksCache))
                     {
                         _tileDragStart = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragStart", value, (args) =>
-                        {
-                            OnHandlingTileDragStart(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragStart", value);
                         this.OnRefChanged("TileDragStart", null, "event:::TileDragStart", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileDragStartRef = refName;
@@ -529,7 +514,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileDragEnd(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileDragEnd = null;
 
         /// <summary>
@@ -549,11 +533,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileDragEnd, ref eventCallbacksCache))
                     {
                         _tileDragEnd = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragEnd", value, (args) =>
-                        {
-                            OnHandlingTileDragEnd(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragEnd", value);
                         this.OnRefChanged("TileDragEnd", null, "event:::TileDragEnd", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileDragEndRef = refName;
@@ -606,7 +586,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileDragCancel(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileDragCancel = null;
 
         /// <summary>
@@ -626,11 +605,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileDragCancel, ref eventCallbacksCache))
                     {
                         _tileDragCancel = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragCancel", value, (args) =>
-                        {
-                            OnHandlingTileDragCancel(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileDragCancel", value);
                         this.OnRefChanged("TileDragCancel", null, "event:::TileDragCancel", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileDragCancelRef = refName;
@@ -683,7 +658,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileResizeStart(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileResizeStart = null;
 
         /// <summary>
@@ -703,11 +677,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileResizeStart, ref eventCallbacksCache))
                     {
                         _tileResizeStart = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeStart", value, (args) =>
-                        {
-                            OnHandlingTileResizeStart(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeStart", value);
                         this.OnRefChanged("TileResizeStart", null, "event:::TileResizeStart", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileResizeStartRef = refName;
@@ -760,7 +730,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileResizeEnd(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileResizeEnd = null;
 
         /// <summary>
@@ -780,11 +749,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileResizeEnd, ref eventCallbacksCache))
                     {
                         _tileResizeEnd = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeEnd", value, (args) =>
-                        {
-                            OnHandlingTileResizeEnd(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeEnd", value);
                         this.OnRefChanged("TileResizeEnd", null, "event:::TileResizeEnd", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileResizeEndRef = refName;
@@ -837,7 +802,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingTileResizeCancel(IgbTileComponentEventArgs args);
         private EventCallback<IgbTileComponentEventArgs>? _tileResizeCancel = null;
 
         /// <summary>
@@ -857,11 +821,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _tileResizeCancel, ref eventCallbacksCache))
                     {
                         _tileResizeCancel = value;
-                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeCancel", value, (args) =>
-                        {
-                            OnHandlingTileResizeCancel(args);
-
-                        });
+                        this.SetHandler<IgbTileComponentEventArgs>(this.Name, "TileResizeCancel", value);
                         this.OnRefChanged("TileResizeCancel", null, "event:::TileResizeCancel", true, false, (refName, oldValue, newValue) =>
                         {
                             this._tileResizeCancelRef = refName;

--- a/src/components/Blazor/TileManager.cs
+++ b/src/components/Blazor/TileManager.cs
@@ -890,13 +890,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbTileManager(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTileManager(ser);
 
             if (IsPropDirty("ResizeMode"))
             { ser.AddEnumProp("resizeMode", this._resizeMode); }

--- a/src/components/Blazor/Toast.cs
+++ b/src/components/Blazor/Toast.cs
@@ -44,25 +44,5 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameToast(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameToast(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
     }
 }

--- a/src/components/Blazor/Toast.cs
+++ b/src/components/Blazor/Toast.cs
@@ -64,15 +64,5 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbToast(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbToast(ser);
-
-        }
-
     }
 }

--- a/src/components/Blazor/ToggleButton.cs
+++ b/src/components/Blazor/ToggleButton.cs
@@ -112,25 +112,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameToggleButton(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameToggleButton(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/ToggleButton.cs
+++ b/src/components/Blazor/ToggleButton.cs
@@ -56,7 +56,6 @@ namespace IgniteUI.Blazor.Controls
 
         private string _value;
 
-        partial void OnValueChanging(ref string newValue);
         /// <summary>
         /// The value of the control.
         /// </summary>
@@ -76,7 +75,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _selected = false;
 
-        partial void OnSelectedChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the button is selected.
         /// </summary>
@@ -96,7 +94,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Determines whether the button is disabled.
         /// </summary>

--- a/src/components/Blazor/ToggleButton.cs
+++ b/src/components/Blazor/ToggleButton.cs
@@ -194,13 +194,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("click", new object[] { }, new string[] { });
         }
 
-        partial void SerializeCoreIgbToggleButton(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbToggleButton(ser);
 
             if (IsPropDirty("Value"))
             { ser.AddStringProp("value", this._value); }

--- a/src/components/Blazor/Tooltip.cs
+++ b/src/components/Blazor/Tooltip.cs
@@ -55,7 +55,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _open = false;
 
-        partial void OnOpenChanging(ref bool newValue);
         /// <summary>
         /// Whether the tooltip is showing.
         /// </summary>
@@ -75,7 +74,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _withArrow = false;
 
-        partial void OnWithArrowChanging(ref bool newValue);
         /// <summary>
         /// Whether to render an arrow indicator for the tooltip.
         /// </summary>
@@ -95,7 +93,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _offset = 6;
 
-        partial void OnOffsetChanging(ref double newValue);
         /// <summary>
         /// The offset of the tooltip from the anchor in pixels.
         /// </summary>
@@ -115,7 +112,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private PopoverPlacement _placement = PopoverPlacement.Bottom;
 
-        partial void OnPlacementChanging(ref PopoverPlacement newValue);
         /// <summary>
         /// Where to place the tooltip relative to its anchor element.
         /// </summary>
@@ -135,7 +131,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _anchor;
 
-        partial void OnAnchorChanging(ref string newValue);
         /// <summary>
         /// The ID of the element to use as the anchor for the tooltip.
         /// </summary>
@@ -155,7 +150,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _showTriggers;
 
-        partial void OnShowTriggersChanging(ref string newValue);
         /// <summary>
         /// Which event triggers will show the tooltip.
         /// Expects a comma separated string of different event triggers.
@@ -176,7 +170,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _hideTriggers;
 
-        partial void OnHideTriggersChanging(ref string newValue);
         /// <summary>
         /// Which event triggers will hide the tooltip.
         /// Expects a comma separated string of different event triggers.
@@ -197,7 +190,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _showDelay = 200;
 
-        partial void OnShowDelayChanging(ref double newValue);
         /// <summary>
         /// Specifies the number of milliseconds that should pass before showing the tooltip.
         /// </summary>
@@ -217,7 +209,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _hideDelay = 300;
 
-        partial void OnHideDelayChanging(ref double newValue);
         /// <summary>
         /// Specifies the number of milliseconds that should pass before hiding the tooltip.
         /// </summary>
@@ -237,7 +228,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _message;
 
-        partial void OnMessageChanging(ref string newValue);
         /// <summary>
         /// Specifies plain text as the tooltip content.
         /// </summary>
@@ -257,7 +247,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _sticky = false;
 
-        partial void OnStickyChanging(ref bool newValue);
         /// <summary>
         /// Specifies if the tooltip remains visible until the user closes it via the close button or Esc key.
         /// </summary>

--- a/src/components/Blazor/Tooltip.cs
+++ b/src/components/Blazor/Tooltip.cs
@@ -665,13 +665,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbTooltip(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTooltip(ser);
 
             if (IsPropDirty("Open"))
             { ser.AddBooleanProp("open", this._open); }

--- a/src/components/Blazor/Tooltip.cs
+++ b/src/components/Blazor/Tooltip.cs
@@ -359,7 +359,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpening(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opening = null;
 
         /// <summary>
@@ -379,11 +378,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opening, ref eventCallbacksCache))
                     {
                         _opening = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value, (args) =>
-                        {
-                            OnHandlingOpening(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opening", value);
                         this.OnRefChanged("Opening", null, "event:::Opening", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openingRef = refName;
@@ -436,7 +431,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingOpened(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _opened = null;
 
         /// <summary>
@@ -456,11 +450,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _opened, ref eventCallbacksCache))
                     {
                         _opened = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value, (args) =>
-                        {
-                            OnHandlingOpened(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Opened", value);
                         this.OnRefChanged("Opened", null, "event:::Opened", true, false, (refName, oldValue, newValue) =>
                         {
                             this._openedRef = refName;
@@ -513,7 +503,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosing(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closing = null;
 
         /// <summary>
@@ -533,11 +522,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closing, ref eventCallbacksCache))
                     {
                         _closing = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value, (args) =>
-                        {
-                            OnHandlingClosing(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closing", value);
                         this.OnRefChanged("Closing", null, "event:::Closing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closingRef = refName;
@@ -590,7 +575,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingClosed(IgbVoidEventArgs args);
         private EventCallback<IgbVoidEventArgs>? _closed = null;
 
         /// <summary>
@@ -610,11 +594,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _closed, ref eventCallbacksCache))
                     {
                         _closed = value;
-                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value, (args) =>
-                        {
-                            OnHandlingClosed(args);
-
-                        });
+                        this.SetHandler<IgbVoidEventArgs>(this.Name, "Closed", value);
                         this.OnRefChanged("Closed", null, "event:::Closed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._closedRef = refName;

--- a/src/components/Blazor/Tooltip.cs
+++ b/src/components/Blazor/Tooltip.cs
@@ -265,25 +265,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTooltip(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTooltip(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/Tree.cs
+++ b/src/components/Blazor/Tree.cs
@@ -612,13 +612,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void SerializeCoreIgbTree(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTree(ser);
 
             if (IsPropDirty("SingleBranchExpand"))
             { ser.AddBooleanProp("singleBranchExpand", this._singleBranchExpand); }

--- a/src/components/Blazor/Tree.cs
+++ b/src/components/Blazor/Tree.cs
@@ -178,7 +178,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingSelectionChanged(IgbTreeSelectionEventArgs args);
         private EventCallback<IgbTreeSelectionEventArgs>? _selectionChanged = null;
 
         /// <summary>
@@ -198,11 +197,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _selectionChanged, ref eventCallbacksCache))
                     {
                         _selectionChanged = value;
-                        this.SetHandler<IgbTreeSelectionEventArgs>(this.Name, "SelectionChanged", value, (args) =>
-                        {
-                            OnHandlingSelectionChanged(args);
-
-                        });
+                        this.SetHandler<IgbTreeSelectionEventArgs>(this.Name, "SelectionChanged", value);
                         this.OnRefChanged("SelectionChanged", null, "event:::SelectionChanged", true, false, (refName, oldValue, newValue) =>
                         {
                             this._selectionChangedRef = refName;
@@ -255,7 +250,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingItemExpanding(IgbTreeItemComponentEventArgs args);
         private EventCallback<IgbTreeItemComponentEventArgs>? _itemExpanding = null;
 
         /// <summary>
@@ -275,11 +269,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _itemExpanding, ref eventCallbacksCache))
                     {
                         _itemExpanding = value;
-                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ItemExpanding", value, (args) =>
-                        {
-                            OnHandlingItemExpanding(args);
-
-                        });
+                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ItemExpanding", value);
                         this.OnRefChanged("ItemExpanding", null, "event:::ItemExpanding", true, false, (refName, oldValue, newValue) =>
                         {
                             this._itemExpandingRef = refName;
@@ -332,7 +322,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingItemExpanded(IgbTreeItemComponentEventArgs args);
         private EventCallback<IgbTreeItemComponentEventArgs>? _itemExpanded = null;
 
         /// <summary>
@@ -352,11 +341,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _itemExpanded, ref eventCallbacksCache))
                     {
                         _itemExpanded = value;
-                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ItemExpanded", value, (args) =>
-                        {
-                            OnHandlingItemExpanded(args);
-
-                        });
+                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ItemExpanded", value);
                         this.OnRefChanged("ItemExpanded", null, "event:::ItemExpanded", true, false, (refName, oldValue, newValue) =>
                         {
                             this._itemExpandedRef = refName;
@@ -409,7 +394,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingItemCollapsing(IgbTreeItemComponentEventArgs args);
         private EventCallback<IgbTreeItemComponentEventArgs>? _itemCollapsing = null;
 
         /// <summary>
@@ -429,11 +413,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _itemCollapsing, ref eventCallbacksCache))
                     {
                         _itemCollapsing = value;
-                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ItemCollapsing", value, (args) =>
-                        {
-                            OnHandlingItemCollapsing(args);
-
-                        });
+                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ItemCollapsing", value);
                         this.OnRefChanged("ItemCollapsing", null, "event:::ItemCollapsing", true, false, (refName, oldValue, newValue) =>
                         {
                             this._itemCollapsingRef = refName;
@@ -486,7 +466,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingItemCollapsed(IgbTreeItemComponentEventArgs args);
         private EventCallback<IgbTreeItemComponentEventArgs>? _itemCollapsed = null;
 
         /// <summary>
@@ -506,11 +485,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _itemCollapsed, ref eventCallbacksCache))
                     {
                         _itemCollapsed = value;
-                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ItemCollapsed", value, (args) =>
-                        {
-                            OnHandlingItemCollapsed(args);
-
-                        });
+                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ItemCollapsed", value);
                         this.OnRefChanged("ItemCollapsed", null, "event:::ItemCollapsed", true, false, (refName, oldValue, newValue) =>
                         {
                             this._itemCollapsedRef = refName;
@@ -563,7 +538,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingActiveItem(IgbTreeItemComponentEventArgs args);
         private EventCallback<IgbTreeItemComponentEventArgs>? _activeItem = null;
 
         /// <summary>
@@ -583,11 +557,7 @@ namespace IgniteUI.Blazor.Controls
                     if (!CompareEventCallbacks(value, _activeItem, ref eventCallbacksCache))
                     {
                         _activeItem = value;
-                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ActiveItem", value, (args) =>
-                        {
-                            OnHandlingActiveItem(args);
-
-                        });
+                        this.SetHandler<IgbTreeItemComponentEventArgs>(this.Name, "ActiveItem", value);
                         this.OnRefChanged("ActiveItem", null, "event:::ActiveItem", true, false, (refName, oldValue, newValue) =>
                         {
                             this._activeItemRef = refName;

--- a/src/components/Blazor/Tree.cs
+++ b/src/components/Blazor/Tree.cs
@@ -111,21 +111,20 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTree(string name, ref object item);
         public override object FindByName(string name)
         {
-
             var baseResult = base.FindByName(name);
             if (baseResult != null)
             {
                 return baseResult;
             }
 
-            object item = null;
-            FindByNameTree(name, ref item);
-            if (item != null)
+            foreach (var item in ContentItems)
             {
-                return item;
+                if (item.Name == name || item.ContainerId == name)
+                {
+                    return item;
+                }
             }
 
             return null;

--- a/src/components/Blazor/Tree.cs
+++ b/src/components/Blazor/Tree.cs
@@ -55,7 +55,6 @@ namespace IgniteUI.Blazor.Controls
 
         private bool _singleBranchExpand = false;
 
-        partial void OnSingleBranchExpandChanging(ref bool newValue);
         /// <summary>
         /// Whether a single or multiple of a parent's child items can be expanded.
         /// </summary>
@@ -75,7 +74,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _toggleNodeOnClick = false;
 
-        partial void OnToggleNodeOnClickChanging(ref bool newValue);
         /// <summary>
         /// Whether clicking over nodes will change their expanded state or not.
         /// </summary>
@@ -95,7 +93,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private TreeSelection _selection = TreeSelection.None;
 
-        partial void OnSelectionChanging(ref TreeSelection newValue);
         /// <summary>
         /// The selection state of the tree.
         /// </summary>

--- a/src/components/Blazor/TreeItem.cs
+++ b/src/components/Blazor/TreeItem.cs
@@ -361,13 +361,9 @@ namespace IgniteUI.Blazor.Controls
             InvokeMethodSync("collapse", new object[] { }, new string[] { });
         }
 
-        partial void SerializeCoreIgbTreeItem(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTreeItem(ser);
 
             if (IsPropDirty("Parent"))
             { ser.AddSerializableProp("parent", this._parent); }

--- a/src/components/Blazor/TreeItem.cs
+++ b/src/components/Blazor/TreeItem.cs
@@ -53,7 +53,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbTreeItem _parent;
 
-        partial void OnParentChanging(ref IgbTreeItem newValue);
         /// <summary>
         /// The parent item of the current tree item (if any)
         /// </summary>
@@ -73,7 +72,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private double _level = 0;
 
-        partial void OnLevelChanging(ref double newValue);
         /// <summary>
         /// The depth of the item, relative to the root.
         /// </summary>
@@ -93,7 +91,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private string _label;
 
-        partial void OnLabelChanging(ref string newValue);
         /// <summary>
         /// The tree item label.
         /// </summary>
@@ -113,7 +110,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _expanded = false;
 
-        partial void OnExpandedChanging(ref bool newValue);
         /// <summary>
         /// The tree item expansion state.
         /// </summary>
@@ -133,7 +129,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _active = false;
 
-        partial void OnActiveChanging(ref bool newValue);
         /// <summary>
         /// Marks the item as the tree's active item.
         /// </summary>
@@ -153,7 +148,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _disabled = false;
 
-        partial void OnDisabledChanging(ref bool newValue);
         /// <summary>
         /// Get/Set whether the tree item is disabled. Disabled items are ignored for user interactions.
         /// </summary>
@@ -173,7 +167,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _selected = false;
 
-        partial void OnSelectedChanging(ref bool newValue);
         /// <summary>
         /// The tree item selection state.
         /// </summary>
@@ -193,7 +186,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private bool _loading = false;
 
-        partial void OnLoadingChanging(ref bool newValue);
         /// <summary>
         /// To be used for load-on-demand scenarios in order to specify whether the item is loading data.
         /// </summary>
@@ -213,7 +205,6 @@ namespace IgniteUI.Blazor.Controls
         }
         private object _value;
 
-        partial void OnValueChanging(ref object newValue);
         /// <summary>
         /// The value entry that the tree item is visualizing. Required for searching through items.
         /// </summary>

--- a/src/components/Blazor/TreeItem.cs
+++ b/src/components/Blazor/TreeItem.cs
@@ -263,25 +263,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameTreeItem(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTreeItem(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
         public async Task SetNativeElementAsync(Object element)
         {
             await InvokeMethod("setNativeElement", new object[] { ObjectToParam(element) }, new string[] { "Json" });

--- a/src/components/Blazor/TreeItemComponentEventArgs.cs
+++ b/src/components/Blazor/TreeItemComponentEventArgs.cs
@@ -33,26 +33,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTreeItemComponentEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTreeItemComponentEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/TreeItemComponentEventArgs.cs
+++ b/src/components/Blazor/TreeItemComponentEventArgs.cs
@@ -55,13 +55,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbTreeItemComponentEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTreeItemComponentEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/TreeItemComponentEventArgs.cs
+++ b/src/components/Blazor/TreeItemComponentEventArgs.cs
@@ -15,8 +15,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbTreeItem _detail;
 
-        partial void OnDetailChanging(ref IgbTreeItem newValue);
-
         /// <summary>
         /// The tree item the event applies to.
         /// </summary>

--- a/src/components/Blazor/TreeSelectionEventArgs.cs
+++ b/src/components/Blazor/TreeSelectionEventArgs.cs
@@ -59,13 +59,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbTreeSelectionEventArgs(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTreeSelectionEventArgs(ser);
 
             if (IsPropDirty("Detail"))
             { ser.AddSerializableProp("detail", this._detail); }

--- a/src/components/Blazor/TreeSelectionEventArgs.cs
+++ b/src/components/Blazor/TreeSelectionEventArgs.cs
@@ -13,8 +13,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbTreeSelectionEventArgsDetail _detail;
 
-        partial void OnDetailChanging(ref IgbTreeSelectionEventArgsDetail newValue);
-
         /// <summary>
         /// The selection the tree is about to apply.
         /// </summary>
@@ -24,7 +22,6 @@ namespace IgniteUI.Blazor.Controls
             get { return this._detail; }
             set
             {
-                OnDetailChanging(ref value);
                 MarkPropDirty("Detail");
                 if (this._detail != null)
                 {

--- a/src/components/Blazor/TreeSelectionEventArgs.cs
+++ b/src/components/Blazor/TreeSelectionEventArgs.cs
@@ -36,26 +36,6 @@ namespace IgniteUI.Blazor.Controls
 
         }
 
-        partial void FindByNameTreeSelectionEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTreeSelectionEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/TreeSelectionEventArgsDetail.cs
+++ b/src/components/Blazor/TreeSelectionEventArgsDetail.cs
@@ -14,8 +14,6 @@ namespace IgniteUI.Blazor.Controls
 
         private IgbTreeItem[] _newSelection;
 
-        partial void OnNewSelectionChanging(ref IgbTreeItem[] newValue);
-
         /// <summary>
         /// The tree items that will make up the new selection.
         /// </summary>

--- a/src/components/Blazor/TreeSelectionEventArgsDetail.cs
+++ b/src/components/Blazor/TreeSelectionEventArgsDetail.cs
@@ -54,13 +54,9 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbTreeSelectionEventArgsDetail(RendererSerializer ser);
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);
-
-            SerializeCoreIgbTreeSelectionEventArgsDetail(ser);
 
             if (IsPropDirty("NewSelection"))
             { ser.AddSerializableArrayProp("newSelection", this._newSelection); }

--- a/src/components/Blazor/TreeSelectionEventArgsDetail.cs
+++ b/src/components/Blazor/TreeSelectionEventArgsDetail.cs
@@ -32,26 +32,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTreeSelectionEventArgsDetail(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameTreeSelectionEventArgsDetail(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         internal override void SerializeCore(RendererSerializer ser)
         {
             base.SerializeCore(ser);

--- a/src/components/Blazor/VoidEventArgs.cs
+++ b/src/components/Blazor/VoidEventArgs.cs
@@ -29,16 +29,6 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        partial void SerializeCoreIgbVoidEventArgs(RendererSerializer ser);
-
-        internal override void SerializeCore(RendererSerializer ser)
-        {
-            base.SerializeCore(ser);
-
-            SerializeCoreIgbVoidEventArgs(ser);
-
-        }
-
         protected internal override void ToEventJson(BaseRendererControl control, Dictionary<string, object> args)
         {
             base.ToEventJson(control, args);

--- a/src/components/Blazor/VoidEventArgs.cs
+++ b/src/components/Blazor/VoidEventArgs.cs
@@ -9,26 +9,6 @@ namespace IgniteUI.Blazor.Controls
     {
         public override string Type { get { return "VoidEventArgs"; } }
 
-        partial void FindByNameVoidEventArgs(string name, ref object item);
-        public override object FindByName(string name)
-        {
-
-            var baseResult = base.FindByName(name);
-            if (baseResult != null)
-            {
-                return baseResult;
-            }
-
-            object item = null;
-            FindByNameVoidEventArgs(name, ref item);
-            if (item != null)
-            {
-                return item;
-            }
-
-            return null;
-        }
-
         protected internal override void ToEventJson(BaseRendererControl control, Dictionary<string, object> args)
         {
             base.ToEventJson(control, args);

--- a/src/componentsBase/WebInputs/Accordion.cs
+++ b/src/componentsBase/WebInputs/Accordion.cs
@@ -27,17 +27,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameAccordion(string name, ref object item)
-        {
-            foreach (var it in ContentItems)
-            {
-                if (it.Name == name || it.ContainerId == name)
-                {
-                    item = it;
-                    return;
-                }
-            }
-        }
     }
 
     public partial class IgbExpansionPanel : IDisposable

--- a/src/componentsBase/WebInputs/Chat.cs
+++ b/src/componentsBase/WebInputs/Chat.cs
@@ -6,12 +6,6 @@ namespace IgniteUI.Blazor.Controls
     /// </remarks>
     public partial class IgbChat
     {
-        partial void OnOptionsChanging(ref IgbChatOptions? newValue)
-        {
-            newValue ??= new IgbChatOptions();
-            newValue.DisableInputAttachments = true;
-        }
-
         public IgbChatDraftMessage GetCurrentDraftMessage()
         {
             var iv = InvokeMethodSync("p:DraftMessage", new object[] { }, new string[] { });

--- a/src/componentsBase/WebInputs/Dropdown.cs
+++ b/src/componentsBase/WebInputs/Dropdown.cs
@@ -100,17 +100,6 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameDropdown(string name, ref object item)
-        {
-            foreach (var it in ContentItems)
-            {
-                if (it.Name == name || it.ContainerId == name)
-                {
-                    item = it;
-                    return;
-                }
-            }
-        }
     }
 
 }

--- a/src/componentsBase/WebInputs/Input.cs
+++ b/src/componentsBase/WebInputs/Input.cs
@@ -20,7 +20,7 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void OnHandlingInputOcurred(IgbComponentValueChangedEventArgs args)
+        private void RaiseValueChanging(IgbComponentValueChangedEventArgs args)
         {
             if (!EventCallback<string>.Empty.Equals(ValueChanging))
             {

--- a/src/componentsBase/WebInputs/Select.cs
+++ b/src/componentsBase/WebInputs/Select.cs
@@ -25,16 +25,5 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameSelect(string name, ref object item)
-        {
-            foreach (var it in ContentItems)
-            {
-                if (it.Name == name || it.ContainerId == name)
-                {
-                    item = it;
-                    return;
-                }
-            }
-        }
     }
 }

--- a/src/componentsBase/WebInputs/Tabs.cs
+++ b/src/componentsBase/WebInputs/Tabs.cs
@@ -5,7 +5,7 @@ namespace IgniteUI.Blazor.Controls
     public partial class IgbTabs : BaseRendererControl
     {
 
-        partial void OnHandlingChange(IgbTabComponentEventArgs args)
+        private void SyncSelectedTab(IgbTabComponentEventArgs args)
         {
             var selectedTab = args.Detail;
             // add check in case something triggers event without args.

--- a/src/componentsBase/WebInputs/TileManager.cs
+++ b/src/componentsBase/WebInputs/TileManager.cs
@@ -25,16 +25,5 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTileManager(string name, ref object item)
-        {
-            foreach (var it in ContentItems)
-            {
-                if (it.Name == name || it.ContainerId == name)
-                {
-                    item = it;
-                    return;
-                }
-            }
-        }
     }
 }

--- a/src/componentsBase/WebInputs/Tree.cs
+++ b/src/componentsBase/WebInputs/Tree.cs
@@ -25,16 +25,5 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        partial void FindByNameTree(string name, ref object item)
-        {
-            foreach (var it in ContentItems)
-            {
-                if (it.Name == name || it.ContainerId == name)
-                {
-                    item = it;
-                    return;
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Removes the generated `partial void` extensibility hooks from `src/components/Blazor/`. They were a code-generation affordance: a seam for hand-written partials to intercept generated code. Now that the source is hand-maintained, the seam has no reason to exist — a hook with no implementation is unreachable code, and a hook with one is an indirection that reads better inlined at the call point.

**After this series there are zero `partial void` members in `src/`.** One commit per family so each can be reviewed on its own. Continues #316 (`OnCreated*` constructor hooks).

| Commit | Family | Declarations | Call sites | Implementations | Lines |
| --- | --- | --- | --- | --- | --- |
| 1 | `SerializeCoreIgb<X>` | 141 | 141 | 0 | -696 |
| 2 | `OnEventUpdating<Prop>` | 16 | 16 | 0 | -64 |
| 3 | `On<Prop>Changing` | 538 | 46 | 1 (inlined) | -666 |
| 4 | `FindByName<X>` | 141 | 141 | 5 (inlined) | -2686 |
| 5 | `OnHandling<Event>` | 121 | 121 | 2 (renamed) | -569 |
| 6 | `OnIgbTab*`, `GetSerializableTabsCollection` | 3 | 3 | 1 (inlined) | -12 |

Commits 1–6 total **149 files, +137 / -4830**.

---

## Commit 1 — `SerializeCoreIgb<X>`

Every generated type that overrides `SerializeCore` declared a hook and called it as the first statement after `base.SerializeCore(ser)`:

```csharp
partial void SerializeCoreIgbAccordion(RendererSerializer ser);

internal override void SerializeCore(RendererSerializer ser)
{
    base.SerializeCore(ser);

    SerializeCoreIgbAccordion(ser);

    if (IsPropDirty("SingleExpand"))
    { ser.AddBooleanProp("singleExpand", this._singleExpand); }
    ...
}
```

**141 declarations, 141 call sites, 0 implementations** repo-wide, including `tests/` and `stories/`. Unlike a bare declaration, which the compiler erases for free, each of these also occupied a line inside the per-render property snapshot path.

| Change | Count |
| --- | --- |
| `partial void SerializeCoreIgb<X>(RendererSerializer ser);` declarations removed | 141 |
| `SerializeCoreIgb<X>(ser);` call sites removed | 141 |
| `SerializeCore` overrides in classes with no declared serializable properties left with nothing to do, removed entirely | 22 |

## Commit 2 — `OnEventUpdating<Prop>`

The inbound half of two-way binding. When the client raises the change event for a bound property, the generated handler converts the payload, called this hook to let a partial adjust the value in flight, then wrote it back and invoked `<Prop>Changed`:

```csharp
newValueSelected = (bool)(args.Detail);
;
OnEventUpdatingSelected(this._selected, ref newValueSelected);
if (UseDirectRender)
{
    this.Selected = newValueSelected;
}
```
Also removed: the **16 stray empty statements** (`;` alone on a line)

---

## Commit 3 — `On<Prop>Changing`

The generator declared one of these next to every property backing field, and the setter called it so a partial could rewrite the incoming value before the property stored it:

```csharp
private IgbChatOptions? _options;

partial void OnOptionsChanging(ref IgbChatOptions? newValue);

[Parameter]
public IgbChatOptions? Options
{
    get { return this._options; }
    set
    {
        OnOptionsChanging(ref value);
        MarkPropDirty("Options");
        ...
    }
}
```

| Change | Count |
| --- | --- |
| `partial void On<Prop>Changing(ref T newValue);` declarations removed | 538 |
| of which had no call site whatsoever | 492 |
| `On<Prop>Changing(ref value);` call sites removed | 45 |
| implementations folded into the setter | 1 |

### The one implementation

`IgbChat.OnOptionsChanging` lived in [src/componentsBase/WebInputs/Chat.cs](src/componentsBase/WebInputs/Chat.cs) and normalized the incoming options object. Moved into the `Options` setter it was called from, which is now self-explanatory:

```csharp
set
{
    // Never store a null options object, and input attachments are not supported yet.
    value ??= new IgbChatOptions();
    value.DisableInputAttachments = true;
    MarkPropDirty("Options");
    ...
}
```

---

## Commit 4 — `FindByName<X>`

Name-based ref resolution: the client sends `{"refType": "name", "id": "…"}` and `FindByName` maps it back to the .NET instance. Every generated type declared a hook and an override that tried base, then the hook, then gave up:

```csharp
partial void FindByNameAvatar(string name, ref object item);
public override object FindByName(string name)
{
    var baseResult = base.FindByName(name);
    if (baseResult != null) { return baseResult; }

    object item = null;
    FindByNameAvatar(name, ref item);
    if (item != null) { return item; }

    return null;
}
```

With the hook unimplemented that whole override reduces to `return base.FindByName(name)`, so **135 of the 141 were forwarding-only and are removed entirely**.

The **5 implementations** (`Accordion`, `Dropdown`, `Select`, `TileManager`, `Tree`) were five byte-identical copies of the same `ContentItems` scan sitting in `componentsBase/WebInputs`. Each is now inlined into its own override, and the `ref`-parameter dance becomes a direct return:

```csharp
foreach (var item in ContentItems)
{
    if (item.Name == name || item.ContainerId == name)
    {
        return item;
    }
}
```

`IgbTabs` is the sixth case — it keeps its override for the `ActualTabsCollection` lookup, minus the hook.

---

## Commit 5 — `OnHandling<Event>`

Every event setter wrapped the hook in an `onArgs` lambda handed to `SetHandler`:

```csharp
this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opening", value, (args) =>
{
    OnHandlingOpening(args);

});
```

**104 of the 121 lambdas contained nothing but the dead call.** `onArgs` is an optional parameter that `SetHandler` null-checks before invoking ([BaseRendererControl.cs:2952](src/componentsBase/BaseRendererControl.cs#L2952)), so the argument is dropped outright rather than left as an empty lambda — one less closure allocated per wired event:

```csharp
this.SetHandler<IgbExpansionPanelComponentEventArgs>(this.Name, "Opening", value);
```

The other 15 lambdas carry two-way binding write-back and keep their bodies, minus the hook call.

The **2 implementations** become ordinary private methods named for what they do, called from the same point:

| Was | Now |
| --- | --- |
| `IgbTabs.OnHandlingChange` | `SyncSelectedTab` |
| `IgbInputBase.OnHandlingInputOcurred` | `RaiseValueChanging` |

Both stay in `componentsBase/WebInputs` beside the `EnsureXHandled` helpers they belong with. Only the hook indirection is gone — the call site now names a real method instead of dispatching to a partial that may or may not exist.

---

## Commit 6 — the last three

- `IgbTab.OnIgbTabInitializing` / `OnIgbTabDisposing` — declared and called in `OnInitializedAsync` and `Dispose`, never implemented.
- `IgbTabs.GetSerializableTabsCollection` — declared *and* implemented in the same generated file, so the partial bought nothing. Its body assigned `ActualTabsCollection` unconditionally, which made the caller's read of `_tabsCollection` dead code:

  ```csharp
  // was
  { var coll = this._tabsCollection; GetSerializableTabsCollection(ref coll); ser.AddCollectionProp("tabsCollection", coll); }
  // now
  { ser.AddCollectionProp("tabsCollection", ActualTabsCollection); }
  ```

---

## Found while sweeping, not fixed here

`IgbTab.Dispose()` **adds** the tab to its parent collection instead of removing it ([src/components/Blazor/Tab.cs:59](src/components/Blazor/Tab.cs#L59)):

```csharp
public void Dispose()
{
    if (TabsParent != null)
    {
        var sv = (IgbTabs)TabsParent;
        sv.ContentTabsCollection.Add(this);   // Add, in Dispose
    }
}
```

`OnInitializedAsync` immediately above it does the identical `Add`. Compare `IgbExpansionPanel.Dispose()` in [src/componentsBase/WebInputs/Accordion.cs](src/componentsBase/WebInputs/Accordion.cs), which calls `ContentItems.Remove(this)`. This looks like a copy-paste fault in the generator template — a disposed tab is re-added to `ContentTabsCollection`, so the collection accumulates dead entries across re-renders. Left alone deliberately: it is a behaviour change that wants its own test and its own commit, not a line smuggled into a dead-code sweep.
Edit: https://github.com/IgniteUI/igniteui-blazor/pull/319
