### PR TITLE
Integration test host: clean shutdown and readable output

### DIFF
--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/ComponentTest.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/ComponentTest.cs
@@ -1,4 +1,5 @@
 using IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure;
+using IgniteUI.Blazor.Lite.TestBed.Components.Common;
 using Microsoft.Playwright;
 using NUnit.Framework.Internal;
 
@@ -33,9 +34,18 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests
             });
             //await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            await Page.EvaluateAsync(@"renderComponent('" + this.componentName + "');");
+            var summary = await Page.EvaluateAsync<ComponentRunSummary>(
+                @"renderComponent('" + this.componentName + "')");
             string[] error = await Page.EvaluateAsync<string[]>(@"getErrors();");
-            Assert.That(error.Length == 0, "There were errors : " + string.Join(", \n", error));
+
+            Assert.That(summary, Is.Not.Null, "The run returned no summary.");
+            TestContext.Out.WriteLine(summary.ToString());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(error, Is.Empty, "There were errors : " + string.Join(", \n", error));
+                Assert.That(summary.Failure, Is.Null);
+            });
         }
     }
 }

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/BlazorApplicationFactory.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/BlazorApplicationFactory.cs
@@ -46,30 +46,30 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
             // Create the host for TestServer now before we modify the builder to use Kestrel instead.
             var testHost = builder.Build();
 
-            // Modify the host builder to use Kestrel instead of TestServer so we can listen on a real address.    
+            // Modify the host builder to use Kestrel instead of TestServer so we can listen on a real address.
             // configure and start the actual host using Kestrel.
             builder.ConfigureWebHost(webHostBuilder => webHostBuilder.UseKestrel());
 
-            // Create and start the Kestrel server before the test server,  
-            // otherwise due to the way the deferred host builder works    
-            // for minimal hosting, the server will not get "initialized    
-            // enough" for the address it is listening on to be available.    
-            // See https://github.com/dotnet/aspnetcore/issues/33846.    
+            // Create and start the Kestrel server before the test server,
+            // otherwise due to the way the deferred host builder works
+            // for minimal hosting, the server will not get "initialized
+            // enough" for the address it is listening on to be available.
+            // See https://github.com/dotnet/aspnetcore/issues/33846.
             host = builder.Build();
             host.Start();
 
-            // Extract the selected dynamic port out of the Kestrel server  
-            // and assign it onto the client options for convenience so it    
-            // "just works" as otherwise it'll be the default http://localhost    
-            // URL, which won't route to the Kestrel-hosted HTTP server.     
+            // Extract the selected dynamic port out of the Kestrel server
+            // and assign it onto the client options for convenience so it
+            // "just works" as otherwise it'll be the default http://localhost
+            // URL, which won't route to the Kestrel-hosted HTTP server.
             var server = host.Services.GetRequiredService<IServer>();
             var addresses = server.Features.Get<IServerAddressesFeature>();
             ClientOptions.BaseAddress = addresses!.Addresses.Select(x => new Uri(x)).Last();
 
-            // Return the host that uses TestServer, rather than the real one.  
-            // Otherwise the internals will complain about the host's server    
-            // not being an instance of the concrete type TestServer.    
-            // See https://github.com/dotnet/aspnetcore/pull/34702.   
+            // Return the host that uses TestServer, rather than the real one.
+            // Otherwise the internals will complain about the host's server
+            // not being an instance of the concrete type TestServer.
+            // See https://github.com/dotnet/aspnetcore/pull/34702.
             testHost.Start();
             return testHost;
         }
