### PR TITLE
test: adjust waits to avoid flickers, minor date handling fix, misc

### DIFF
--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/ComponentTest.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/ComponentTest.cs
@@ -1,6 +1,5 @@
 using IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure;
 using IgniteUI.Blazor.Lite.TestBed.Components.Common;
-using Microsoft.Playwright;
 using NUnit.Framework.Internal;
 
 namespace IgniteUI.Blazor.Lite.IntegrationTests
@@ -27,12 +26,9 @@ namespace IgniteUI.Blazor.Lite.IntegrationTests
             TestContext.Out.WriteLine("Test started for " + this.componentName);
 
             await Page.GotoAsync("http://localhost:5249/");
-            // wait for blazor to load
-            await Page.WaitForConsoleMessageAsync(new PageWaitForConsoleMessageOptions
-            {
-                Predicate = msg => msg.Text.Contains("App Loaded.")
-            });
-            //await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            // wait for blazor to load. On the flag rather than the console message, which is
+            // gone for good if it arrives before the listener is attached.
+            await Page.WaitForFunctionAsync("() => window.appLoaded === true");
 
             var summary = await Page.EvaluateAsync<ComponentRunSummary>(
                 @"renderComponent('" + this.componentName + "')");

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/flicker-repro.ps1
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/flicker-repro.ps1
@@ -1,0 +1,131 @@
+<#
+.SYNOPSIS
+    Hunt for flickers in the Bulk API integration tests by running them under CPU pressure.
+
+.DESCRIPTION
+    Flickers here tend to come from timing: the tests drive a Blazor server component
+    through a browser, so a check can outrun whatever it is waiting on. A developer box
+    with cores to spare hides that, and a handful of green runs on one says very little.
+    Confining the run to a single CPU makes the server, the browser and everything they
+    queue compete, which is usually enough to surface an ordering assumption. The
+    confinement is applied at process creation and inherited, so the test host and the
+    browser Playwright starts are both covered - that breadth is the point, and it is why
+    DOTNET_PROCESSOR_COUNT=1 is not a substitute: it resizes the thread pool without
+    making anything else compete for the core.
+
+    A run counts as failed on any test failure. The patterns in $signatures only decide
+    which lines get echoed for context, so add to them when chasing a failure they do
+    not cover.
+
+    Read the result as a rate, not a verdict: this raises the odds of a race losing, it
+    does not make one certain, so a clean pass is evidence and not proof.
+
+    For illustration, the #249 flickers (property values and events read before the
+    wrapper had flushed them to the client) came up in roughly a third of single-CPU runs
+    and in none unpinned.
+
+.PARAMETER Affinity
+    CPU mask in hex, the same form as cmd's start /affinity. 1 = CPU0 (default),
+    3 = CPU0 and CPU1, F = CPU0 through CPU3. Fewer cores means more pressure.
+
+.EXAMPLE
+    .\flicker-repro.ps1
+    IgbCalendar, 10 runs, one core.
+
+.EXAMPLE
+    .\flicker-repro.ps1 -Component IgbTile -Runs 20
+
+.EXAMPLE
+    .\flicker-repro.ps1 -Component '' -Runs 3
+    The whole suite, around 50s per run.
+
+.NOTES
+    Exits non-zero if any run failed, so it can gate a bisect.
+#>
+[CmdletBinding()]
+param(
+    [string]$Component = 'IgbCalendar',
+    [int]$Runs = 10,
+    [string]$Affinity = '1',
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+$project = Join-Path $repoRoot 'tests' 'IgniteUI.Blazor.Lite.IntegrationTests'
+$runsettings = Join-Path $repoRoot '.runsettings'
+$onWindows = $IsWindows -or $env:OS -eq 'Windows_NT'
+
+if (-not $SkipBuild) {
+    # Rebuild by default: the runs below pass --no-build for speed, so against a stale
+    # binary you would be testing the branch you came from and calling it clean.
+    Write-Host 'building...'
+    $buildLog = [IO.Path]::GetTempFileName()
+    dotnet build $project -v q --nologo *> $buildLog
+    if ($LASTEXITCODE -ne 0) {
+        Select-String -Path $buildLog -Pattern 'error CS', ' error ' | Select-Object -First 20 | ForEach-Object { $_.Line }
+        throw "build failed, see $buildLog"
+    }
+    Remove-Item $buildLog -ErrorAction SilentlyContinue
+}
+
+$filter = if ($Component) { "--filter `"FullyQualifiedName~$Component`"" } else { '' }
+
+# All the quoting lives in a generated batch file, so PowerShell only has to run it and
+# read the output back. start applies the affinity at creation time, which Start-Process
+# plus a ProcessorAffinity assignment cannot promise - the test host may already be up.
+$runner = $null
+if ($onWindows) {
+    $runner = [IO.Path]::ChangeExtension([IO.Path]::GetTempFileName(), '.cmd')
+    Set-Content -Path $runner -Encoding ASCII -Value @(
+        '@echo off',
+        "start `"`" /affinity $Affinity /b /wait dotnet test `"$project`" --settings `"$runsettings`" --no-build $filter"
+    )
+}
+else {
+    # taskset wants a core list rather than a mask
+    $mask = [Convert]::ToInt64($Affinity, 16)
+    $cores = (0..63 | Where-Object { $mask -band ([int64]1 -shl $_) }) -join ','
+    if (-not (Get-Command taskset -ErrorAction SilentlyContinue)) {
+        Write-Warning 'no taskset, running unpinned - the flickers likely will not reproduce'
+        $cores = $null
+    }
+}
+
+$label = if ($Component) { $Component } else { 'all components' }
+Write-Host "$label x$Runs on cpu mask $Affinity"
+
+$signatures = 'mismatch after setting', 'did not fire', 'Timeout \d+ms', 'Exception :'
+$fails = 0
+
+for ($i = 1; $i -le $Runs; $i++) {
+    if ($onWindows) {
+        $out = & cmd.exe /c $runner 2>&1 | Out-String
+    }
+    elseif ($cores) {
+        $out = & taskset -c $cores dotnet test $project --settings $runsettings --no-build $(if ($Component) { '--filter'; "FullyQualifiedName~$Component" }) 2>&1 | Out-String
+    }
+    else {
+        $out = & dotnet test $project --settings $runsettings --no-build $(if ($Component) { '--filter'; "FullyQualifiedName~$Component" }) 2>&1 | Out-String
+    }
+
+    if ($out -match 'Failed!') {
+        $fails++
+        Write-Host "run $i`: FAIL"
+        $out -split "`r?`n" |
+            Select-String -Pattern $signatures |
+            ForEach-Object { $_.Line.Trim() } |
+            Select-Object -Unique -First 5 |
+            ForEach-Object { Write-Host "  $_" }
+    }
+    else {
+        Write-Host -NoNewline '.'
+    }
+}
+
+Write-Host ''
+Write-Host "$fails/$Runs runs failed"
+
+if ($runner) { Remove-Item $runner -ErrorAction SilentlyContinue }
+if ($fails -gt 0) { exit 1 }

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/flicker-repro.sh
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/flicker-repro.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Hunt for flickers in the Bulk API integration tests by running them under CPU pressure.
+#
+# Flickers here tend to come from timing: the tests drive a Blazor server component
+# through a browser, so a check can outrun whatever it is waiting on. A developer box
+# with cores to spare hides that, and a handful of green runs on one says very little.
+# Confining the run to a single CPU makes the server, the browser and everything they
+# queue compete, which is usually enough to surface an ordering assumption.
+#
+#   ./flicker-repro.sh                    # IgbCalendar, 10 runs, 1 core
+#   ./flicker-repro.sh -c IgbTile -n 20   # another component, more runs
+#   ./flicker-repro.sh -c '' -n 3         # whole suite (~50s per run)
+#   ./flicker-repro.sh -p 0,1             # two cores, for a milder squeeze
+#   ./flicker-repro.sh -s                 # skip the build, if you just built
+#
+# A run counts as failed on any test failure. The patterns below only decide which lines
+# get echoed for context, so add to them when chasing a failure they do not cover.
+#
+# Read the result as a rate, not a verdict: this raises the odds of a race losing, it
+# does not make one certain, so a clean pass is evidence and not proof. Exits non-zero
+# if any run failed, so it can gate a bisect.
+#
+# For illustration, the #249 flickers (property values and events read before the
+# wrapper had flushed them to the client) came up in roughly a third of single-CPU runs
+# and in none unpinned. DOTNET_PROCESSOR_COUNT=1 did not reproduce them either - it
+# resizes the thread pool without making anything else compete for the core.
+set -o pipefail
+
+COMPONENT=IgbCalendar
+RUNS=10
+CPUS=0
+BUILD=1
+
+while getopts "c:n:p:sh" opt; do
+  case $opt in
+    c) COMPONENT=$OPTARG ;;
+    n) RUNS=$OPTARG ;;
+    p) CPUS=$OPTARG ;;
+    s) BUILD=0 ;;
+    h) sed -n '2,25p' "$0"; exit 0 ;;
+    *) exit 2 ;;
+  esac
+done
+
+cd "$(dirname "$0")/../.." || exit 1
+PROJECT=./tests/IgniteUI.Blazor.Lite.IntegrationTests
+
+if [ "$BUILD" = 1 ]; then
+  # Rebuild by default: the runs below pass --no-build for speed, so against a stale
+  # binary you would be testing the branch you came from and calling it clean.
+  echo "building..."
+  BUILD_LOG=$(mktemp)
+  if ! dotnet build "$PROJECT" -v q --nologo > "$BUILD_LOG" 2>&1; then
+    grep -E ' error |error CS' "$BUILD_LOG" | head -20
+    echo "build failed, see $BUILD_LOG"
+    exit 1
+  fi
+  rm -f "$BUILD_LOG"
+fi
+
+FILTER=()
+[ -n "$COMPONENT" ] && FILTER=(--filter "FullyQualifiedName~$COMPONENT")
+
+RUNNER=()
+if [ -n "$CPUS" ]; then
+  if command -v taskset >/dev/null; then
+    RUNNER=(taskset -c "$CPUS")
+  else
+    echo "warning: no taskset, running unpinned - the flickers likely will not reproduce"
+  fi
+fi
+
+echo "${COMPONENT:-all components} x$RUNS on cpu(s) ${CPUS:-all}"
+
+fails=0
+for i in $(seq 1 "$RUNS"); do
+  out=$("${RUNNER[@]}" dotnet test "$PROJECT" --settings ./.runsettings --no-build "${FILTER[@]}" 2>&1)
+  if echo "$out" | grep -q 'Failed!'; then
+    fails=$((fails + 1))
+    echo "run $i: FAIL"
+    echo "$out" | grep -E 'mismatch after setting|did not fire|Timeout [0-9]+ms|Exception :' \
+      | sed 's/^ */  /' | sort -u | head -5
+  else
+    printf '.'
+  fi
+done
+
+echo
+echo "$fails/$RUNS runs failed"
+[ "$fails" = 0 ]

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/TestUtil.cs
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Common/TestUtil.cs
@@ -42,8 +42,16 @@ namespace IgniteUI.Blazor.Lite.TestBed.Components.Common
 
             if (prop.PropertyType == typeof(DateTime))
             {
-                serverString = JsonConvert.DeserializeObject<DateTime>(serverString).ToShortDateString();
-                clientValue = JsonConvert.DeserializeObject<DateTime>(clientValue).ToShortDateString();
+                // Nullable: a client with no value yet compares unequal instead of throwing.
+                var serverDate = JsonConvert.DeserializeObject<DateTime?>(serverString);
+                var clientDate = JsonConvert.DeserializeObject<DateTime?>(clientValue);
+                if (serverDate == null || clientDate == null)
+                {
+                    return false;
+                }
+
+                serverString = serverDate.Value.ToShortDateString();
+                clientValue = clientDate.Value.ToShortDateString();
             }
 
             if (prop.PropertyType == typeof(DateTime[]))

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
@@ -130,7 +130,7 @@
             var r = ReflectionUtils.CreateRenderFragmentForType(arg, instance!);
 
             parameters.Add(tmpl.Name, r);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
             var clientPropName = char.ToLower(tmpl.Name[0]) + tmpl.Name.Substring(1);
             var res = await WaitForClientCheck("checkServerTemplate", clientPropName);
             summary.ServerTemplates++;
