### PR TITLE
test: cover child collection lifecycle for every parent/child family

### DIFF
--- a/.github/workflows/igniteui-blazor-lite-release.yml
+++ b/.github/workflows/igniteui-blazor-lite-release.yml
@@ -50,7 +50,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Build .NET library
-        run: dotnet build ./src/IgniteUI.Blazor.Lite.csproj --no-restore --configuration Release /p:Version=${{ env.VERSION }} /p:TreatWarningsAsErrors=false
+        run: dotnet build ./src/IgniteUI.Blazor.Lite.csproj --no-restore --configuration Release /p:Version=${{ env.VERSION }} /p:TreatWarningsAsErrors=false /p:ExposeInternalsToTests=false
 
       - name: Authenticate to Azure
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0

--- a/skills/igniteui-blazor-lite-testing/SKILL.md
+++ b/skills/igniteui-blazor-lite-testing/SKILL.md
@@ -20,6 +20,7 @@ Three test projects under `tests/`, two suites:
 |---|---|
 | Property → rendered attribute (direct-render components) | unit: plain bUnit facts (`cut.Find(...).GetAttribute(...)`) |
 | Markup/child content rendering | unit: plain bUnit facts |
+| **Parent/child collection membership** — a child registering itself into its parent's collection and leaving again over the child's lifetime | unit: plain bUnit facts in the *parent's* suite, in a `#region Child collection lifecycle` — membership only; name resolution *off* that collection is interop behavior and stays in the contract |
 | Message-borne state serialization shapes | unit: `PropertySerializationTests` / `EnumSerializationTests` / `RenderingSerializationTests` |
 | **Interop wire behavior** — method identifiers, argument serialization + type tags, return decoding, event-handler registration/removal transmissions + JS→.NET event dispatch, `@bind-` two-way round trips, interop-borne props/data | unit: the component's `ComponentContract` — full authoring guide: [`references/interop-contracts.md`](./references/interop-contracts.md) |
 | `<Member>Script` parameters (JS-side handlers/providers) | unit: automated sweep (`ScriptPropTests`, all components at once — no per-contract entries, no integration coverage exists) |
@@ -49,6 +50,7 @@ dotnet test tests/IgniteUI.Blazor.Tests -f net10.0 --nologo --filter "FullyQuali
 - Generally follow **one file per component: `<Name>Tests.cs` holds `<Name>Tests`.** A component's **child** components may share the parent's file (`SelectTests.cs` also holds `SelectItemTests`/`SelectGroupTests`/`SelectHeaderTests`; likewise Card, List, Dropdown, NavDrawer, Tabs, Stepper, TileManager, Tree, Rating, Slider) — that's the only permitted multi-class file. Cross-cutting suites (`BaseControlTests`, `*SerializationTests`, `ScriptPropTests`, `Interop*Tests`) are keyed to a class/behavior, not a component, and keep their own files.
 - New facts go into the existing `<Name>Tests` class; if the class carries a contract, plain bUnit facts sit alongside the contract runners in the same class.
 - Shared test helpers live in `ElementAssertionExtensions.cs`.
+- **Readable arrange/act/assert in the test beats sharing.** A little repetition across suites is fine; extract obvious repeated mechanics if needed, but ensure those are well documented and easy to grasp without breaking the flow of the test itself.
 - **Skips need a mechanism reason.** Bug-tracker or `componentsConfig.json` listings are not skip reasons. If a member's decode hits a gap in shared infrastructure the change doesn't own, cover it pinning current behavior and write the *correct* assertion commented out under a `// TODO:` explaining the gap — ready to uncomment when fixed. A gap in a component under construction is a bug to fix, not to pin — see the two authoring modes in the interop reference.
 - Components are `partial` — the generated `src/components/Blazor/<Name>.cs` is not the whole class; always check `src/componentsBase/WebInputs/<Name>.cs` for hand-written extensions before drawing conclusions.
 - Formatting: only `dotnet format whitespace --folder` is safe in this repo — a full `dotnet format` writes conflict markers into multi-targeted sources.
@@ -78,5 +80,6 @@ over the component's public surface —
 ## Adding coverage for a new component — checklist
 
 1. Unit suite: bUnit facts for rendered attributes/markup; if the component has an interop surface (it sends interop invocations or registers JS-originated event handlers — the reference explains how to identify these per stack), add a `ComponentContract` per [`references/interop-contracts.md`](./references/interop-contracts.md). For a brand-new component this works TDD-style: author the contract first from the intended API following the library's conventions; the contract doubles as the API design record (spec mode in the reference).
