### PR TITLE
fix: Observe async EventCallback faults instead of dropping them.

### DIFF
--- a/src/components/Blazor/Calendar.cs
+++ b/src/components/Blazor/Calendar.cs
@@ -427,19 +427,13 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<DateTime>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                             if (!EventCallback<DateTime[]>.Empty.Equals(ValuesChanged))
                             {
                                 var task = ValuesChanged.InvokeAsync(newValueValues);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/CheckboxBase.cs
+++ b/src/components/Blazor/CheckboxBase.cs
@@ -398,10 +398,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<bool>.Empty.Equals(CheckedChanged))
                             {
                                 var task = CheckedChanged.InvokeAsync(newValueChecked);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/Chip.cs
+++ b/src/components/Blazor/Chip.cs
@@ -350,10 +350,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<bool>.Empty.Equals(SelectedChanged))
                             {
                                 var task = SelectedChanged.InvokeAsync(newValueSelected);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/Combo.cs
+++ b/src/components/Blazor/Combo.cs
@@ -871,10 +871,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<T[]>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/DatePicker.cs
+++ b/src/components/Blazor/DatePicker.cs
@@ -1077,10 +1077,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<DateTime?>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/DateRangePicker.cs
+++ b/src/components/Blazor/DateRangePicker.cs
@@ -1211,10 +1211,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<IgbDateRangeValue?>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/DateTimeInput.cs
+++ b/src/components/Blazor/DateTimeInput.cs
@@ -291,10 +291,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<DateTime?>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/Input.cs
+++ b/src/components/Blazor/Input.cs
@@ -456,10 +456,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<string>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/MaskInput.cs
+++ b/src/components/Blazor/MaskInput.cs
@@ -293,10 +293,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<string>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/Radio.cs
+++ b/src/components/Blazor/Radio.cs
@@ -398,10 +398,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<bool>.Empty.Equals(CheckedChanged))
                             {
                                 var task = CheckedChanged.InvokeAsync(newValueChecked);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/RadioGroup.cs
+++ b/src/components/Blazor/RadioGroup.cs
@@ -223,10 +223,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<string>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/Rating.cs
+++ b/src/components/Blazor/Rating.cs
@@ -484,10 +484,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<double>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/Select.cs
+++ b/src/components/Blazor/Select.cs
@@ -618,10 +618,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<string?>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/Slider.cs
+++ b/src/components/Blazor/Slider.cs
@@ -368,10 +368,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<double>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/components/Blazor/Textarea.cs
+++ b/src/components/Blazor/Textarea.cs
@@ -685,10 +685,7 @@ namespace IgniteUI.Blazor.Controls
                             if (!EventCallback<string>.Empty.Equals(ValueChanged))
                             {
                                 var task = ValueChanged.InvokeAsync(newValueValue);
-                                if (task.Exception != null)
-                                {
-                                    throw task.Exception;
-                                }
+                                ObserveHandlerTask(task);
                             }
 
                         });

--- a/src/componentsBase/BaseRendererControl.cs
+++ b/src/componentsBase/BaseRendererControl.cs
@@ -2934,6 +2934,32 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
+        /// <summary>
+        /// Observes the task returned by an <see cref="EventCallback.InvokeAsync"/> so that
+        /// exceptions raised by asynchronous consumer handlers are not silently swallowed.
+        /// Synchronous faults are rethrown to preserve the previous behavior; asynchronous
+        /// faults are surfaced through the same error channel as the interop dispatcher.
+        /// </summary>
+        internal static void ObserveHandlerTask(System.Threading.Tasks.Task task)
+        {
+            if (task == null)
+            {
+                return;
+            }
+            if (task.IsCompleted)
+            {
+                if (task.Exception != null)
+                {
+                    throw task.Exception;
+                }
+                return;
+            }
+            task.ContinueWith(static t =>
+            {
+                Console.WriteLine(t.Exception!.ToString());
+            }, System.Threading.Tasks.TaskContinuationOptions.OnlyOnFaulted | System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously);
+        }
+
         internal void SetHandler<T>(string name, string propertyName, EventCallback<T>? handler, Action<T> onArgs = null) where T : BaseRendererElement, new()
         {
             if (!handler.HasValue)
@@ -2954,10 +2980,7 @@ namespace IgniteUI.Blazor.Controls
                     onArgs(a);
                 }
                 var task = handler?.InvokeAsync(a);
-                if (task.Exception != null)
-                {
-                    throw task.Exception;
-                }
+                ObserveHandlerTask(task);
                 ele.ToEventJson(this, (Dictionary<string, object>)args);
                 ele.Parent = (null);
             };
@@ -2983,10 +3006,7 @@ namespace IgniteUI.Blazor.Controls
                     onArgs(a);
                 }
                 var task = handler?.InvokeAsync(a);
-                if (task.Exception != null)
-                {
-                    throw task.Exception;
-                }
+                ObserveHandlerTask(task);
             };
 
             //Console.WriteLine("setting handler: " + name + "/" + propertyName);

--- a/src/componentsBase/BaseRendererControl.cs
+++ b/src/componentsBase/BaseRendererControl.cs
@@ -2950,14 +2950,16 @@ namespace IgniteUI.Blazor.Controls
             {
                 if (task.Exception != null)
                 {
-                    throw task.Exception;
+                    System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(task.Exception).Throw();
                 }
                 return;
             }
             task.ContinueWith(static t =>
             {
-                Console.WriteLine(t.Exception!.ToString());
-            }, System.Threading.Tasks.TaskContinuationOptions.OnlyOnFaulted | System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously);
+                Console.WriteLine(t.Exception!);
+            }, System.Threading.CancellationToken.None,
+            System.Threading.Tasks.TaskContinuationOptions.OnlyOnFaulted | System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously,
+            System.Threading.Tasks.TaskScheduler.Default);
         }
 
         internal void SetHandler<T>(string name, string propertyName, EventCallback<T>? handler, Action<T> onArgs = null) where T : BaseRendererElement, new()