@@ -159,7 +159,7 @@
             var tmplName = ReflectionUtils.Camelize(scriptProp.Name.Replace("Script", ""));
             await JS.InvokeVoidAsync("generateClientTmpl", tmplName);
             parameters.Add(scriptProp.Name, tmplName);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
 
             var res = await WaitForClientCheck("checkClientTemplate", tmplName);
             summary.ClientTemplates++;
@@ -313,37 +313,40 @@
             }
             // set prop and wait for state to change
             parameters.Add(p.Name, value!);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
 
             var clientPropName = ReflectionUtils.GetActualPropertyName(p);
-            var clientValue = await WaitForClientPropValue(clientPropName, value, p);
+            var (clientValue, matched) = await WaitForClientPropValue(clientPropName, value, p);
             summary.Properties++;
-            if (!TestUtil.PropertyValuesAreEqual(value, clientValue, p))
+            if (!matched)
             {
                 string serverString = value is Enum ?
                value.ToString()?.ToLowerInvariant() ?? string.Empty :
                JsonConvert.SerializeObject(value, new JsonSerializerSettings()
                     { ContractResolver = new IgnorePropertiesResolver(ReflectionUtils.IgnoredProps().ToArray()) });
-                this.errorMessages.Add("Property value mismatch after setting. Prop name:  " + p.Name + ". Expected:" + serverString + ", but got the following on the client: " + clientValue);
+                // Naming the wait rules out a premature read, so the value is wrong rather than late.
+                this.errorMessages.Add("Property value mismatch after setting. Prop name:  " + p.Name + ". Expected:" + serverString + ", but after " + PropagationTimeoutMs + "ms got the following on the client: " + clientValue);
             }
         }
     }
 
     /// <summary>
     /// Reads the client value, retrying until it matches what was set or the timeout runs out.