-2. Integration: the sweep picks the component up automatically; add  `componentsConfig.json` entries only for members the generic sweep genuinely cannot  model (cite why), and mirror each exclusion with unit contract coverage.
-3. Verify: unit full-suite on all TFMs, plus the component's integration fixture.
+2. If it is a parent that collects children, or a child that registers with a parent, exercise that membership **over the child's lifetime**, not just at first render: the children are the collection in order, a disposed child leaves it, all disposed empties it. Keep these facts to membership and asserting resolution that are covered by the interop contract.
+3. Integration: the sweep picks the component up automatically; add  `componentsConfig.json` entries only for members the generic sweep genuinely cannot  model (cite why), and mirror each exclusion with unit contract coverage.
+4. Verify: unit full-suite on all TFMs, plus the component's integration fixture.

--- a/src/IgniteUI.Blazor.Lite.csproj
+++ b/src/IgniteUI.Blazor.Lite.csproj
@@ -53,6 +53,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(ExposeInternalsToTests)' != 'false'">
+    <InternalsVisibleTo Include="IgniteUI.Blazor.Tests" />
+  </ItemGroup>
+
   <ItemGroup>
     <!-- Exclude the TypeScript interop source (src/) and its build output (dist/) -->
     <Compile Remove="dist\**" />
@@ -81,7 +85,7 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-  
+
   <!--<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="npm run build &amp;&amp; npm run copythemes" />
   </Target>-->

--- a/tests/IgniteUI.Blazor.Tests/AccordionTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/AccordionTests.cs
@@ -91,4 +91,50 @@ public class AccordionTests : ComponentWithContractTestBase<IgbAccordion>
     {
         Assert.True(typeof(IgbAccordion).IsSubclassOf(typeof(BaseRendererControl)));
     }
+
+    #region Child collection lifecycle
+
+    /// <summary>Renders <paramref name="count"/> <see cref="IgbExpansionPanel"/> children.</summary>
+    static Action<ComponentParameterCollectionBuilder<IgbAccordion>> AccordionWith(int count) => ps =>
+        ps.AddChildContent(builder =>
+        {
+            for (var i = 0; i < count; i++)
+            {
+                builder.OpenComponent<IgbExpansionPanel>(i);
+                builder.CloseComponent();
+            }
+        });
+
+    [Fact]
+    public void Accordion_ChildPanels_RegisterOnInitialize()
+    {
+        var cut = Render<IgbAccordion>(AccordionWith(2));
+
+        Assert.Equal(
+            cut.FindComponents<IgbExpansionPanel>().Select(p => p.Instance),
+            cut.Instance.ContentItems);
+    }
+
+    [Fact]
+    public void Accordion_DisposedChildPanel_LeavesTheCollection()
+    {
+        var cut = Render<IgbAccordion>(AccordionWith(2));
+        var survivor = cut.FindComponents<IgbExpansionPanel>()[0].Instance;
+
+        cut.Render(AccordionWith(1));
+
+        Assert.Same(survivor, Assert.Single(cut.Instance.ContentItems));
+    }
+
+    [Fact]
+    public void Accordion_AllChildPanelsDisposed_EmptiesTheCollection()
+    {
+        var cut = Render<IgbAccordion>(AccordionWith(2));
+
+        cut.Render(ps => ps.AddChildContent(builder => { }));
+
+        Assert.Empty(cut.Instance.ContentItems);
+    }
+
+    #endregion Child collection lifecycle
 }

--- a/tests/IgniteUI.Blazor.Tests/DropdownTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/DropdownTests.cs
@@ -299,4 +299,50 @@ public class DropdownHeaderTests : BlazorComponentTestBase
 
         Assert.Equal(PopoverPlacement.BottomStart, dropdown.Placement);
     }
+
+    #region Child collection lifecycle
+
+    /// <summary>Renders <paramref name="count"/> <see cref="IgbDropdownItem"/> children.</summary>
+    static Action<ComponentParameterCollectionBuilder<IgbDropdown>> DropdownWith(int count) => ps =>
+        ps.AddChildContent(builder =>
+        {
+            for (var i = 0; i < count; i++)
+            {
+                builder.OpenComponent<IgbDropdownItem>(i);
+                builder.CloseComponent();
+            }
+        });
+
+    [Fact]
+    public void Dropdown_ChildItems_RegisterOnInitialize()
+    {
+        var cut = Render<IgbDropdown>(DropdownWith(2));
+
+        Assert.Equal(
+            cut.FindComponents<IgbDropdownItem>().Select(i => i.Instance),
+            cut.Instance.ContentItems);
+    }
+
+    [Fact]
+    public void Dropdown_DisposedChildItem_LeavesTheCollection()
+    {
+        var cut = Render<IgbDropdown>(DropdownWith(2));
+        var survivor = cut.FindComponents<IgbDropdownItem>()[0].Instance;
+
+        cut.Render(DropdownWith(1));
+
+        Assert.Same(survivor, Assert.Single(cut.Instance.ContentItems));
+    }
+
+    [Fact]
+    public void Dropdown_AllChildItemsDisposed_EmptiesTheCollection()
+    {
+        var cut = Render<IgbDropdown>(DropdownWith(2));
+
+        cut.Render(ps => ps.AddChildContent(builder => { }));
+
+        Assert.Empty(cut.Instance.ContentItems);
+    }
+
+    #endregion Child collection lifecycle
 }

--- a/tests/IgniteUI.Blazor.Tests/SelectTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/SelectTests.cs
@@ -306,4 +306,50 @@ public class SelectHeaderTests : BlazorComponentTestBase
 
         Assert.Equal(PopoverPlacement.BottomStart, select.Placement);
     }
+
+    #region Child collection lifecycle
+
+    /// <summary>Renders <paramref name="count"/> <see cref="IgbSelectItem"/> children.</summary>
+    static Action<ComponentParameterCollectionBuilder<IgbSelect>> SelectWith(int count) => ps =>
+        ps.AddChildContent(builder =>
+        {
+            for (var i = 0; i < count; i++)
+            {
+                builder.OpenComponent<IgbSelectItem>(i);
+                builder.CloseComponent();
+            }
+        });
+
+    [Fact]
+    public void Select_ChildItems_RegisterOnInitialize()
+    {
+        var cut = Render<IgbSelect>(SelectWith(2));
+
+        Assert.Equal(
+            cut.FindComponents<IgbSelectItem>().Select(i => i.Instance),
+            cut.Instance.ContentItems);
+    }
+
+    [Fact]
+    public void Select_DisposedChildItem_LeavesTheCollection()
+    {
+        var cut = Render<IgbSelect>(SelectWith(2));
+        var survivor = cut.FindComponents<IgbSelectItem>()[0].Instance;
+
+        cut.Render(SelectWith(1));
+
+        Assert.Same(survivor, Assert.Single(cut.Instance.ContentItems));
+    }
+
+    [Fact]
+    public void Select_AllChildItemsDisposed_EmptiesTheCollection()
+    {
+        var cut = Render<IgbSelect>(SelectWith(2));
+
+        cut.Render(ps => ps.AddChildContent(builder => { }));
+
+        Assert.Empty(cut.Instance.ContentItems);
+    }
+
+    #endregion
 }

--- a/tests/IgniteUI.Blazor.Tests/TabsTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TabsTests.cs
@@ -100,6 +100,8 @@ public class TabsTests : ComponentWithContractTestBase<IgbTabs>
         Assert.True(typeof(IgbTabs).IsSubclassOf(typeof(BaseRendererControl)));
     }
 
+    #region Child collection lifecycle
+
     /// <summary>Renders <paramref name="labels"/> as <see cref="IgbTab"/> children.</summary>
     static Action<ComponentParameterCollectionBuilder<IgbTabs>> TabsWith(params string[] labels) => ps =>
         ps.AddChildContent(builder =>
@@ -146,6 +148,21 @@ public class TabsTests : ComponentWithContractTestBase<IgbTabs>
 
         Assert.Empty(cut.Instance.ActualTabsCollection);
     }
+
+    [Fact]
+    public void Tabs_ChildTabRenderedAgainAfterRemoval_Reregisters()
+    {
+        var cut = Render<IgbTabs>(TabsWith("one", "two"));
+
+        cut.Render(TabsWith("one"));
+        cut.Render(TabsWith("one", "two"));
+
+        Assert.Equal(
+            cut.FindComponents<IgbTab>().Select(t => t.Instance),
+            cut.Instance.ActualTabsCollection);
+    }
+
+    #endregion
 }
 
 // IgbTab has no interop surface of its own: its @bind-Selected pair is driven entirely by

--- a/tests/IgniteUI.Blazor.Tests/TileManagerTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TileManagerTests.cs
@@ -199,6 +199,52 @@ public class TileManagerTests : ComponentWithContractTestBase<IgbTileManager>
 
         Assert.Contains("Tile content", cut.Find("igc-tile").InnerHtml);
     }