--- a/src/componentsBase/WebInputs/Tabs.cs
+++ b/src/componentsBase/WebInputs/Tabs.cs
@@ -29,10 +29,7 @@ namespace IgniteUI.Blazor.Controls
                 if (!EventCallback<bool>.Empty.Equals(item.SelectedChanged))
                 {
                     var task = item.SelectedChanged.InvokeAsync(item.Selected);
-                    if (task.Exception != null)
-                    {
-                        throw task.Exception;
-                    }
+                    ObserveHandlerTask(task);
                 }
             }
 

--- a/tests/IgniteUI.Blazor.Tests/InteropEventTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropEventTests.cs
@@ -48,4 +48,100 @@ public class InteropEventTests : BlazorComponentTestBase
         // No handler bound — dispatch must be a no-op rather than an error.
         Interop.RaiseEvent(Interop.ContainerIdOf(cut), "Closing");
     }
+
+    /// <summary>
+    /// Regression coverage for <c>BaseRendererControl.ObserveHandlerTask</c>: an async
+    /// <see cref="EventCallback{T}"/> handler that faults *after* an await returns a
+    /// task that completes asynchronously. Without observation those exceptions would
+    /// be silently dropped by the interop dispatch path (which does not itself await
+    /// the returned task). The observer surfaces the fault through the same error
+    /// channel as the interop dispatcher — captured here via <see cref="Console.Out"/>.
+    /// </summary>
+    [Fact]
+    public async Task AsyncHandler_FaultingAfterAwait_IsObservedNotSwallowed()
+    {
+        var gate = new TaskCompletionSource();
+        const string faultMessage = "async handler fault after await";
+
+        var cut = Render<IgbChip>(parameters => parameters
+            .Add(c => c.Select, _ => { })
+            .Add<bool>(c => c.SelectedChanged, async _ =>
+            {
+                await gate.Task;
+                throw new InvalidOperationException(faultMessage);
+            }));
+
+        var originalOut = Console.Out;
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            // Dispatch must not throw — the handler is still awaiting the gate,
+            // so InvokeAsync returns an incomplete task.
+            Interop.RaiseEvent(Interop.ContainerIdOf(cut), "Select", """{"detail": true}""");
+
+            Assert.DoesNotContain(faultMessage, writer.ToString());
+
+            // Release the async handler; ObserveHandlerTask's continuation runs
+            // synchronously (TaskContinuationOptions.ExecuteSynchronously) on the
+            // completing thread and must log the fault.
+            gate.SetResult();
+
+            // Belt-and-braces: if the continuation is deferred, give it a bounded
+            // window so the test stays deterministic without racing forever.
+            for (var i = 0; i < 50 && !writer.ToString().Contains(faultMessage); i++)
+            {
+                await Task.Delay(10);
+            }
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.Contains(faultMessage, writer.ToString());
+    }
+
+    /// <summary>
+    /// Negative control for <c>ObserveHandlerTask</c>: a successfully-completing
+    /// async handler must not write anything to the interop error channel. Guards
+    /// against a regression where the observer logs on every completion rather
+    /// than only on faults.
+    /// </summary>
+    [Fact]
+    public async Task AsyncHandler_CompletingSuccessfully_IsNotReportedAsError()
+    {
+        var gate = new TaskCompletionSource();
+        var completed = false;
+
+        var cut = Render<IgbChip>(parameters => parameters
+            .Add(c => c.Select, _ => { })
+            .Add<bool>(c => c.SelectedChanged, async _ =>
+            {
+                await gate.Task;
+                completed = true;
+            }));
+
+        var originalOut = Console.Out;
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            Interop.RaiseEvent(Interop.ContainerIdOf(cut), "Select", """{"detail": true}""");
+            gate.SetResult();
+
+            // Give any (unwanted) continuation a chance to run.
+            for (var i = 0; i < 10 && !completed; i++)
+            {
+                await Task.Delay(10);
+            }
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.True(completed);
+        Assert.Equal(string.Empty, writer.ToString());
+    }
 }

--- a/tests/IgniteUI.Blazor.Tests/InteropEventTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropEventTests.cs
@@ -72,7 +72,7 @@ public class InteropEventTests : BlazorComponentTestBase
             }));
 
         var originalOut = Console.Out;
-        var writer = new StringWriter();
+        using var writer = new StringWriter();
         Console.SetOut(writer);
         try
         {
@@ -123,7 +123,7 @@ public class InteropEventTests : BlazorComponentTestBase
             }));
 
         var originalOut = Console.Out;
-        var writer = new StringWriter();
+        using var writer = new StringWriter();
         Console.SetOut(writer);
         try
         {


### PR DESCRIPTION
## Description

The old code did:

```
var task = handler?.InvokeAsync(a);
if (task.Exception != null) throw task.Exception;
```

Exception is only populated once the task is in the Faulted state. For any async consumer handler, InvokeAsync returns a still-running task, so task.Exception is null at the point of inspection and the delayed failure vanishes.

So adding a handler `ObserveHandlerTask` that handles both the sync scenario and throws (same as before) and handling for a still running task so that delayed faults are observed.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:
All that have two-way bind: Calendar, Checkbox, Combo, Radio, RadioGroup etc.


## How Has This Been Tested?
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified

Closes #338