+    /// Reports the last value seen and whether it ever matched.
     /// </summary>
-    private async Task<string> WaitForClientPropValue(string clientPropName, object? expected, PropertyInfo prop)
+    private async Task<(string Value, bool Matched)> WaitForClientPropValue(string clientPropName, object? expected, PropertyInfo prop)
     {
         var clientValue = await GetClientPropValue(clientPropName);
-        for (var waited = 0;
-            waited < PropagationTimeoutMs && !TestUtil.PropertyValuesAreEqual(expected, clientValue, prop);
-            waited += PollIntervalMs)
+        var matched = TestUtil.PropertyValuesAreEqual(expected, clientValue, prop);
+
+        for (var waited = 0; !matched && waited < PropagationTimeoutMs; waited += PollIntervalMs)
         {
             await Task.Delay(PollIntervalMs);
             clientValue = await GetClientPropValue(clientPropName);
+            matched = TestUtil.PropertyValuesAreEqual(expected, clientValue, prop);
         }
 
-        return clientValue;
+        return (clientValue, matched);
     }
 
     /// <summary>
@@ -419,7 +422,7 @@
 
             parameters.Add(evt.Name, instance);
 
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
             var evtName = evt.Name == "Focus" || evt.Name == "Blur" ? evt.Name.ToLower() : "igc" + evt.Name;
 
             // event is renamed on the client side, so we need to handle that case

--- a/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/Components/Pages/Home.razor
@@ -28,6 +28,11 @@
     private string eventMessage = string.Empty;
     private ComponentRunSummary summary = new();
 
+    // BaseRendererControl.QueueUpdate flushes to the client on a queued, fire-and-forget pass
+    // timed by the thread pool, so wait for results to show up, not for a fixed delay.
+    private const int PropagationTimeoutMs = 1000;
+    private const int PollIntervalMs = 20;
+
     private IConfigurationRoot config;
 
     public Home()
@@ -126,9 +131,8 @@
 
             parameters.Add(tmpl.Name, r);
             StateHasChanged();
-            await Task.Delay(1);
             var clientPropName = char.ToLower(tmpl.Name[0]) + tmpl.Name.Substring(1);
-            var res = await JS.InvokeAsync<bool>("checkServerTemplate", clientPropName);
+            var res = await WaitForClientCheck("checkServerTemplate", clientPropName);
             summary.ServerTemplates++;
 
             if (!res)
@@ -156,9 +160,8 @@
             await JS.InvokeVoidAsync("generateClientTmpl", tmplName);
             parameters.Add(scriptProp.Name, tmplName);
             StateHasChanged();
-            await Task.Delay(100);
 
-            var res = await JS.InvokeAsync<bool>("checkClientTemplate", tmplName);
+            var res = await WaitForClientCheck("checkClientTemplate", tmplName);
             summary.ClientTemplates++;
             if (!res)
             {
@@ -311,10 +314,9 @@
             // set prop and wait for state to change
             parameters.Add(p.Name, value!);
             StateHasChanged();
-            await Task.Delay(1);
 
             var clientPropName = ReflectionUtils.GetActualPropertyName(p);
-            var clientValue = await GetClientPropValue(clientPropName);
+            var clientValue = await WaitForClientPropValue(clientPropName, value, p);
             summary.Properties++;
             if (!TestUtil.PropertyValuesAreEqual(value, clientValue, p))
             {
@@ -325,6 +327,38 @@
                 this.errorMessages.Add("Property value mismatch after setting. Prop name:  " + p.Name + ". Expected:" + serverString + ", but got the following on the client: " + clientValue);
             }
         }
+    }
+
+    /// <summary>
+    /// Reads the client value, retrying until it matches what was set or the timeout runs out.
+    /// </summary>
+    private async Task<string> WaitForClientPropValue(string clientPropName, object? expected, PropertyInfo prop)
+    {
+        var clientValue = await GetClientPropValue(clientPropName);
+        for (var waited = 0;
+            waited < PropagationTimeoutMs && !TestUtil.PropertyValuesAreEqual(expected, clientValue, prop);
+            waited += PollIntervalMs)
+        {
+            await Task.Delay(PollIntervalMs);
+            clientValue = await GetClientPropValue(clientPropName);
+        }
+
+        return clientValue;
+    }
+
+    /// <summary>
+    /// Runs a client-side check, retrying until it reports true or the timeout runs out.
+    /// </summary>
+    private async Task<bool> WaitForClientCheck(string jsFunction, string arg)
+    {
+        var result = await JS.InvokeAsync<bool>(jsFunction, arg);
+        for (var waited = 0; waited < PropagationTimeoutMs && !result; waited += PollIntervalMs)
+        {
+            await Task.Delay(PollIntervalMs);
+            result = await JS.InvokeAsync<bool>(jsFunction, arg);
+        }
+
+        return result;
     }
 
     // in cases of slower operations, connection closes and execution stops, hence adding a try catch with a 5 second timeout and retry if needed.
@@ -377,7 +411,7 @@
             {
                 argDetailToSend = ReflectionUtils.GetSimpleType(detailType);
             }
-            var instance = Activator.CreateInstance(evt.PropertyType, [this, (Action)EventHandler]);
+            var instance = Activator.CreateInstance(evt.PropertyType, [this, (Action)(() => eventMessage = evt.Name)]);
             if (instance == null)
             {
                 continue;
@@ -386,7 +420,6 @@
             parameters.Add(evt.Name, instance);
 
             StateHasChanged();
-            await Task.Delay(1);
             var evtName = evt.Name == "Focus" || evt.Name == "Blur" ? evt.Name.ToLower() : "igc" + evt.Name;
 
             // event is renamed on the client side, so we need to handle that case
@@ -401,19 +434,26 @@
             }
 
             eventMessage = "";
-            await JS.InvokeAsync<object>("triggerEvent", evtName, argDetailToSend, detailType == typeof(DateTime));
             summary.Events++;
-            await Task.Delay(100);
 
-            if (eventMessage != $"Event fired.")
+            // The client-side subscription lands on the same flush as properties, so an event
+            // dispatched too early goes nowhere; re-dispatch until it takes. Matching on the
+            // name keeps a late duplicate from reading as the next event firing.
+            for (var waited = 0; waited < PropagationTimeoutMs; waited += PollIntervalMs)
+            {
+                await Task.Delay(PollIntervalMs);
+                if (eventMessage == evt.Name)
+                {
+                    break;
+                }
+
+                await JS.InvokeAsync<object>("triggerEvent", evtName, argDetailToSend, detailType == typeof(DateTime));
+            }
+
+            if (eventMessage != evt.Name)
             {
                 this.errorMessages.Add("Event with name: " + evt.Name + " did not fire.");
             }
         }
-    }
-
-    private void EventHandler()
-    {
-        eventMessage = $"Event fired.";
     }
 }

--- a/tests/IgniteUI.Blazor.Lite.TestBed/wwwroot/app.js
+++ b/tests/IgniteUI.Blazor.Lite.TestBed/wwwroot/app.js
@@ -7,6 +7,8 @@ async function renderComponent(componentName) {
 }
 
 function onAfterRender() {
+  //a flag, so a test can check for load it if it missed the message
+  window.appLoaded = true;
   console.log('App Loaded.');
 }
 


### PR DESCRIPTION
# Fix the Bulk API test flickers

Closes #249, and the `Timeout 30000ms exceeded while waiting for event "Console"` raised in review on #323.

## Root cause

The wrapper flushes property changes to the client on a queued, fire-and-forget pass — [BaseRendererControl.QueueUpdate](src/componentsBase/BaseRendererControl.cs#L1592):

```csharp
_updateQueued = true;
Task.Delay(0).ContinueWith((t) => InvokeAsync(Update));
```

A thread-pool hop, then `InvokeAsync(Update)` queued on the circuit dispatcher, then `igSendMessage`. Nothing awaits any of it. The test bed did `StateHasChanged(); await Task.Delay(1);` and then read the client value — betting 1ms against that scheduling hop. Under load the hop loses and `checkProp` reaches the client ahead of the update, giving `Property value mismatch after setting`. Events fail the same way: the client-side subscription is installed by that same flush, so an event dispatched before it lands has nothing listening — `did not fire`.

The load wait was a separate ordering bug: `WaitForConsoleMessageAsync` was attached *after* `GotoAsync` and does not replay, so an "App Loaded." arriving in between was lost and the wait burned its full 30s.

## Changes

- Props and templates poll for the value or the check instead of sleeping, up to 1s at 20ms. The deadline counts only the delays, so the real budget stretches on a slower machine. If `QueueUpdate` ever becomes synchronous the first poll just succeeds.
- Events wait for their handler and re-dispatch only if nothing arrived, and match on their own name so a late duplicate cannot be read as the next event firing.
- The load wait moves to a `window.appLoaded` flag via `WaitForFunctionAsync` — state, not a transient event. The `console.log` stays for in-browser debugging.
- Removing the fixed 100ms waits makes the suite slightly faster, ~46s to ~42s.
- Two ideas taken from Maya's attempt in #265: renders are requested with `await InvokeAsync(StateHasChanged)` so they always go through the renderer's dispatcher, and a mismatch now says how long we waited, which rules out a premature read.

Separate commit: `TestUtil.PropertyValuesAreEqual` deserialized a `DateTime` as non-nullable, so it threw `JsonSerializationException` on the `"null"` a client reports for a property it has no value for. It now degrades to unequal, matching the guard the `DateTime[]` branch below it already had. This is a third flicker signature rather than a latent bug — a slow `DateTime` property made the comparison throw, taking the whole component test down with a `PlaywrightException`.

`QueueUpdate` itself is untouched — the batching is intentional for real consumers, and changing flush semantics to fix a test flake is the wrong trade.

## Reproducing

The races are lost scheduling hops, so an idle multi-core box will not reproduce them — 15 runs clean here proved nothing. Confining the test process to a single CPU does, at roughly the rate CI sees, because the confinement is inherited by the test host and by the browser Playwright starts, so they compete for that core. `flicker-repro.sh` / `flicker-repro.ps1` in the integration test folder wrap this up and exit non-zero on any failure, so they can gate a `git bisect run`.

`DOTNET_PROCESSOR_COUNT=1` is not a substitute: it resizes the thread pool without making anything else compete for the core, and reproduces nothing.

## Verification

Same command, same machine, one core, on the commit before this work versus after:

| | before | after |
|---|---|---|
| IgbCalendar, two 10-run samples | 4/10 and 3/10 failed | 0/20 failed |
| IgbTile | — | 0/8 failed |
| IgbThemeProvider | — | 0/8 failed |
| Full suite, 1 / 2 / 28 cores | — | 72/72 |

Between them those pre-fix runs reproduced four distinct signatures: the reported property mismatch, `did not fire`, the `DateTime` conversion exception, and the console timeout. The console timeout was also reproduced deterministically by widening the listener-attach window with a 3s delay, which fails on the old code and passes on the new.

Per-component check counts are unchanged throughout — same 72 components, same totals (`IgbCombo` 53, `IgbCalendar` 25), same 13 slot-only wrappers with no members. Nothing was skipped to make it pass.