+
+    #region Child collection lifecycle
+
+    /// <summary>Renders <paramref name="count"/> <see cref="IgbTile"/> children.</summary>
+    static Action<ComponentParameterCollectionBuilder<IgbTileManager>> TileManagerWith(int count) => ps =>
+        ps.AddChildContent(builder =>
+        {
+            for (var i = 0; i < count; i++)
+            {
+                builder.OpenComponent<IgbTile>(i);
+                builder.CloseComponent();
+            }
+        });
+
+    [Fact]
+    public void TileManager_ChildTiles_RegisterOnInitialize()
+    {
+        var cut = Render<IgbTileManager>(TileManagerWith(2));
+
+        Assert.Equal(
+            cut.FindComponents<IgbTile>().Select(t => t.Instance),
+            cut.Instance.ContentItems);
+    }
+
+    [Fact]
+    public void TileManager_DisposedChildTile_LeavesTheCollection()
+    {
+        var cut = Render<IgbTileManager>(TileManagerWith(2));
+        var survivor = cut.FindComponents<IgbTile>()[0].Instance;
+
+        cut.Render(TileManagerWith(1));
+
+        Assert.Same(survivor, Assert.Single(cut.Instance.ContentItems));
+    }
+
+    [Fact]
+    public void TileManager_AllChildTilesDisposed_EmptiesTheCollection()
+    {
+        var cut = Render<IgbTileManager>(TileManagerWith(2));
+
+        cut.Render(ps => ps.AddChildContent(builder => { }));
+
+        Assert.Empty(cut.Instance.ContentItems);
+    }
+
+    #endregion
 }
 
 public class TileTests : ComponentWithContractTestBase<IgbTile>

--- a/tests/IgniteUI.Blazor.Tests/TreeTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/TreeTests.cs
@@ -155,6 +155,52 @@ public class TreeTests : ComponentWithContractTestBase<IgbTree>
 
         Assert.Contains("Child", cut.Find("igc-tree-item").InnerHtml);
     }
+
+    #region Child collection lifecycle
+
+    /// <summary>Renders <paramref name="count"/> top-level <see cref="IgbTreeItem"/> children.</summary>
+    static Action<ComponentParameterCollectionBuilder<IgbTree>> TreeWith(int count) => ps =>
+        ps.AddChildContent(builder =>
+        {
+            for (var i = 0; i < count; i++)
+            {
+                builder.OpenComponent<IgbTreeItem>(i);
+                builder.CloseComponent();
+            }
+        });
+
+    [Fact]
+    public void Tree_ChildItems_RegisterOnInitialize()
+    {
+        var cut = Render<IgbTree>(TreeWith(2));
+
+        Assert.Equal(
+            cut.FindComponents<IgbTreeItem>().Select(i => i.Instance),
+            cut.Instance.ContentItems);
+    }
+
+    [Fact]
+    public void Tree_DisposedChildItem_LeavesTheCollection()
+    {
+        var cut = Render<IgbTree>(TreeWith(2));
+        var survivor = cut.FindComponents<IgbTreeItem>()[0].Instance;
+
+        cut.Render(TreeWith(1));
+
+        Assert.Same(survivor, Assert.Single(cut.Instance.ContentItems));
+    }
+
+    [Fact]
+    public void Tree_AllChildItemsDisposed_EmptiesTheCollection()
+    {
+        var cut = Render<IgbTree>(TreeWith(2));
+
+        cut.Render(ps => ps.AddChildContent(builder => { }));
+
+        Assert.Empty(cut.Instance.ContentItems);
+    }
+
+    #endregion
 }
 
 public class TreeItemTests : ComponentWithContractTestBase<IgbTreeItem>


### PR DESCRIPTION
Interop contracts render once, so nothing ever observed a collection after a child was disposed — which is how the `IgbTab.Dispose` defect slipped through. This closes that shape gap for the rest of the components, and adds to the Tab from #319.



Three tests in each component's own suite: children are the collection in order, a disposed child leaves it, all disposed empties it. Tabs gets a fourth for re-adding, guarding `CollectionAdapter`'s removed-key bookkeeping. Asserted as equality against the whole collection — "does not contain" passes even when teardown appends, which is what the defect did.
Membership only: name resolution follows from it and belongs in the contract, behind the `InteropHarness` seam.

Reading the collections needs `InternalsVisibleTo`, since `ContentItems` is internal on `IgbAccordion`, `IgbSelect` and `IgbTileManager` while public on `IgbDropdown` and `IgbTree`. Declared as an MSBuild item so it can be conditioned: it defaults on, because CI builds library and tests in one Release pass, and `/p:ExposeInternalsToTests=false` removes it for a build that should not ship it.

### Type of Change (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [x] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:
<!-- List the component(s) or area(s) this PR touches, e.g. Grid, Combo, Theming -->


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**:
 - **Hosting model**: <!-- Blazor Server / WebAssembly / Hybrid / United -->
 - **Browser(s)**:
 - **OS**:

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified

