### PR TITLE
fix: RendererSerializer.AddArrayProp obj cast NRE for struct arrays (int,double)

### DIFF
--- a/src/componentsBase/RendererSerializer.cs
+++ b/src/componentsBase/RendererSerializer.cs
@@ -182,15 +182,14 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        public void AddArrayProp(string propertyName, object values)
+        public void AddArrayProp<T>(string propertyName, IEnumerable<T> values)
         {
+            var items = values == null ? null : values as IList<T> ?? values.ToList();
             bool containsSub = false;
-            var valuesArray = values as object[];
-            if (values != null)
+            if (items != null)
             {
-                for (int i = 0; i < valuesArray.Length; i++)
+                foreach (var val in items)
                 {
-                    object val = valuesArray[i];
                     if (val is BaseRendererControl || val is BaseRendererElement)
                     {
                         containsSub = true;
@@ -210,7 +209,7 @@ namespace IgniteUI.Blazor.Controls
                     context = new SerializationContext(_context.Writer, null);
                 }
             }
-            if (values == null)
+            if (items == null)
             {
                 //_properties.Add("\"" + propertyName + "\"" + ": null");
                 context.Writer.WriteNull(propertyName);
@@ -218,9 +217,8 @@ namespace IgniteUI.Blazor.Controls
             }
             //string[] strValues = new string[values.Length];
             context.Writer.WriteStartArray(propertyName);
-            for (int i = 0; i < valuesArray.Length; i++)
+            foreach (object val in items)
             {
-                object val = valuesArray[i];
                 if (val is String)
                 {
                     context.Writer.WriteStringValue((string)val);

--- a/tests/IgniteUI.Blazor.Tests/ComboTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComboTests.cs
@@ -284,7 +284,7 @@ public class ComboTests : ComponentWithContractTestBase<IgbCombo<ComboItem>>
     }
 }
 
-// TODO: Mismatched T=int - handling (T[])DowncastArray<T>(Detail.NewValue) for
+// TODO: Mismatched T=int inbound handling (T[])DowncastArray<T>(Detail.NewValue) for
 // two-way Value propagation: a mismatched T (e.g. the item type on a keyed combo)
 // throws InvalidCastException — swallowed by OnRaiseEvent, so delivery silently dies;
 // and numeric keys decode as JSON numbers → boxed double, so T=int fails the unbox
@@ -311,12 +311,13 @@ public class ComboValueKeyTests : ComponentWithContractTestBase<IgbCombo<double>
                 // Two-way Value propagation through the generated wrapper works when T
                 // matches the key value type.
                 Assert.Equal(2.0, Assert.Single(cut.Instance.Value));
-            });
-    // TODO: Value set with struct types (int, double) doesn't work - RendererSerializer.AddArrayProp object cast
-    // .Prop(c => c.Value,
-    //     value: [1, 3],
-    //     arrange,
-    //     wire: (interop, cut) => new JsonSubset("[1, 3]"))
+            })
+        // A value-type value array (double[] here) crosses as plain JSON numbers — the keys
+        // themselves, no data-source refs, since a keyed combo's value is the key.
+        .Prop(c => c.Value,
+            value: [1, 3],
+            arrange: arrange,
+            wire: new RawJson("[1, 3]"));
 
     [Fact]
     public void Props_FollowContract() => VerifyPropContract();


### PR DESCRIPTION
Property value set with struct types (int, double) didn't work - `RendererSerializer.AddArrayProp` object cast fails for those values and produced `null` result which causes an immediate `NullReferenceException` after trying to access `valuesArray.Length` because the check is for the original param `values`.

This is reproducible by setting `IgbCombo.Value` to an array of such struct values, say `int[]` with `ValueKey="Id"` scenario.

I've updated the method to be generic and accept and enumerable instead so it can directly iterate over that. The null check is probably redundant, but CBA fixing everything in this class in one go :)


### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:
<!-- List the component(s) or area(s) this PR touches, e.g. Grid, Combo, Theming -->


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**:
 - **Hosting model**: <!-- Blazor Server / WebAssembly / Hybrid / United -->
 - **Browser(s)**:
 - **OS**:

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified

Closes #
