### PR TITLE
fix(tabs): remove the tab from its parent collection on dispose

### DIFF
--- a/src/components/Blazor/Tab.cs
+++ b/src/components/Blazor/Tab.cs
@@ -62,7 +62,7 @@ namespace IgniteUI.Blazor.Controls
             if (TabsParent != null)
             {
                 var sv = (IgbTabs)TabsParent;
-                sv.ContentTabsCollection.Add(this);
+                sv.ContentTabsCollection.Remove(this);
             }
 
         }

--- a/tests/IgniteUI.Blazor.Tests/TabsTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TabsTests.cs
@@ -124,9 +124,6 @@ public class TabsTests : ComponentWithContractTestBase<IgbTabs>
             cut.Instance.ActualTabsCollection);
     }
 
-    // Regression: IgbTab.Dispose called ContentTabsCollection.Add instead of Remove, so a
-    // disposed tab was re-added and ended up in ActualTabsCollection twice — the collection
-    // grew on teardown instead of shrinking, and the stale tab kept being serialized.
     [Fact]
     public void Tabs_DisposedChildTab_LeavesTheCollection()
     {

--- a/tests/IgniteUI.Blazor.Tests/TabsTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TabsTests.cs
@@ -99,6 +99,56 @@ public class TabsTests : ComponentWithContractTestBase<IgbTabs>
     {
         Assert.True(typeof(IgbTabs).IsSubclassOf(typeof(BaseRendererControl)));
     }
+
+    /// <summary>Renders <paramref name="labels"/> as <see cref="IgbTab"/> children.</summary>
+    static Action<ComponentParameterCollectionBuilder<IgbTabs>> TabsWith(params string[] labels) => ps =>
+        ps.AddChildContent(builder =>
+        {
+            var seq = 0;
+            foreach (var label in labels)
+            {
+                builder.OpenComponent<IgbTab>(seq++);
+                builder.AddAttribute(seq++, "Label", label);
+                builder.CloseComponent();
+            }
+        });
+
+    [Fact]
+    public void Tabs_ChildTabs_RegisterOnInitialize()
+    {
+        var cut = Render<IgbTabs>(TabsWith("one", "two"));
+
+        Assert.Equal(2, cut.Instance.ActualTabsCollection.Count);
+        Assert.Equal(
+            cut.FindComponents<IgbTab>().Select(t => t.Instance),
+            cut.Instance.ActualTabsCollection);
+    }
+
+    // Regression: IgbTab.Dispose called ContentTabsCollection.Add instead of Remove, so a
+    // disposed tab was re-added and ended up in ActualTabsCollection twice — the collection
+    // grew on teardown instead of shrinking, and the stale tab kept being serialized.
+    [Fact]
+    public void Tabs_DisposedChildTab_LeavesTheCollection()
+    {
+        var cut = Render<IgbTabs>(TabsWith("one", "two"));
+        Assert.Equal(2, cut.Instance.ActualTabsCollection.Count);
+
+        // Re-render without the second tab; Blazor disposes the removed component.
+        cut.Render(TabsWith("one"));
+
+        var remaining = Assert.Single(cut.FindComponents<IgbTab>()).Instance;
+        Assert.Same(remaining, Assert.Single(cut.Instance.ActualTabsCollection));
+    }
+
+    [Fact]
+    public void Tabs_AllChildTabsDisposed_EmptiesTheCollection()
+    {
+        var cut = Render<IgbTabs>(TabsWith("one", "two"));
+
+        cut.Render(ps => ps.AddChildContent(builder => { }));
+
+        Assert.Empty(cut.Instance.ActualTabsCollection);
+    }
 }
 
 // IgbTab has no interop surface of its own: its @bind-Selected pair is driven entirely by


### PR DESCRIPTION
`IgbTab.Dispose()` called `ContentTabsCollection.Add(this)` — the same call `OnInitializedAsync` makes directly above it:

```csharp
public void Dispose()
{
    if (TabsParent != null)
    {
        var sv = (IgbTabs)TabsParent;
        sv.ContentTabsCollection.Add(this);   // Add, on teardown
    }
}
```

The fix: `Add` → `Remove`. This is what the other five parent/child handling have always done — `IgbExpansionPanel`, `IgbDropdownItem`, `IgbSelectItem`, `IgbTile` and `IgbTreeItem` all call `ContentItems.Remove(this)` in `Dispose`.

Adds three tests: registration on initialize, one child disposed, and all children disposed. The two regression tests were confirmed failing against the bug before the fix.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

## Checklist:
 - [ x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified