### PR TITLE
test(e2e): fix component generic type handling - Combo<T>

### DIFF
--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/TestUtil.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/TestUtil.cs
@@ -16,23 +16,7 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests
                   p.IsSubclassOf(typeof(BaseRendererControl)) &&
                   !p.Name.Contains("Base")
             ).ToList();
-            foreach (var c in classes)
-            {
-                try
-                {
-                    var instance = Activator.CreateInstance(c);
-                    var a = c.GetProperty("Type")?.GetValue(instance)?.ToString()?.StartsWith("Web");
-                    if (a == true)
-                    {
-                        result.Add(c.Name);
-                    }
-                }
-                catch (Exception)
-                {
-                }
-            }
-
-            return result.Where(x => !excluded.Contains(x)).ToList();
+            return classes.Select(x => x.IsGenericType ? x.Name[..x.Name.IndexOf('`')] : x.Name).Where(x => !excluded.Contains(x)).ToList();
         }
     }
 }

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/TestUtil.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/TestUtil.cs
@@ -5,10 +5,9 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests
 {
     public class TestUtil
     {
-        private static List<string> excluded = new List<string>();
+        private static readonly List<string> excluded = new List<string>();
         public static List<string> GetComponentsForTesting()
         {
-            var result = new List<string>();
             var asm = Assembly.Load("IgniteUI.Blazor.Lite");
             var classes = asm.GetTypes().Where(p =>
                   p.Namespace == "IgniteUI.Blazor.Controls" &&

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
@@ -73,7 +73,13 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
                   p.Name.StartsWith("Igb")
             ).ToList();
 
-            var match = classes.Find(x => x.Name == type);
+            var match = classes.Find(x => x.Name.Contains(type));
+            if (match is not null && match.IsGenericTypeDefinition)
+            {
+                var typeArgs = match.GetGenericArguments();
+                var concreteArgs = typeArgs.Select(_ => typeof(object)).ToArray();
+                match = match.MakeGenericType(concreteArgs);
+            }
             return match;
         }
 

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
@@ -67,13 +67,19 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
 
         public static Type? GetComponentByType(string type)
         {
+            var fullName = "Igb" + type;
             var asm = Assembly.Load("IgniteUI.Blazor.Lite");
             var classes = asm.GetTypes().Where(p =>
                  p.Namespace == "IgniteUI.Blazor.Controls" &&
-                  p.Name.StartsWith("Igb")
+                  p.Name.StartsWith("Igb") &&
+                  p.IsSubclassOf(typeof(BaseRendererControl))
             ).ToList();
 
-            var match = classes.Find(x => x.Name.Contains(type));
+            var match = classes.Find(x =>
+            {
+                var name = x.IsGenericType ? x.Name[..x.Name.IndexOf('`')] : x.Name;
+                return name == fullName;
+            });
             if (match is not null && match.IsGenericTypeDefinition)
             {
                 var typeArgs = match.GetGenericArguments();

--- a/tests/IgniteUI.Blazor.Lite.TestBed/componentsConfig.json
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/componentsConfig.json
@@ -42,6 +42,12 @@
       "FocusComponentAsync"
     ]
   },
+  "IgbCombo": {
+    "DependantMethods": [
+      // BUG 35183
+      "FocusComponentAsync"
+    ]
+  },
   "IgbRating": {
     "DependantMethods": [],
     "ExcludedEvents": []


### PR DESCRIPTION
## Description

Combo<T> was skipped in testing due to silent failure when collecting components to test.
Removing the whole filtering logic, since we don't really have any components we need to exclude from the tests here (not xlpat specific components) and adding handling for generic type.