@@ -78,7 +78,7 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
         {
             if (host is null)
             {
-                // This forces WebApplicationFactory to bootstrap the server  
+                // This forces WebApplicationFactory to bootstrap the server
                 try
                 {
                     using var _ = CreateDefaultClient();
@@ -93,8 +93,22 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
 
         public override async ValueTask DisposeAsync()
         {
-            await base.DisposeAsync();
-            host?.Dispose();
+            // IHost.Dispose() only disposes the service provider; Stop the Kestrel host first to
+            // close SignalR live connections while that provider is still alive & avoid errors:
+            try
+            {
+                if (host is { } kestrelHost)
+                {
+                    await kestrelHost.StopAsync();
+                }
+            }
+            finally
+            {
+                // StopAsync rethrows hosted service failures, and the port is fixed, so
+                // cleanup cannot be left downstream of it.
+                host?.Dispose();
+                await base.DisposeAsync();
+            }
         }
     }
 }

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/BlazorApplicationFactory.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/BlazorApplicationFactory.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
 {
@@ -39,6 +40,32 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
             // Setting port to 0 means that Kestrel will pick any free a port.
             // but we don't want freedom, just use to use same port
             builder.UseUrls("http://127.0.0.1:5249");
+
+            builder.ConfigureLogging(logging =>
+            {
+                // Each test builds two hosts (TestServer + Kestrel), both logging their whole
+                // lifetime to the console. Keep issues only, reported through the test.
+                logging.ClearProviders();
+                logging.AddProvider(new TestOutputLoggerProvider());
+
+                // Not SetMinimumLevel: appsettings.json sets a Default level for the null
+                // category, and a matching rule always wins over MinLevel.
+                logging.Services.PostConfigure<LoggerFilterOptions>(options =>
+                {
+                    options.Rules.Clear();
+                    options.MinLevel = LogLevel.Warning;
+                });
+            });
+        }
+
+        /// <summary>
+        /// The startup details the host's own logging would have printed, for the test to log.
+        /// </summary>
+        public string Describe()
+        {
+            EnsureServer();
+            var env = host?.Services.GetRequiredService<IWebHostEnvironment>();
+            return $"listening on {ServerAddress} - environment {env?.EnvironmentName}, content root {env?.ContentRootPath}";
         }
 
         protected override IHost CreateHost(IHostBuilder builder)

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/BlazorPageTest.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/BlazorPageTest.cs
@@ -43,17 +43,17 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
         [TearDown]
         public async Task HostTearDown()
         {
+            // The client side of the SignalR connection has to be gone before the server
+            // shuts down. BrowserTest closes the contexts too, but only after this TearDown
+            // and only when the test passed; CloseAsync is idempotent, so that stays a no-op.
+            if (Context != null)
+            {
+                await Context.CloseAsync().ConfigureAwait(false);
+            }
+
             if (host is { } currentHost)
             {
                 host = null;
-
-                // Navigate to about:blank to ensure any SignalR
-                // connections are dropped.
-                //await Page.GotoAsync("about:blank");
-                if (Context != null)
-                {
-                    await Context.DisposeAsync().ConfigureAwait(false);
-                }
                 await currentHost.DisposeAsync().ConfigureAwait(false);
             }
         }

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/BlazorPageTest.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/BlazorPageTest.cs
@@ -7,6 +7,8 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
     public class BlazorPageTest<TProgram> : BrowserTest
         where TProgram : class
     {
+        private static int hostDescribed;
+
         private BlazorApplicationFactory<TProgram>? host;
 
         public IBrowserContext Context { get; private set; } = null!;
@@ -35,6 +37,12 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
             var options = ContextOptions() ?? new BrowserNewContextOptions();
             options.BaseURL = Host.ServerAddress;
             options.IgnoreHTTPSErrors = true;
+
+            // All the hosts are configured the same, so this is worth reporting once per run.
+            if (Interlocked.Exchange(ref hostDescribed, 1) == 0)
+            {
+                TestContext.Out.WriteLine($"[host] {Host.Describe()}");
+            }
 
             Context = await NewContext(options).ConfigureAwait(false);
             Page = await Context.NewPageAsync().ConfigureAwait(false);

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/TestOutputLoggerProvider.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/TestOutputLoggerProvider.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+
+namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
+{
+    /// <summary>
+    /// Routes host logs into the output of the test that is running. Writing them to the
+    /// process console instead attributes them to whatever test the runner happens to be
+    /// reporting when the host emits them.
+    /// </summary>
+    public sealed class TestOutputLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new TestOutputLogger(categoryName);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class TestOutputLogger(string category) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                var message = $"[host {logLevel}] {category}: {formatter(state, exception)}";
+                if (exception != null)
+                {
+                    message += Environment.NewLine + exception;
+                }
+
+                // Out is attributed to the current test but only surfaced when it fails;
+                // Progress is always shown, so errors go to both.
+                TestContext.Out.WriteLine(message);
+                if (logLevel >= LogLevel.Error)
+                {
+                    TestContext.Progress.WriteLine(message);
+                }
+            }
+        }
+    }
+}

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ComponentRunSummary.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ComponentRunSummary.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
+{
+    /// <summary>
+    /// What a single component run exercised, so a passing run reports the members it
+    /// covered and a run that never got as far as the component says why.
+    /// </summary>
+    public class ComponentRunSummary
+    {
+        public string Component { get; set; } = string.Empty;
+
+        /// <summary>The client-side selector the checks were run against.</summary>
+        public string Selector { get; set; } = string.Empty;
+
+        /// <summary>Failure message for why the run never reached/ran the component, if any.</summary>
+        public string? Failure { get; set; }
+
+        /// <summary>Initial values compared against the client component's, before anything was set.</summary>
+        public int Defaults { get; set; }
+
+        public int Properties { get; set; }
+
+        public int Events { get; set; }
+
+        public int ServerTemplates { get; set; }
+
+        public int ClientTemplates { get; set; }
+
+        public int Methods { get; set; }
+
+        public int Errors { get; set; }
+
+        [JsonIgnore]
+        public int Checks => Defaults + Properties + Events + ServerTemplates + ClientTemplates + Methods;
+
+        public static ComponentRunSummary Failed(string component, string failure)
+            => new() { Component = component, Failure = failure };
+
+        public override string ToString()
+        {
+            if (Failure != null)
+            {
+                return $"{Component}: {Failure}";
+            }
+
+            if (Checks == 0)
+            {
+                return $"{Component} ({Selector}): rendered, no members to check";
+            }
+
+            var text = $"{Component} ({Selector}): {Checks} checks - "
+                + $"{Defaults} defaults, {Properties} props, {Events} events, {Methods} methods, "
+                + $"{ServerTemplates} server / {ClientTemplates} client templates";
+
+            return Errors > 0 ? $"{text}, {Errors} errors" : text;
+        }
+    }
+}

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/ReflectionUtils.cs
@@ -67,7 +67,6 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
 
         public static Type? GetComponentByType(string type)
         {
-            var fullName = "Igb" + type;
             var asm = Assembly.Load("IgniteUI.Blazor.Lite");
             var classes = asm.GetTypes().Where(p =>
                  p.Namespace == "IgniteUI.Blazor.Controls" &&
@@ -75,10 +74,12 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
                   p.IsSubclassOf(typeof(BaseRendererControl))
             ).ToList();
 
+            // The names come from TestUtil.GetComponentsForTesting and already carry the
+            // Igb prefix, matching the componentsConfig.json keys.
             var match = classes.Find(x =>
             {
                 var name = x.IsGenericType ? x.Name[..x.Name.IndexOf('`')] : x.Name;
-                return name == fullName;
+                return name == type;
             });
             if (match is not null && match.IsGenericTypeDefinition)
             {

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
@@ -26,6 +26,7 @@
     private Dictionary<string, object> componentParameters = new();
     private List<string> errorMessages = new List<string>();
     private string eventMessage = string.Empty;
+    private ComponentRunSummary summary = new();
 
     private IConfigurationRoot config;
 
@@ -53,21 +54,22 @@
     }
 
     [JSInvokable("SetComponentType")]
-    public static async Task<bool> SetComponentType(string type)
+    public static async Task<ComponentRunSummary> SetComponentType(string type)
     {
         var app = _app;
         if (app == null)
         {
-            return false;
+            return ComponentRunSummary.Failed(type, "the test bed page is not initialized");
         }
 
         var component = ReflectionUtils.GetComponentByType(type);
         if (component == null)
         {
-            return false;
+            return ComponentRunSummary.Failed(type, "no component type matches that name");
         }
 
         app.errorMessages.Clear();
+        app.summary = new ComponentRunSummary { Component = type };
         app.selectedType = component;
 
         ReflectionUtils.excludedProps = app.config.GetSection(type + ":ExcludedProps")?.Get<string[]>()?.ToList() ?? new List<string>();
@@ -81,13 +83,14 @@
 
         if (app.dc?.Instance is not BaseRendererControl renderer)
         {
-            return false;
+            return ComponentRunSummary.Failed(type, "the rendered component is not a BaseRendererControl");
         }
 
         await renderer.EnsureReady();
         await Task.Delay(100);
 
         app.componentSelector = ReflectionUtils.GetComponentSelector(app.dc.Instance, type);
+        app.summary.Selector = app.componentSelector;
         await app.JS.InvokeAsync<string>("setSelector", app.componentSelector);
 
         app.componentParameters = new Dictionary<string, object>();
@@ -100,7 +103,9 @@
         await app.TestProps();
         await app.TestAPI();
 
-        return true;
+        app.summary.Errors = app.errorMessages.Count;
+
+        return app.summary;
     }
 
     public async Task TestServerTemplates()
@@ -124,6 +129,7 @@
             await Task.Delay(1);
             var clientPropName = char.ToLower(tmpl.Name[0]) + tmpl.Name.Substring(1);
             var res = await JS.InvokeAsync<bool>("checkServerTemplate", clientPropName);
+            summary.ServerTemplates++;
 
             if (!res)
             {
@@ -153,6 +159,7 @@
             await Task.Delay(100);
 
             var res = await JS.InvokeAsync<bool>("checkClientTemplate", tmplName);
+            summary.ClientTemplates++;
             if (!res)
             {
                 errorMessages.Add("Template not set for prop:  " + scriptProp.Name);
@@ -196,6 +203,7 @@
             }
             var syncName = method.Name.Replace("Async", "");
             var clientMethodName = ReflectionUtils.Camelize(syncName);
+            summary.Methods++;
             await JS.InvokeVoidAsync("spyOnMethod", clientMethodName);
             object? res = null;
             try
@@ -259,6 +267,8 @@
                 continue;
             }
 
+            summary.Defaults++;
+
             if (!TestUtil.PropertyValuesAreEqual(serverValue, clientValue, p))
             {
                 var serverString = serverValue is Enum
@@ -305,6 +315,7 @@
 
             var clientPropName = ReflectionUtils.GetActualPropertyName(p);
             var clientValue = await GetClientPropValue(clientPropName);
+            summary.Properties++;
             if (!TestUtil.PropertyValuesAreEqual(value, clientValue, p))
             {
                 string serverString = value is Enum ?
@@ -391,6 +402,7 @@
 
             eventMessage = "";
             await JS.InvokeAsync<object>("triggerEvent", evtName, argDetailToSend, detailType == typeof(DateTime));
+            summary.Events++;
             await Task.Delay(100);
 
             if (eventMessage != $"Event fired.")

--- a/tests/IgniteUI.Blazor.Lite.TestBed/wwwroot/app.js
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/wwwroot/app.js
@@ -1,7 +1,9 @@
-﻿//function that invokes the server-side render of a component by name
+﻿//function that invokes the server-side render of a component by name,
+//resolving with a summary of what the run checked
 async function renderComponent(componentName) {
   var res = await DotNet.invokeMethodAsync('IgniteUI.Blazor.Lite.TestBed', 'SetComponentType', componentName);
-  console.log('Task completed successfully: ' + res);
+  console.log('Task completed successfully: ', res);
+  return res;
 }
 
 function onAfterRender() {


### PR DESCRIPTION
## 1. Stop the Kestrel host instead of only disposing it

`BlazorApplicationFactory.DisposeAsync` called `host.Dispose()` on the Kestrel host. `IHost.Dispose()` only disposes the service provider — it never calls `StopAsync`, so `ApplicationStopping` never fired. That is the event `HttpConnectionManager` registers `CloseConnections` on, which is what disconnects live circuits (awaiting each `OnDisconnectedAsync`) while the container is still alive.

Without it, teardown was a race: closing the browser context returns as soon as the client side is gone, and the server noticed the dead socket whenever it got round to it. If that landed after the provider was disposed, `OnDisconnectedAsync` failed on a disposed `IServiceProvider` — the intermittent `ObjectDisposedException` noise in the logs, which never failed a test because the assertions had already completed.

Teardown now `StopAsync`es the host before disposing it, and closes the browser context first. `BrowserTest` closes contexts too, but its `TearDown` runs after the derived one and only when the test passed, so the close cannot be left to it; `CloseAsync` is idempotent, so the base closing it again is a no-op.

## 2. Quieter, test-attributed logging plus per-component coverage

Each test builds two hosts (TestServer + Kestrel) and each logged its full lifetime straight to the console — nine `info:` lines per test, landing on whichever test the runner was reporting at the time.

- The host keeps `Warning` and above only, via `PostConfigure<LoggerFilterOptions>` (not `SetMinimumLevel`, which a `Default` rule in `appsettings.json` would win over).
- What survives goes through `TestOutputLoggerProvider` into the current test's output, with `Error` and above also written to `TestContext.Progress` so it surfaces regardless of runner verbosity.
- The startup details worth having — address, environment, content root — are read off the host and logged once per run.
- `SetComponentType` now returns a `ComponentRunSummary` rather than a `bool`, so each test reports what it covered:

  ```
  [host] listening on http://127.0.0.1:5249/ - environment Development, content root .../IgniteUI.Blazor.Lite.TestBed
  IgbCarousel (igc-carousel): 27 checks - 8 defaults, 11 props, 3 events, 5 methods, 0 server / 0 client templates
  IgbCardContent (igc-card-content): rendered, no members to check
  ```

The `bool` that summary replaces was never checked by the test, so a component that never rendered — an unresolvable name, an instance that is not a `BaseRendererControl` — reported no errors and passed. The summary now carries a `Failure` string instead, which the test asserts is null, along with a summary having been returned at all. Zero checks is left passing: 13 components are slot-only wrappers (`IgbCardContent`, `IgbNavbar`, `IgbRipple`, the various headers) with no settable API, and the summary line says so.