### PR TITLE
feat: make IgniteUI.Blazor.Lite trim-compatible

### DIFF
--- a/.agents/skills/igniteui-blazor-lite-trimming/SKILL.md
+++ b/.agents/skills/igniteui-blazor-lite-trimming/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: igniteui-blazor-lite-trimming
+description: Keep IgniteUI.Blazor.Lite trim-compatible when changing library code. Use when touching reflection, JsonSerializer calls, DynamicallyAccessedMembers annotations, or suppressions in src/, when the build fails with IL2xxx errors, or when asked about trimming, trim warnings, or the PublishSmoke app.
+---
+# IgniteUI.Blazor.Lite — Trimming
+
+The library ships `IsTrimmable` and must stay trim-clean: every trim-analysis diagnostic (IL2xxx) builds as an **error**, enforced by `dotnet_analyzer_diagnostic.category-Trimming.severity = error` in the repo `.editorconfig`. The source of truth for policy and consumer guidance is [docs/TRIMMING.md](../../../docs/TRIMMING.md) — read its "Maintaining trim compatibility (contributors)" section before working around any IL2xxx error.
+
+## Rules
+
+1. **Fix first.** Serialize through source-generated `JsonTypeInfo` — extend `IgbJsonContext` (`src/componentsBase/IgbJsonContext.cs`) rather than calling reflection-based `JsonSerializer` overloads. Annotate `Type` flows with `[DynamicallyAccessedMembers]` where the flow is traceable (scalar `Type`/`string` parameters, properties, generic parameters — annotations are invalid on `Type[]` and do not trace through collections). For "keep members whenever the type is kept, however its `Type` value flows" use the self-referencing generic attribute pattern: `[IgbModule<TSelf>]` on the module classes (see `IgbModuleAttribute<TModule>` in `src/componentsBase/IgbModule.cs`) — a new module MUST carry it, guarded by `ServiceRegistrationTests.EveryLibraryModule_CarriesSelfReferencingIgbModuleAttribute`.
+2. **Never annotate method parameters or fields of component base classes** (`BaseRendererControl`, `BaseRendererElement`, or anything ComponentBase-derived). `OpenComponent<T>` roots component members "via reflection", so such annotations surface as IL2111/IL2110 errors in every consuming app. Annotated *properties* are fine (framework precedent: `RouteView.DefaultLayout`).
+3. **Suppress narrowly when a fix is impossible.** `[UnconditionalSuppressMessage("Trimming", "ILxxxx", Justification = "...")]` on the smallest member, with a justification stating why the pattern is safe at runtime; extract a small private helper if needed so the justification matches exactly what the member does. Keep the helper's `Type` parameter unannotated — annotating it only moves the warning to the caller.
+4. **Never use `#pragma warning disable` for ILxxxx.** It silences only the build analyzer and leaves no metadata for publish-time trim tooling (ILLink, NativeAOT's ILCompiler).
+5. **Don't add reflection over user-supplied or runtime-discovered types** outside the documented data-source boundary (`JSDataSourceSchema` and the `ExtractSchema` entry points).
+
+## Verification
+
+- `dotnet build src/IgniteUI.Blazor.Lite.csproj` must be free of IL diagnostics (they fail the build).
+- For changes touching reflection, serialization, or annotations, run the automated browser checks over the trimmed publish: `dotnet test tests/IgniteUI.Blazor.Lite.IntegrationTests --filter Category=TrimmedPublish --settings .runsettings` (`TrimmedPublishSmokeTest`; publishes the smoke app net10.0 on demand). It is category-scoped — not part of the per-component integration sweep — and covers net10.0 only; the manual checklist in `tests/IgniteUI.Blazor.Lite.PublishSmoke/README.md` covers the other TFMs. Trimming only happens at publish (`dotnet run` proves nothing).
+- Verify claims about linker behavior empirically in the smoke app — a control-vs-fix publish pair, not reasoning from documentation alone.

--- a/.editorconfig
+++ b/.editorconfig
@@ -330,6 +330,14 @@ dotnet_diagnostic.IDE0005.severity = warning
 # end_of_line = crlf
 # charset = utf-8
 
+#### Trimming ####
+
+# REPO: every trim-analysis diagnostic (IL2xxx) is an error; category bulk-config covers future
+# codes too. Inert in projects without the trim analyzer. Suppression policy: docs/TRIMMING.md.
+# For future AOT work: dotnet_analyzer_diagnostic.category-AOT.severity = error
+dotnet_analyzer_diagnostic.category-Trimming.severity = error
+dotnet_analyzer_diagnostic.category-SingleFile.severity = error
+
 #### Generated code — keep LAST so it overrides all sections above ####
 
 # Generated TS interop sources (ingested; tab-indented) — leave untouched so

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -169,7 +169,7 @@ In order to contribute code to a new feature, you need to follow these guideline
 2. Follow a test-driven development process (TDD) to ensure full code coverage.
    * Unit tests go in `tests/IgniteUI.Blazor.Tests`, generally **one file per component** — `<Name>Tests.cs` holds `<Name>Tests`. Suites for a component's child components may share the parent's file (e.g. `SelectItemTests` in `SelectTests.cs`); anything else gets its own file.
 3. Document all newly added public methods, inputs, outputs and properties.
-4. Make sure all static code analysis and tests pass before opening a pull request.
+4. Make sure all static code analysis and tests pass before opening a pull request. Note that trim-analysis diagnostics (IL2xxx) build as errors — see the ["Maintaining trim compatibility" section of docs/TRIMMING.md](../docs/TRIMMING.md#maintaining-trim-compatibility-contributors) for the policy on fixing versus suppressing them (AI agents: also available as the `igniteui-blazor-lite-trimming` skill in `.agents/skills/`).
 5. Test the component with screen reader and browser tools for accessibility compliance.
 6. Reference the issue you've been working on in your commit message and pull request title/description.
 7. Don't forget to make the necessary status updates, as described in the workflow section.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build TypeScript/Webpack assets
         run: npm run build
 
+      - name: Copy component themes to wwwroot
+        run: npm run copythemes
+
       - name: Restore .NET dependencies
         run: dotnet restore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Build .NET library
         run: dotnet build --no-restore --configuration Release /p:TreatWarningsAsErrors=false
 
+      # Trimmed publish of the smoke app fails on any linker warning; publish runs per TFM
+      - name: Publish trimmed smoke app
+        run: |
+          dotnet publish tests/IgniteUI.Blazor.Lite.PublishSmoke --configuration Release --framework net8.0
+          dotnet publish tests/IgniteUI.Blazor.Lite.PublishSmoke --configuration Release --framework net9.0
+          dotnet publish tests/IgniteUI.Blazor.Lite.PublishSmoke --configuration Release --framework net10.0
+
       - name: Build VS Templates
         run: dotnet pack templates/IgniteUI.Blazor.Templates/
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,6 @@
     <!-- Testing -->
     <PackageVersion Include="bunit" Version="2.8.6" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
@@ -29,6 +28,10 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <!-- Latest for TestBed.Client & Publish smoke app (trimmed WASM publish of the library, per library TFM) -->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <!-- Samples / stories -->
     <PackageVersion Include="BlazingStory" Version="1.0.0-preview.84" />
     <PackageVersion Include="MD2RazorGenerator" Version="1.2.4" />

--- a/IgniteUI.Blazor.Lite.slnx
+++ b/IgniteUI.Blazor.Lite.slnx
@@ -16,6 +16,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/IgniteUI.Blazor.Lite.IntegrationTests/IgniteUI.Blazor.Lite.IntegrationTests.csproj" />
+    <Project Path="tests/IgniteUI.Blazor.Lite.PublishSmoke/IgniteUI.Blazor.Lite.PublishSmoke.csproj" />
     <Project Path="tests/IgniteUI.Blazor.Lite.TestBed.Client/IgniteUI.Blazor.Lite.TestBed.Client.csproj" />
     <Project Path="tests/IgniteUI.Blazor.Lite.TestBed/IgniteUI.Blazor.Lite.TestBed.csproj" />
     <Project Path="tests/IgniteUI.Blazor.Tests/IgniteUI.Blazor.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ Build and run the Blazor app.
 
 <!-- ![](images/general/getting-started-blazor-card.jpg) -->
 
+### Publishing with trimming
+
+The library is trim-compatible. Applications publishing with `PublishTrimmed=true` (the Blazor WebAssembly default) should read [docs/TRIMMING.md](docs/TRIMMING.md) — mainly for preserving the data item types they bind.
+
 ## Building and Running Locally
 
 **Prerequisites:** [Node.js](https://nodejs.org/) 22 or later.

--- a/docs/TRIMMING.md
+++ b/docs/TRIMMING.md
@@ -1,0 +1,53 @@
+# Trimming support
+
+`IgniteUI.Blazor.Lite` is trim-compatible (`IsTrimmable=true`): the library builds warning-free under the .NET trim analyzer, and its own serialization uses source-generated `System.Text.Json` contexts and hand-written `Utf8JsonWriter` code that needs no reflection over your types.
+
+Two library features intrinsically depend on runtime type information that the trimmer cannot see. Applications published with `PublishTrimmed=true` (the default for Blazor WebAssembly publish) must follow the guidance below when using them.
+
+## App-provided data types: when to preserve them
+
+Parameters that carry your application's own types — data sources such as **`IgbCombo.Data`**, and value-carrying parameters such as `IgbTreeItem.Value` — work off the public properties and fields of those types at runtime. The trimmer cannot detect this, so unused members of your types may be removed and silently disappear from the rendered output.
+
+Preserve the item types you bind, either with a `DynamicDependency` attribute on any kept method (e.g. your root component or `Program.Main`):
+
+```csharp
+[DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields, typeof(MyDataItem))]
+```
+
+or by annotating the type itself:
+
+```csharp
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+public class MyDataItem { ... }
+```
+
+or with a [trimmer root descriptor](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#root-descriptors) listing the types.
+
+Preservation must cover **every complex type reachable from the item type**, not just the root: if `MyDataItem` has an `Address` property whose members the component renders, `Address` needs the same treatment — the schema builder reflects over nested object types as it encounters them.
+
+## Module preloading: trim-safe by design
+
+Module preloading works unchanged under trimming:
+
+```csharp
+builder.Services.AddIgniteUIBlazor(typeof(IgbTreeModule), typeof(IgbComboModule));
+```
+
+Every library `*Module` class carries a self-referencing `[IgbModule<TSelf>]` attribute that makes the trimmer preserve the module's registration surface whenever the type itself is kept — so `Type`-based preloading works no matter how the `Type` value reaches the library (a `typeof` argument, an array, a value computed at runtime), while modules the app never references still trim away entirely.
+
+The only caveat is **third-party module types**: a custom class with a `Register(IIgniteUIBlazor)` method passed by `Type` doesn't carry the attribute. Such types can opt into the same preservation by implementing `IIgbModule` and marking themselves with `[IgbModule<TSelf>]`, or the app can preserve their `Register` with its own annotations.
+
+## Native AOT
+
+Not supported yet. The data-source layer compiles expression-tree getters (`RequiresDynamicCode`), which is a planned follow-up; trimming and wasm AOT compilation of the interpreter-hosted kind are unaffected.
+
+## Maintaining trim compatibility (contributors)
+
+The library must stay trim-clean. Every trim-analysis diagnostic builds as an error (`dotnet_analyzer_diagnostic.category-Trimming.severity = error` in the repo `.editorconfig`; category bulk-config covers future IL2xxx codes, inert where the analyzer is off). The analyzer cannot validate suppression justifications or retention-based mechanisms like `[IgbModule<TSelf>]` — `tests/IgniteUI.Blazor.Lite.PublishSmoke` is the authoritative check for those, automated as the `TrimmedPublish`-category browser facts in `IgniteUI.Blazor.Lite.IntegrationTests` (net10.0, runs in CI); its README has the manual checklist covering the other TFMs.
+
+When the analyzer flags new code, follow the standard playbook — avoid reflection and dynamic code where possible, otherwise annotate or fix the root cause, and suppress only as a last resort: see [preparing libraries for trimming: recommendations](https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#recommendations) and [resolving trim warnings](https://learn.microsoft.com/dotnet/core/deploying/trimming/fixing-warnings). Repo-specific rules on top:
+
+1. **Serialization goes through source-generated `JsonTypeInfo`** — extend `IgbJsonContext` rather than calling reflection-based `JsonSerializer` overloads.
+2. **Never annotate *method parameters or fields* of component base classes** with `[DynamicallyAccessedMembers]` — `OpenComponent<T>` roots component members "via reflection" and the annotation then surfaces as IL2111/IL2110 in every consuming app (annotated *properties* are fine).
+3. **Suppress narrowly** — `[UnconditionalSuppressMessage]` on the smallest member with a justification that states why the pattern is safe; extract a small helper if needed so the justification matches exactly what the member does.
+4. **Never use `#pragma` for ILxxxx** — it silences only the build analyzer and leaves no metadata for publish-time trim tooling (ILLink, NativeAOT's ILCompiler).

--- a/src/IgniteUI.Blazor.Lite.csproj
+++ b/src/IgniteUI.Blazor.Lite.csproj
@@ -33,6 +33,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/IgniteUI/igniteui-blazor</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <!-- Trim-analysis diagnostics build as errors (.editorconfig, category-Trimming); suppression policy: docs/TRIMMING.md. -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/components/Blazor/AccordionModule.cs
+++ b/src/components/Blazor/AccordionModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbAccordionModule
+    [IgbModule<IgbAccordionModule>]
+    public partial class IgbAccordionModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/AvatarModule.cs
+++ b/src/components/Blazor/AvatarModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbAvatarModule
+    [IgbModule<IgbAvatarModule>]
+    public partial class IgbAvatarModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/BadgeModule.cs
+++ b/src/components/Blazor/BadgeModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbBadgeModule
+    [IgbModule<IgbBadgeModule>]
+    public partial class IgbBadgeModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/BannerModule.cs
+++ b/src/components/Blazor/BannerModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbBannerModule
+    [IgbModule<IgbBannerModule>]
+    public partial class IgbBannerModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/ButtonGroupModule.cs
+++ b/src/components/Blazor/ButtonGroupModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbButtonGroupModule
+    [IgbModule<IgbButtonGroupModule>]
+    public partial class IgbButtonGroupModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/ButtonModule.cs
+++ b/src/components/Blazor/ButtonModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbButtonModule
+    [IgbModule<IgbButtonModule>]
+    public partial class IgbButtonModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/CalendarBaseModule.cs
+++ b/src/components/Blazor/CalendarBaseModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for <see cref="IgbCalendarBase"/>. Registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbCalendarBaseModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbCalendarBaseModule
+    [IgbModule<IgbCalendarBaseModule>]
+    public partial class IgbCalendarBaseModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/CalendarModule.cs
+++ b/src/components/Blazor/CalendarModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbCalendarModule
+    [IgbModule<IgbCalendarModule>]
+    public partial class IgbCalendarModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/CardActionsModule.cs
+++ b/src/components/Blazor/CardActionsModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbCardActions"/> child component of <see cref="IgbCard"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbCardActionsModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbCardActionsModule
+    [IgbModule<IgbCardActionsModule>]
+    public partial class IgbCardActionsModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/CardContentModule.cs
+++ b/src/components/Blazor/CardContentModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbCardContent"/> child component of <see cref="IgbCard"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbCardContentModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbCardContentModule
+    [IgbModule<IgbCardContentModule>]
+    public partial class IgbCardContentModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/CardHeaderModule.cs
+++ b/src/components/Blazor/CardHeaderModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbCardHeader"/> child component of <see cref="IgbCard"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbCardHeaderModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbCardHeaderModule
+    [IgbModule<IgbCardHeaderModule>]
+    public partial class IgbCardHeaderModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/CardMediaModule.cs
+++ b/src/components/Blazor/CardMediaModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbCardMedia"/> child component of <see cref="IgbCard"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbCardMediaModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbCardMediaModule
+    [IgbModule<IgbCardMediaModule>]
+    public partial class IgbCardMediaModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/CardModule.cs
+++ b/src/components/Blazor/CardModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbCardModule
+    [IgbModule<IgbCardModule>]
+    public partial class IgbCardModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/CarouselIndicatorModule.cs
+++ b/src/components/Blazor/CarouselIndicatorModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbCarouselIndicator"/> child component of <see cref="IgbCarousel"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbCarouselIndicatorModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbCarouselIndicatorModule
+    [IgbModule<IgbCarouselIndicatorModule>]
+    public partial class IgbCarouselIndicatorModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/CarouselModule.cs
+++ b/src/components/Blazor/CarouselModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbCarouselModule
+    [IgbModule<IgbCarouselModule>]
+    public partial class IgbCarouselModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/CarouselSlideModule.cs
+++ b/src/components/Blazor/CarouselSlideModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbCarouselSlide"/> child component of <see cref="IgbCarousel"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbCarouselSlideModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbCarouselSlideModule
+    [IgbModule<IgbCarouselSlideModule>]
+    public partial class IgbCarouselSlideModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/ChatModule.cs
+++ b/src/components/Blazor/ChatModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbChatModule
+    [IgbModule<IgbChatModule>]
+    public partial class IgbChatModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/CheckboxBaseModule.cs
+++ b/src/components/Blazor/CheckboxBaseModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for <see cref="IgbCheckboxBase"/>. Registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbCheckboxBaseModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbCheckboxBaseModule
+    [IgbModule<IgbCheckboxBaseModule>]
+    public partial class IgbCheckboxBaseModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/CheckboxModule.cs
+++ b/src/components/Blazor/CheckboxModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbCheckboxModule
+    [IgbModule<IgbCheckboxModule>]
+    public partial class IgbCheckboxModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/ChipModule.cs
+++ b/src/components/Blazor/ChipModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbChipModule
+    [IgbModule<IgbChipModule>]
+    public partial class IgbChipModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/CircularGradientModule.cs
+++ b/src/components/Blazor/CircularGradientModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbCircularGradientModule
+    [IgbModule<IgbCircularGradientModule>]
+    public partial class IgbCircularGradientModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/CircularProgressModule.cs
+++ b/src/components/Blazor/CircularProgressModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbCircularProgressModule
+    [IgbModule<IgbCircularProgressModule>]
+    public partial class IgbCircularProgressModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/ComboModule.cs
+++ b/src/components/Blazor/ComboModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbComboModule
+    [IgbModule<IgbComboModule>]
+    public partial class IgbComboModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/DatePickerModule.cs
+++ b/src/components/Blazor/DatePickerModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbDatePickerModule
+    [IgbModule<IgbDatePickerModule>]
+    public partial class IgbDatePickerModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/DateRangePicker.cs
+++ b/src/components/Blazor/DateRangePicker.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Components;
 
 namespace IgniteUI.Blazor.Controls
@@ -1194,7 +1192,7 @@ namespace IgniteUI.Blazor.Controls
                             var newValueValue = default(IgbDateRangeValue?);
 
                             {
-                                newValueValue = JsonSerializer.Deserialize<IgbDateRangeValue?>(JsonSerializer.Serialize(args.Detail, new JsonSerializerOptions() { ReferenceHandler = ReferenceHandler.IgnoreCycles }));
+                                newValueValue = args.Detail == null ? null : new IgbDateRangeValue { Start = args.Detail.Start, End = args.Detail.End };
 
                                 if (newValueValue != null)
                                 {

--- a/src/components/Blazor/DateRangePickerModule.cs
+++ b/src/components/Blazor/DateRangePickerModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbDateRangePickerModule
+    [IgbModule<IgbDateRangePickerModule>]
+    public partial class IgbDateRangePickerModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/DateTimeInputModule.cs
+++ b/src/components/Blazor/DateTimeInputModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbDateTimeInputModule
+    [IgbModule<IgbDateTimeInputModule>]
+    public partial class IgbDateTimeInputModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/DialogModule.cs
+++ b/src/components/Blazor/DialogModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbDialogModule
+    [IgbModule<IgbDialogModule>]
+    public partial class IgbDialogModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/DividerModule.cs
+++ b/src/components/Blazor/DividerModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbDividerModule
+    [IgbModule<IgbDividerModule>]
+    public partial class IgbDividerModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/DropdownGroupModule.cs
+++ b/src/components/Blazor/DropdownGroupModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbDropdownGroup"/> child component of <see cref="IgbDropdown"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbDropdownGroupModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbDropdownGroupModule
+    [IgbModule<IgbDropdownGroupModule>]
+    public partial class IgbDropdownGroupModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/DropdownHeaderModule.cs
+++ b/src/components/Blazor/DropdownHeaderModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbDropdownHeader"/> child component of <see cref="IgbDropdown"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbDropdownHeaderModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbDropdownHeaderModule
+    [IgbModule<IgbDropdownHeaderModule>]
+    public partial class IgbDropdownHeaderModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/DropdownItemModule.cs
+++ b/src/components/Blazor/DropdownItemModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbDropdownItem"/> child component of <see cref="IgbDropdown"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbDropdownItemModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbDropdownItemModule
+    [IgbModule<IgbDropdownItemModule>]
+    public partial class IgbDropdownItemModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/DropdownModule.cs
+++ b/src/components/Blazor/DropdownModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbDropdownModule
+    [IgbModule<IgbDropdownModule>]
+    public partial class IgbDropdownModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/ExpansionPanelModule.cs
+++ b/src/components/Blazor/ExpansionPanelModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbExpansionPanelModule
+    [IgbModule<IgbExpansionPanelModule>]
+    public partial class IgbExpansionPanelModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/HighlightModule.cs
+++ b/src/components/Blazor/HighlightModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbHighlightModule
+    [IgbModule<IgbHighlightModule>]
+    public partial class IgbHighlightModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/IconButtonModule.cs
+++ b/src/components/Blazor/IconButtonModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbIconButtonModule
+    [IgbModule<IgbIconButtonModule>]
+    public partial class IgbIconButtonModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/IconModule.cs
+++ b/src/components/Blazor/IconModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbIconModule
+    [IgbModule<IgbIconModule>]
+    public partial class IgbIconModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/InputModule.cs
+++ b/src/components/Blazor/InputModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbInputModule
+    [IgbModule<IgbInputModule>]
+    public partial class IgbInputModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/LinearProgressModule.cs
+++ b/src/components/Blazor/LinearProgressModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbLinearProgressModule
+    [IgbModule<IgbLinearProgressModule>]
+    public partial class IgbLinearProgressModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/ListHeaderModule.cs
+++ b/src/components/Blazor/ListHeaderModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbListHeader"/> child component of <see cref="IgbList"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbListHeaderModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbListHeaderModule
+    [IgbModule<IgbListHeaderModule>]
+    public partial class IgbListHeaderModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/ListItemModule.cs
+++ b/src/components/Blazor/ListItemModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbListItem"/> child component of <see cref="IgbList"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbListItemModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbListItemModule
+    [IgbModule<IgbListItemModule>]
+    public partial class IgbListItemModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/ListModule.cs
+++ b/src/components/Blazor/ListModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbListModule
+    [IgbModule<IgbListModule>]
+    public partial class IgbListModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/MaskInputModule.cs
+++ b/src/components/Blazor/MaskInputModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbMaskInputModule
+    [IgbModule<IgbMaskInputModule>]
+    public partial class IgbMaskInputModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/NavDrawerHeaderItemModule.cs
+++ b/src/components/Blazor/NavDrawerHeaderItemModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbNavDrawerHeaderItem"/> child component of <see cref="IgbNavDrawer"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbNavDrawerHeaderItemModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbNavDrawerHeaderItemModule
+    [IgbModule<IgbNavDrawerHeaderItemModule>]
+    public partial class IgbNavDrawerHeaderItemModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/NavDrawerItemModule.cs
+++ b/src/components/Blazor/NavDrawerItemModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbNavDrawerItem"/> child component of <see cref="IgbNavDrawer"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbNavDrawerItemModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbNavDrawerItemModule
+    [IgbModule<IgbNavDrawerItemModule>]
+    public partial class IgbNavDrawerItemModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/NavDrawerModule.cs
+++ b/src/components/Blazor/NavDrawerModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbNavDrawerModule
+    [IgbModule<IgbNavDrawerModule>]
+    public partial class IgbNavDrawerModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/NavbarModule.cs
+++ b/src/components/Blazor/NavbarModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbNavbarModule
+    [IgbModule<IgbNavbarModule>]
+    public partial class IgbNavbarModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/RadioGroupModule.cs
+++ b/src/components/Blazor/RadioGroupModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbRadioGroupModule
+    [IgbModule<IgbRadioGroupModule>]
+    public partial class IgbRadioGroupModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/RadioModule.cs
+++ b/src/components/Blazor/RadioModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbRadioModule
+    [IgbModule<IgbRadioModule>]
+    public partial class IgbRadioModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/RangeSliderModule.cs
+++ b/src/components/Blazor/RangeSliderModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbRangeSliderModule
+    [IgbModule<IgbRangeSliderModule>]
+    public partial class IgbRangeSliderModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/RatingModule.cs
+++ b/src/components/Blazor/RatingModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbRatingModule
+    [IgbModule<IgbRatingModule>]
+    public partial class IgbRatingModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/RatingSymbolModule.cs
+++ b/src/components/Blazor/RatingSymbolModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbRatingSymbol"/> child component of <see cref="IgbRating"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbRatingSymbolModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbRatingSymbolModule
+    [IgbModule<IgbRatingSymbolModule>]
+    public partial class IgbRatingSymbolModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/RippleModule.cs
+++ b/src/components/Blazor/RippleModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbRippleModule
+    [IgbModule<IgbRippleModule>]
+    public partial class IgbRippleModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/SelectGroupModule.cs
+++ b/src/components/Blazor/SelectGroupModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbSelectGroup"/> child component of <see cref="IgbSelect"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbSelectGroupModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbSelectGroupModule
+    [IgbModule<IgbSelectGroupModule>]
+    public partial class IgbSelectGroupModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/SelectHeaderModule.cs
+++ b/src/components/Blazor/SelectHeaderModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbSelectHeader"/> child component of <see cref="IgbSelect"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbSelectHeaderModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbSelectHeaderModule
+    [IgbModule<IgbSelectHeaderModule>]
+    public partial class IgbSelectHeaderModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/SelectItemModule.cs
+++ b/src/components/Blazor/SelectItemModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbSelectItem"/> child component of <see cref="IgbSelect"/> or <see cref="IgbSelectGroup"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbSelectItemModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbSelectItemModule
+    [IgbModule<IgbSelectItemModule>]
+    public partial class IgbSelectItemModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/SelectModule.cs
+++ b/src/components/Blazor/SelectModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbSelectModule
+    [IgbModule<IgbSelectModule>]
+    public partial class IgbSelectModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/SliderBaseModule.cs
+++ b/src/components/Blazor/SliderBaseModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for <see cref="IgbSliderBase"/>. Registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbSliderBaseModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbSliderBaseModule
+    [IgbModule<IgbSliderBaseModule>]
+    public partial class IgbSliderBaseModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/SliderLabelModule.cs
+++ b/src/components/Blazor/SliderLabelModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbSliderLabel"/> child component of <see cref="IgbSlider"/> or <see cref="IgbRangeSlider"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbSliderLabelModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbSliderLabelModule
+    [IgbModule<IgbSliderLabelModule>]
+    public partial class IgbSliderLabelModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/SliderModule.cs
+++ b/src/components/Blazor/SliderModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbSliderModule
+    [IgbModule<IgbSliderModule>]
+    public partial class IgbSliderModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/SnackbarModule.cs
+++ b/src/components/Blazor/SnackbarModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbSnackbarModule
+    [IgbModule<IgbSnackbarModule>]
+    public partial class IgbSnackbarModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/SplitterModule.cs
+++ b/src/components/Blazor/SplitterModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbSplitterModule
+    [IgbModule<IgbSplitterModule>]
+    public partial class IgbSplitterModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/StepModule.cs
+++ b/src/components/Blazor/StepModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbStep"/> child component of <see cref="IgbStepper"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbStepModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbStepModule
+    [IgbModule<IgbStepModule>]
+    public partial class IgbStepModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/StepperModule.cs
+++ b/src/components/Blazor/StepperModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbStepperModule
+    [IgbModule<IgbStepperModule>]
+    public partial class IgbStepperModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/SwitchModule.cs
+++ b/src/components/Blazor/SwitchModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbSwitchModule
+    [IgbModule<IgbSwitchModule>]
+    public partial class IgbSwitchModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/TabModule.cs
+++ b/src/components/Blazor/TabModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbTab"/> child component of <see cref="IgbTabs"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbTabModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbTabModule
+    [IgbModule<IgbTabModule>]
+    public partial class IgbTabModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/TabsModule.cs
+++ b/src/components/Blazor/TabsModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbTabsModule
+    [IgbModule<IgbTabsModule>]
+    public partial class IgbTabsModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/TextareaModule.cs
+++ b/src/components/Blazor/TextareaModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbTextareaModule
+    [IgbModule<IgbTextareaModule>]
+    public partial class IgbTextareaModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/ThemeProviderModule.cs
+++ b/src/components/Blazor/ThemeProviderModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbThemeProviderModule
+    [IgbModule<IgbThemeProviderModule>]
+    public partial class IgbThemeProviderModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/TileManagerModule.cs
+++ b/src/components/Blazor/TileManagerModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbTileManagerModule
+    [IgbModule<IgbTileManagerModule>]
+    public partial class IgbTileManagerModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/TileModule.cs
+++ b/src/components/Blazor/TileModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbTile"/> child component of <see cref="IgbTileManager"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbTileModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbTileModule
+    [IgbModule<IgbTileModule>]
+    public partial class IgbTileModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/ToastModule.cs
+++ b/src/components/Blazor/ToastModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbToastModule
+    [IgbModule<IgbToastModule>]
+    public partial class IgbToastModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/ToggleButtonModule.cs
+++ b/src/components/Blazor/ToggleButtonModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbToggleButton"/> child component of <see cref="IgbButtonGroup"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbToggleButtonModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbToggleButtonModule
+    [IgbModule<IgbToggleButtonModule>]
+    public partial class IgbToggleButtonModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/TooltipModule.cs
+++ b/src/components/Blazor/TooltipModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbTooltipModule
+    [IgbModule<IgbTooltipModule>]
+    public partial class IgbTooltipModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/components/Blazor/TreeItemModule.cs
+++ b/src/components/Blazor/TreeItemModule.cs
@@ -4,7 +4,8 @@ namespace IgniteUI.Blazor.Controls
     /// Provides the module for the <see cref="IgbTreeItem"/> child component of <see cref="IgbTree"/>. The parent handles its resources, so registering this module has no effect and is no longer required.
     /// </summary>
     [Obsolete("Registering IgbTreeItemModule is no longer required, has no effect and can be safely removed.")]
-    public partial class IgbTreeItemModule
+    [IgbModule<IgbTreeItemModule>]
+    public partial class IgbTreeItemModule : IIgbModule
     {
         /// <summary>
         /// No-op.

--- a/src/components/Blazor/TreeModule.cs
+++ b/src/components/Blazor/TreeModule.cs
@@ -6,7 +6,8 @@ namespace IgniteUI.Blazor.Controls
     /// <remarks>
     /// Register explicitly on application startup by passing this type to <c>AddIgniteUIBlazor</c>.
     /// </remarks>
-    public partial class IgbTreeModule
+    [IgbModule<IgbTreeModule>]
+    public partial class IgbTreeModule : IIgbModule
     {
         /// <summary>
         /// Requests this module's client resources to be loaded into the runtime.

--- a/src/componentsBase/BaseRendererControl.cs
+++ b/src/componentsBase/BaseRendererControl.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
@@ -30,6 +31,8 @@ namespace IgniteUI.Blazor.Controls
         Queued
     }
 
+    // PublicProperties: required by the BuildSequenceInfo parameter walk; rendered components already keep All via OpenComponent<T>.
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
     public partial class BaseRendererControl : ComponentBase, RefSink, JsonSerializable, IAsyncDisposable
     {
         private IIgniteUIBlazor _igBlazor;
@@ -427,26 +430,7 @@ namespace IgniteUI.Blazor.Controls
                 {
                     if (pType.IsEnum)
                     {
-
-                        foreach (var f in pType.GetFields())
-                        {
-                            if (f.IsPublic && !f.IsSpecialName)
-                            {
-                                foreach (var attr in f.GetCustomAttributes(true))
-                                {
-                                    if (attr.GetType().Name == "WCEnumNameAttribute")
-                                    {
-                                        if (wcEnumTransform == null)
-                                        {
-                                            wcEnumTransform = new Dictionary<string, string>();
-                                        }
-                                        var wc = (WCEnumNameAttribute)attr;
-                                        var wcEnumName = Camelize(wc.Name);
-                                        wcEnumTransform.Add(f.Name.ToLower(), wcEnumName);
-                                    }
-                                }
-                            }
-                        }
+                        wcEnumTransform = GetWCEnumTransform(pType);
                     }
                 }
 
@@ -457,6 +441,33 @@ namespace IgniteUI.Blazor.Controls
             }
 
             return info;
+        }
+
+        // enumType intentionally unannotated: PropertyInfo.PropertyType cannot satisfy annotations, so one here would only move the warning to the caller.
+        [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "The trimmer preserves all fields of enum types that are kept, and enum parameter property types are kept with their declaring component.")]
+        private Dictionary<string, string> GetWCEnumTransform(Type enumType)
+        {
+            Dictionary<string, string> wcEnumTransform = null;
+            foreach (var f in enumType.GetFields())
+            {
+                if (f.IsPublic && !f.IsSpecialName)
+                {
+                    foreach (var attr in f.GetCustomAttributes(true))
+                    {
+                        if (attr.GetType().Name == "WCEnumNameAttribute")
+                        {
+                            if (wcEnumTransform == null)
+                            {
+                                wcEnumTransform = new Dictionary<string, string>();
+                            }
+                            var wc = (WCEnumNameAttribute)attr;
+                            var wcEnumName = Camelize(wc.Name);
+                            wcEnumTransform.Add(f.Name.ToLower(), wcEnumName);
+                        }
+                    }
+                }
+            }
+            return wcEnumTransform;
         }
 
         /// <inheritdoc />
@@ -1732,20 +1743,8 @@ namespace IgniteUI.Blazor.Controls
             }
 
             string json = m.ToJson();
-            ElementReference[] nativeElements = m.NativeElements;
 
-            if (nativeElements != null)
-            {
-                //json = "window.sendMessage(`" + this._id + "`, `" + json + "`)";
-                return this.JsInProcessRuntime.Invoke<object>("igSendMessage", new object[] { this._containerId, json,
-                GetObjectRef(), nativeElements });
-            }
-            else
-            {
-                //json = "window.sendMessage(`" + this._id + "`, `" + json + "`)";
-                return this.JsInProcessRuntime.Invoke<object>("igSendMessage", new object[] { this._containerId, json,
-                GetObjectRef()});
-            }
+            return SendJsonSync(json, m.NativeElements);
         }
 
         private void SendJson(string json, ElementReference[] nativeElements)
@@ -1825,20 +1824,21 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        private void SendJsonSync(string json, ElementReference[] nativeElements)
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Arguments are strings, DotNetObjectReference and ElementReference[]; the return value is consumed as a JsonElement and re-parsed only via the source-generated IgbJsonContext — no user types cross this boundary.")]
+        private object SendJsonSync(string json, ElementReference[] nativeElements)
         {
             //json = "window.sendMessage(`" + this._id + "`, `" + json + "`)";
 
             if (nativeElements != null)
             {
-                JsInProcessRuntime.Invoke<object>("igSendMessage",
+                return JsInProcessRuntime.Invoke<object>("igSendMessage",
                     new object[] {
                     this._containerId, json,
                     GetObjectRef(), nativeElements });
             }
             else
             {
-                JsInProcessRuntime.Invoke<object>("igSendMessage",
+                return JsInProcessRuntime.Invoke<object>("igSendMessage",
                     new object[] {
                     this._containerId, json,
                     GetObjectRef() });
@@ -3475,6 +3475,7 @@ namespace IgniteUI.Blazor.Controls
         private bool _isRemoteRuntime = false;
         private System.Reflection.PropertyInfo _remoteRuntimeProp;
 
+        [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Library module types carry [IgbModule<TSelf>], preserving Register whenever the type is kept; third-party module types must be preserved by the app — see docs/TRIMMING.md.")]
         public IgniteUIBlazor(IJSRuntime runtime, IIgniteUIBlazorSettings settings)
         {
             JsRuntime = runtime;
@@ -3543,6 +3544,7 @@ namespace IgniteUI.Blazor.Controls
             _loadedCache.AddOrUpdate(moduleName, true, (name, oldValue) => true);
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Probes the optional RemoteJSRuntime.IsInitialized, which does not exist in supported trim targets (WASM, WebView); a string DynamicDependency is not an option — it fails with IL2035 where the Server assembly is absent.")]
         public bool IsRuntimeValid(bool reevaluate = false)
         {
             if (JsRuntime == null)

--- a/src/componentsBase/BaseRendererControl.cs
+++ b/src/componentsBase/BaseRendererControl.cs
@@ -290,7 +290,7 @@ namespace IgniteUI.Blazor.Controls
             EnsureSequenceInfo();
 
             var ser = Serialize();
-            var data = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(ser);
+            var data = JsonSerializer.Deserialize(ser, SerializerContext.DictionaryStringObject);
             Dictionary<string, object> ret = new Dictionary<string, object>();
             foreach (var key in data.Keys)
             {
@@ -636,7 +636,7 @@ namespace IgniteUI.Blazor.Controls
 
         internal Dictionary<string, object>[] DeserializeDictionaryArray(string batch)
         {
-            return JsonSerializer.Deserialize<Dictionary<string, object>[]>(batch, SerializerOptions);
+            return JsonSerializer.Deserialize(batch, SerializerContext.DictionaryStringObjectArray);
         }
 
         private Dictionary<string, DynamicContentInfo> _dynamicContentInfos = new Dictionary<string, DynamicContentInfo>();
@@ -705,7 +705,7 @@ namespace IgniteUI.Blazor.Controls
                         object context = null;
                         if (args != null)
                         {
-                            var argsDic = JsonSerializer.Deserialize<Dictionary<string, object>>(args, SerializerOptions);
+                            var argsDic = JsonSerializer.Deserialize(args, SerializerContext.DictionaryStringObject);
                             context = ConvertReturnValue(argsDic);
                         }
                         dynamicContent.UpdateContext(context);
@@ -958,19 +958,19 @@ namespace IgniteUI.Blazor.Controls
             return InvokeMethodHelperSync(null, methodName, arguments, types, nativeElements);
         }
 
-        private JsonSerializerOptions _serializerOptions = null;
-        private JsonSerializerOptions SerializerOptions
+        private IgbJsonContext _serializerContext = null;
+        private IgbJsonContext SerializerContext
         {
             get
             {
-                if (_serializerOptions == null)
+                if (_serializerContext == null)
                 {
                     var def = IgBlazor.Settings.JsonSerializerOptions;
                     var options = new JsonSerializerOptions();
                     options.MaxDepth = def.MaxDepth;
-                    _serializerOptions = options;
+                    _serializerContext = new IgbJsonContext(options);
                 }
-                return _serializerOptions;
+                return _serializerContext;
             }
         }
 
@@ -1009,7 +1009,7 @@ namespace IgniteUI.Blazor.Controls
             if (ret is JsonElement && ((JsonElement)ret).ValueKind == JsonValueKind.String)
             {
                 var str = ((JsonElement)ret).GetString();
-                var retDict = JsonSerializer.Deserialize<Dictionary<string, object>>(str, SerializerOptions);
+                var retDict = JsonSerializer.Deserialize(str, SerializerContext.DictionaryStringObject);
 
                 if (retDict.ContainsKey("retType") &&
                     retDict["retType"] is JsonElement &&
@@ -1061,7 +1061,7 @@ namespace IgniteUI.Blazor.Controls
             if (ret is JsonElement && ((JsonElement)ret).ValueKind == JsonValueKind.String)
             {
                 var str = ((JsonElement)ret).GetString();
-                var retDict = JsonSerializer.Deserialize<Dictionary<string, object>>(str, SerializerOptions);
+                var retDict = JsonSerializer.Deserialize(str, SerializerContext.DictionaryStringObject);
                 ret = retDict;
 
                 if (retDict.ContainsKey("retType") &&
@@ -1887,7 +1887,7 @@ namespace IgniteUI.Blazor.Controls
                     Dictionary<string, object> obj;
                     if (returnValue is String)
                     {
-                        obj = JsonSerializer.Deserialize<Dictionary<string, object>>((string)returnValue, SerializerOptions);
+                        obj = JsonSerializer.Deserialize((string)returnValue, SerializerContext.DictionaryStringObject);
                     }
                     else if (returnValue is JsonElement)
                     {
@@ -1924,7 +1924,7 @@ namespace IgniteUI.Blazor.Controls
                             JsonDocument document = JsonDocument.Parse(str);
                             if (document.RootElement.ValueKind == JsonValueKind.Array)
                             {
-                                returnValue = JsonSerializer.Deserialize<Dictionary<string, object>[]>((string)j.ToString(), SerializerOptions);
+                                returnValue = JsonSerializer.Deserialize((string)j.ToString(), SerializerContext.DictionaryStringObjectArray);
                             }
                             else
                             {
@@ -1935,7 +1935,7 @@ namespace IgniteUI.Blazor.Controls
                         {
                             //var str = j.ToString();
                             //Console.WriteLine(j.ToString());
-                            obj = JsonSerializer.Deserialize<Dictionary<string, object>>((string)j.ToString(), SerializerOptions);
+                            obj = JsonSerializer.Deserialize((string)j.ToString(), SerializerContext.DictionaryStringObject);
                         }
                     }
                     else
@@ -2049,7 +2049,7 @@ namespace IgniteUI.Blazor.Controls
                                         var v = ((JsonElement)obj["value"]);
                                         var str = v.ToString();
                                         //Console.WriteLine(str);
-                                        var ev = JsonSerializer.Deserialize<Dictionary<string, object>>(str, SerializerOptions);
+                                        var ev = JsonSerializer.Deserialize(str, SerializerContext.DictionaryStringObject);
                                         ((BaseRendererElement)o).FromEventJson(this, ev);
                                         returnValue = o;
                                     }
@@ -2070,7 +2070,7 @@ namespace IgniteUI.Blazor.Controls
                                         return null;
                                     }
                                     var ret = obj["value"].ToString();
-                                    returnValue = JsonSerializer.Deserialize<Dictionary<string, object>>(ret, SerializerOptions);
+                                    returnValue = JsonSerializer.Deserialize(ret, SerializerContext.DictionaryStringObject);
                                 }
                             }
                             else
@@ -2107,7 +2107,7 @@ namespace IgniteUI.Blazor.Controls
             if (returnValue is JsonElement && ((JsonElement)returnValue).ValueKind == JsonValueKind.String)
             {
                 var str = ((JsonElement)returnValue).GetString();
-                result = JsonSerializer.Deserialize<Dictionary<string, object>>(str, SerializerOptions);
+                result = JsonSerializer.Deserialize(str, SerializerContext.DictionaryStringObject);
 
             }
             InvokeAsync(() =>
@@ -2247,7 +2247,7 @@ namespace IgniteUI.Blazor.Controls
             }
             try
             {
-                var arr = JsonSerializer.Deserialize<object[]>((string)val.ToString(), SerializerOptions);
+                var arr = JsonSerializer.Deserialize((string)val.ToString(), SerializerContext.ObjectArray);
                 DateTime[] ret = new DateTime[arr.Length];
                 for (int i = 0; i < arr.Length; i++)
                 {
@@ -2602,7 +2602,7 @@ namespace IgniteUI.Blazor.Controls
 
         internal string StringToString(object val)
         {
-            return val == null ? null : JsonSerializer.Serialize(val.ToString(), SerializerOptions);
+            return val == null ? null : JsonSerializer.Serialize(val.ToString(), SerializerContext.String);
             //return val == null ? null : val.ToString();
         }
 
@@ -2716,7 +2716,7 @@ namespace IgniteUI.Blazor.Controls
             // return jarr.toString();
             try
             {
-                return JsonSerializer.Serialize(arr, SerializerOptions);
+                return JsonSerializer.Serialize(arr, SerializerContext.StringArray);
             }
             catch (Exception e)
             {
@@ -2737,7 +2737,7 @@ namespace IgniteUI.Blazor.Controls
             // return jarr.toString();
             try
             {
-                return JsonSerializer.Serialize(arr, SerializerOptions);
+                return JsonSerializer.Serialize(arr, SerializerContext.Int32Array);
             }
             catch (Exception e)
             {
@@ -2758,7 +2758,7 @@ namespace IgniteUI.Blazor.Controls
             // return jarr.toString();
             try
             {
-                return JsonSerializer.Serialize(arr, SerializerOptions);
+                return JsonSerializer.Serialize(arr, SerializerContext.DoubleArray);
             }
             catch (Exception e)
             {
@@ -2779,7 +2779,7 @@ namespace IgniteUI.Blazor.Controls
             }
             try
             {
-                var arr = JsonSerializer.Deserialize<object[]>((string)val.ToString(), SerializerOptions);
+                var arr = JsonSerializer.Deserialize((string)val.ToString(), SerializerContext.ObjectArray);
                 Object[] ret = new Object[arr.Length];
                 for (int i = 0; i < arr.Length; i++)
                 {
@@ -2809,7 +2809,7 @@ namespace IgniteUI.Blazor.Controls
             val = ConvertReturnValue(val);
             try
             {
-                var arr = JsonSerializer.Deserialize<Dictionary<string, object>[]>((string)val.ToString(), SerializerOptions);
+                var arr = JsonSerializer.Deserialize((string)val.ToString(), SerializerContext.DictionaryStringObjectArray);
                 T[] ret = new T[arr.Length];
                 for (int i = 0; i < arr.Length; i++)
                 {
@@ -2841,7 +2841,7 @@ namespace IgniteUI.Blazor.Controls
             try
             {
                 var valStr = val.ToString();
-                var arr = JsonSerializer.Deserialize<string[]>((string)valStr, SerializerOptions);
+                var arr = JsonSerializer.Deserialize((string)valStr, SerializerContext.StringArray);
                 string[] ret = new string[arr.Length];
                 for (int i = 0; i < arr.Length; i++)
                 {
@@ -2865,7 +2865,7 @@ namespace IgniteUI.Blazor.Controls
             val = ConvertReturnValue(val);
             try
             {
-                var arr = JsonSerializer.Deserialize<object[]>((string)val.ToString(), SerializerOptions);
+                var arr = JsonSerializer.Deserialize((string)val.ToString(), SerializerContext.ObjectArray);
                 double[] ret = new double[arr.Length];
                 for (int i = 0; i < arr.Length; i++)
                 {
@@ -2889,7 +2889,7 @@ namespace IgniteUI.Blazor.Controls
             val = ConvertReturnValue(val);
             try
             {
-                var arr = JsonSerializer.Deserialize<object[]>((string)val.ToString(), SerializerOptions);
+                var arr = JsonSerializer.Deserialize((string)val.ToString(), SerializerContext.ObjectArray);
                 int[] ret = new int[arr.Length];
                 for (int i = 0; i < arr.Length; i++)
                 {
@@ -3060,13 +3060,13 @@ namespace IgniteUI.Blazor.Controls
                 Object senderObj = null;
                 try
                 {
-                    var obj = JsonSerializer.Deserialize<Dictionary<string, object>>((string)args.ToString(), SerializerOptions);
+                    var obj = JsonSerializer.Deserialize((string)args.ToString(), SerializerContext.DictionaryStringObject);
                     //Console.WriteLine(args.ToString());
 
                     object sender = obj["sender"];
                     if (sender is JsonElement && ((JsonElement)sender).ValueKind == JsonValueKind.String)
                     {
-                        sender = JsonSerializer.Deserialize<Dictionary<string, object>>(((JsonElement)sender).GetString(), SerializerOptions);
+                        sender = JsonSerializer.Deserialize(((JsonElement)sender).GetString(), SerializerContext.DictionaryStringObject);
                     }
 
                     senderObj = ConvertReturnValue(sender);
@@ -3090,7 +3090,7 @@ namespace IgniteUI.Blazor.Controls
                         //Console.WriteLine(doc.RootElement.ValueKind.ToString());
                         if (doc.RootElement.ValueKind == JsonValueKind.Object)
                         {
-                            var dict = JsonSerializer.Deserialize<Dictionary<string, object>>((string)argsString, SerializerOptions);
+                            var dict = JsonSerializer.Deserialize((string)argsString, SerializerContext.DictionaryStringObject);
                             val = dict;
 
                             // Avoid double unwrapping primitive value types. This primarily only applies to events with primitive types for event args which
@@ -3113,7 +3113,7 @@ namespace IgniteUI.Blazor.Controls
                         }
                         else
                         {
-                            val = JsonSerializer.Deserialize<object>((string)argsString, SerializerOptions);
+                            val = JsonSerializer.Deserialize((string)argsString, SerializerContext.Object);
                         }
                     }
                     //Console.WriteLine("calling handler");

--- a/src/componentsBase/DynamicContentHolder.cs
+++ b/src/componentsBase/DynamicContentHolder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 
@@ -104,6 +105,7 @@ namespace IgniteUI.Blazor.Controls
 
     public abstract class DynamicContentInfo
     {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public Type ControlType { get; set; }
         public DynamicContentInfo()
         {
@@ -155,7 +157,7 @@ namespace IgniteUI.Blazor.Controls
     public class TypedDynamicContent
         : DynamicContentInfo
     {
-        public TypedDynamicContent(Type t)
+        public TypedDynamicContent([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type t)
         {
             ControlType = t;
         }

--- a/src/componentsBase/IgbComponentRendererContainer.cs
+++ b/src/componentsBase/IgbComponentRendererContainer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 
@@ -8,6 +9,8 @@ namespace IgniteUI.Blazor.Controls
 
         private Type _componentType;
         [Parameter]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        [UnconditionalSuppressMessage("Trimming", "IL2078", Justification = "The backing field is only assigned through this annotated property; annotating the field would surface IL2110 in consuming apps.")]
         public Type ComponentType
         {
             get

--- a/src/componentsBase/IgbJsonContext.cs
+++ b/src/componentsBase/IgbJsonContext.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace IgniteUI.Blazor.Controls
+{
+    /// <summary>
+    /// Source-generated serializer context for the closed set of JSON shapes exchanged with the
+    /// client renderer. Deserialized <c>object</c> values surface as <see cref="System.Text.Json.JsonElement"/>.
+    /// </summary>
+    [JsonSerializable(typeof(Dictionary<string, object>))]
+    [JsonSerializable(typeof(Dictionary<string, object>[]))]
+    [JsonSerializable(typeof(object))]
+    [JsonSerializable(typeof(object[]))]
+    [JsonSerializable(typeof(string))]
+    [JsonSerializable(typeof(string[]))]
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(double[]))]
+    internal partial class IgbJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/componentsBase/IgbModule.cs
+++ b/src/componentsBase/IgbModule.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace IgniteUI.Blazor.Controls
+{
+    /// <summary>
+    /// A client resource module that can register itself with the Ignite UI Blazor runtime.
+    /// Implemented by the component <c>*Module</c> classes.
+    /// </summary>
+    public interface IIgbModule
+    {
+        /// <summary>
+        /// Requests this module's client resources to be loaded into the runtime.
+        /// </summary>
+        /// <param name="runtime">The Ignite UI Blazor runtime to load the resources into.</param>
+        static abstract void Register(IIgniteUIBlazor runtime);
+    }
+
+    /// <summary>
+    /// Marks a module class so the trimmer preserves its public methods whenever the type is kept,
+    /// keeping the reflective <c>Register</c> lookup working under trimming; unreferenced modules
+    /// still trim away. Applied self-referentially, e.g. <c>[IgbModule&lt;IgbTreeModule&gt;]</c>.
+    /// A plain class-level <see cref="DynamicallyAccessedMembersAttribute"/> would not work here:
+    /// it only activates for instantiated types (or annotated <c>GetType()</c> flows), and module
+    /// classes are only ever referenced via <c>typeof</c>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class IgbModuleAttribute<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TModule> : Attribute where TModule : IIgbModule
+    {
+    }
+}

--- a/src/componentsBase/JsonDataSourceSchema.cs
+++ b/src/componentsBase/JsonDataSourceSchema.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace IgniteUI.Blazor.Controls
@@ -213,6 +214,7 @@ namespace IgniteUI.Blazor.Controls
             return ret;
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Data item types are supplied by the application at runtime; trimmed apps must preserve their data item types — see docs/TRIMMING.md.")]
         private static void GetPropertiesFromType(Type type, List<PropertyInfo> properties)
         {
             if (type.BaseType != null && type.BaseType != typeof(object))
@@ -230,6 +232,7 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Data item types are supplied by the application at runtime; trimmed apps must preserve their data item types — see docs/TRIMMING.md.")]
         private static void GetFieldsFromType(Type type, List<FieldInfo> fields)
         {
             if (type.BaseType != null && type.BaseType != typeof(object))
@@ -247,6 +250,7 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Reflects only the indexer of Dictionary<string, object> (both call sites guard on that type), which the library also uses statically — the 'Item' property is always preserved alongside this code.")]
         public static JSDataSourceSchema CreateFromDictionary(IDictionary item)
         {
             JSDataSourceSchema s = new JSDataSourceSchema();

--- a/src/componentsBase/RuntimeHelper.cs
+++ b/src/componentsBase/RuntimeHelper.cs
@@ -23,6 +23,9 @@ namespace IgniteUI.Blazor.Controls
             "Microsoft.AspNetCore.Components.WebAssembly")]
 #endif
         //[System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(WebAssemblyJSRuntime))]
+        [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Probes the net8-only InvokeUnmarshalled methods (removed in net9+), preserved via the DynamicDependency above; absence falls back to the raw-pointer InvokeVoid path.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2060", Justification = "The generic arguments are statically referenced framework/library types, and the InvokeUnmarshalled generic parameters carry no DynamicallyAccessedMembers requirements.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The DynamicDependency above marks the runtime's RequiresUnreferencedCode members (Invoke, GetValue, SetValue, ...); the probe filters by name and never invokes them.")]
         public RuntimeHelper(IJSRuntime runtime, IIgniteUIBlazor igBlazor)
         {
             _igBlazor = igBlazor;

--- a/src/componentsBase/UnmarshalledDataSource.cs
+++ b/src/componentsBase/UnmarshalledDataSource.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace IgniteUI.Blazor.Controls
@@ -2297,6 +2298,7 @@ namespace IgniteUI.Blazor.Controls
         //     }
         // }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Data item types are supplied by the application at runtime; trimmed apps must preserve their data item types — see docs/TRIMMING.md.")]
         public static JSDataSourceSchema ExtractSchema(object item)
         {
             if (item == null)
@@ -2364,7 +2366,7 @@ namespace IgniteUI.Blazor.Controls
             return JSDataSourceSchema.Create(c);
         }
 
-        private static Type GetIListTypeArg(Type itemType)
+        private static Type GetIListTypeArg([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type itemType)
         {
             foreach (var inter in itemType.GetInterfaces())
             {
@@ -2380,7 +2382,7 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
-        private static Type GetIEnumerableTypeArg(Type itemType)
+        private static Type GetIEnumerableTypeArg([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type itemType)
         {
             foreach (var inter in itemType.GetInterfaces())
             {
@@ -2396,6 +2398,7 @@ namespace IgniteUI.Blazor.Controls
             return null;
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Data item types are supplied by the application at runtime; trimmed apps must preserve their data item types — see docs/TRIMMING.md.")]
         public static JSDataSourceSchema ExtractSchemaFromType(Type itemType)
         {
             if (itemType.IsArray)

--- a/src/componentsBase/Utils.cs
+++ b/src/componentsBase/Utils.cs
@@ -1,7 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace IgniteUI.Blazor.Controls
 {
     internal static class Utils
     {
+        // enumType intentionally unannotated: the requirement would propagate into ObjectToParam on the
+        // component base classes, where DAM method parameters surface IL2111 in every consuming app.
+        [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "The trimmer preserves all fields of enum types that are kept, and the enum types reaching here are statically referenced by their callers.")]
         internal static bool TryGetWCEnumName(Type enumType, string enumMemberName, out string name)
         {
             name = null;

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/TrimmedPublishServer.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/Infrastructure/TrimmedPublishServer.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+
+namespace IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure
+{
+    /// <summary>
+    /// Serves the PublishSmoke app's trimmed publish output as static files on a dynamic port
+    /// for the TrimmedPublish browser checks, publishing it first when the output is missing
+    /// (CI publishes ahead of the test run, so it hits the fast path).
+    /// </summary>
+    internal sealed class TrimmedPublishServer : IAsyncDisposable
+    {
+        private const string Tfm = "net10.0";
+
+        private readonly WebApplication app;
+
+        public string BaseUrl { get; }
+
+        private TrimmedPublishServer(WebApplication app, string baseUrl)
+        {
+            this.app = app;
+            BaseUrl = baseUrl;
+        }
+
+        public static async Task<TrimmedPublishServer> StartAsync()
+        {
+            var files = new PhysicalFileProvider(EnsurePublished());
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+            var app = builder.Build();
+            app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = files });
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = files,
+                // Blazor publish output contains fingerprinted asset names with no mapped extension.
+                ServeUnknownFileTypes = true,
+            });
+
+            await app.StartAsync().ConfigureAwait(false);
+            return new TrimmedPublishServer(app, app.Urls.First());
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await app.StopAsync().ConfigureAwait(false);
+            await app.DisposeAsync().ConfigureAwait(false);
+        }
+
+        private static string EnsurePublished()
+        {
+            var repoRoot = FindRepoRoot();
+            var wwwroot = Path.Combine(repoRoot, "tests", "IgniteUI.Blazor.Lite.PublishSmoke",
+                "bin", "Release", Tfm, "publish", "wwwroot");
+
+            if (!File.Exists(Path.Combine(wwwroot, "index.html")))
+            {
+                var publish = new ProcessStartInfo("dotnet",
+                    $"publish tests/IgniteUI.Blazor.Lite.PublishSmoke -c Release -f {Tfm} --nologo")
+                {
+                    WorkingDirectory = repoRoot,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                };
+                using var process = Process.Start(publish)!;
+                var stderr = process.StandardError.ReadToEndAsync();
+                var output = process.StandardOutput.ReadToEnd() + stderr.GetAwaiter().GetResult();
+                process.WaitForExit();
+                if (process.ExitCode != 0 || !File.Exists(Path.Combine(wwwroot, "index.html")))
+                {
+                    throw new InvalidOperationException($"Publishing the smoke app failed ({process.ExitCode}):\n{output}");
+                }
+            }
+
+            return wwwroot;
+        }
+
+        private static string FindRepoRoot()
+        {
+            for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+            {
+                if (dir.EnumerateFiles("*.slnx").Any())
+                {
+                    return dir.FullName;
+                }
+            }
+
+            throw new InvalidOperationException("Could not locate the repository root (no .slnx found above " + AppContext.BaseDirectory + ").");
+        }
+    }
+}

--- a/tests/IgniteUI.Blazor.Lite.IntegrationTests/TrimmedPublishSmokeTest.cs
+++ b/tests/IgniteUI.Blazor.Lite.IntegrationTests/TrimmedPublishSmokeTest.cs
@@ -1,0 +1,149 @@
+using System.Collections.Concurrent;
+using IgniteUI.Blazor.Lite.IntegrationTests.Infrastructure;
+using Microsoft.Playwright;
+using Microsoft.Playwright.NUnit;
+
+namespace IgniteUI.Blazor.Lite.IntegrationTests
+{
+    /// <summary>
+    /// Browser checks over the PublishSmoke app's trimmed publish output — the runtime gate for
+    /// behavior the trim analyzer cannot verify: suppression justifications and retention-based
+    /// mechanisms, which trim silently when they stop holding. Mirrors the checklist in
+    /// <c>tests/IgniteUI.Blazor.Lite.PublishSmoke/README.md</c>.
+    /// </summary>
+    [Parallelizable(ParallelScope.Self)]
+    [Category("TrimmedPublish")]
+    public class TrimmedPublishSmokeTest : BrowserTest
+    {
+        private static TrimmedPublishServer server = null!;
+
+        // Filled from Playwright's dispatcher thread while the test thread may be reading.
+        private IBrowserContext context = null!;
+        private IPage page = null!;
+        private ConcurrentQueue<string> pageErrors = null!;
+        private ConcurrentQueue<string> failedRequests = null!;
+
+        [OneTimeSetUp]
+        public static async Task StartServer() => server = await TrimmedPublishServer.StartAsync();
+
+        [OneTimeTearDown]
+        public static async Task StopServer()
+        {
+            if (server is not null)
+            {
+                await server.DisposeAsync();
+            }
+        }
+
+        [SetUp]
+        public async Task LoadApp()
+        {
+            pageErrors = new();
+            failedRequests = new();
+
+            context = await NewContext(new BrowserNewContextOptions { BaseURL = server.BaseUrl });
+            page = await context.NewPageAsync();
+            page.Console += (_, message) =>
+            {
+                // Resource-load failures land in failedRequests with the URL (and the favicon
+                // exclusion); the console duplicate carries neither.
+                if (message.Type == "error" && !message.Text.StartsWith("Failed to load resource"))
+                {
+                    pageErrors.Enqueue(message.Text);
+                }
+            };
+            page.PageError += (_, error) => pageErrors.Enqueue(error);
+            page.Response += (_, response) =>
+            {
+                if (response.Status >= 400 && !response.Url.EndsWith("favicon.ico"))
+                {
+                    failedRequests.Enqueue($"{response.Status} {response.Url}");
+                }
+            };
+
+            await page.GotoAsync("/", new() { WaitUntil = WaitUntilState.NetworkIdle });
+            await page.WaitForSelectorAsync("#module-preload-result", new() { Timeout = 30000 });
+            // Components ready: child components commit in later render batches than the App
+            // markup above, and a non-empty bounding box on the last one means its web-component
+            // module loaded and the element upgraded.
+            await page.WaitForSelectorAsync("igc-date-range-picker", new() { State = WaitForSelectorState.Visible, Timeout = 30000 });
+        }
+
+        [TearDown]
+        public async Task CloseContext()
+        {
+            if (context is not null)
+            {
+                await context.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        /// IgbChat's component is never referenced by the app, so its Type-based preload survives
+        /// trimming only through <c>[IgbModule&lt;IgbChatModule&gt;]</c> — the check that catches
+        /// both attribute regressions and linker-behavior changes on SDK updates.
+        /// </summary>
+        [Test]
+        public async Task ModulePreload_RegisterSurvivesTrimming()
+        {
+            var text = await page.Locator("#module-preload-result").TextContentAsync();
+
+            Assert.That(text, Does.Contain("ChatModule preloaded: True"));
+        }
+
+        /// <summary>
+        /// Enum parameters must serialize as web-component tokens — camelCase by convention,
+        /// or via [WCEnumName] where present ("single-required"). Numbers mean the enum fields
+        /// were trimmed; a camelCase "singleRequired" means the field attributes were.
+        /// </summary>
+        [Test]
+        public async Task EnumParameters_SerializeAsWebComponentTokens()
+        {
+            var tokens = await page.EvaluateAsync<string[]>(
+                @"[document.querySelector('igc-button').variant,
+                   document.querySelector('igc-avatar').shape,
+                   document.querySelector('igc-button-group').selection]");
+
+            Assert.That(tokens, Is.EqualTo(new[] { "outlined", "circle", "single-required" }));
+        }
+
+        /// <summary>
+        /// The combo's schema is built by reflecting over the app's item type, preserved via the
+        /// documented DynamicallyAccessedMembers pattern from docs/TRIMMING.md.
+        /// </summary>
+        [Test]
+        public async Task DataSource_ReflectsPreservedItemType()
+        {
+            // The data lands through interop after the element upgrades.
+            await page.WaitForFunctionAsync("() => document.querySelector('igc-combo')?.data?.length === 3");
+            var firstItemNames = await page.EvaluateAsync<string[]>(
+                @"Object.keys(document.querySelector('igc-combo').data[0])");
+
+            Assert.That(firstItemNames, Does.Contain("Id").And.Contain("Name"));
+        }
+
+        [Test]
+        public async Task EventPayload_MaterializesDateRangeValue()
+        {
+            await page.EvaluateAsync(
+                @"document.querySelector('igc-date-range-picker').dispatchEvent(
+                      new CustomEvent('igcChange', { detail: { start: new Date(2026, 0, 5), end: new Date(2026, 0, 9) } }))");
+
+            await page.WaitForFunctionAsync(
+                @"() => !document.querySelector('#range-result').textContent.includes('no range selected')");
+            var text = await page.Locator("#range-result").TextContentAsync();
+
+            Assert.That(text, Does.Contain("2026"));
+        }
+
+        [Test]
+        public void CleanLoad_NoErrorsOrFailedRequests()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(pageErrors, Is.Empty, "Console/page errors during the trimmed app load.");
+                Assert.That(failedRequests, Is.Empty, "Failed requests during the trimmed app load.");
+            });
+        }
+    }
+}

--- a/tests/IgniteUI.Blazor.Lite.PublishSmoke/App.razor
+++ b/tests/IgniteUI.Blazor.Lite.PublishSmoke/App.razor
@@ -1,0 +1,63 @@
+@inject IIgniteUIBlazor IgBlazor
+
+<h1>IgniteUI.Blazor.Lite publish smoke</h1>
+
+@* Expected: True. Chat's preload survives trimming only through [IgbModule<IgbChatModule>]
+   (see Program.cs); the static IsLoadRequested call here roots that method, not Register. *@
+<section id="module-preload-section">
+    <p id="module-preload-result">ChatModule preloaded: @IgbChatModule.IsLoadRequested(IgBlazor)</p>
+</section>
+
+@* Enum serialization path: Variant/Shape flow through AddEnumProp/TryGetWCEnumName.
+   Under trimming these must render as camelCase strings, not numbers. *@
+<section id="button-section">
+    <IgbButton Variant="ButtonVariant.Outlined">Outlined button</IgbButton>
+</section>
+
+<section id="avatar-section">
+    <IgbAvatar Shape="AvatarShape.Circle" Initials="PS"></IgbAvatar>
+</section>
+
+@* WCEnumName attribute path: SingleRequired maps via [WCEnumName("single-required")], not
+   camelCase conversion — fails if enum field attributes are trimmed. *@
+<section id="buttongroup-section">
+    <IgbButtonGroup Selection="ButtonGroupSelection.SingleRequired">
+        <IgbToggleButton Value="smoke">Toggle</IgbToggleButton>
+    </IgbButtonGroup>
+</section>
+
+@* Data source path: reflects over SmokeDataItem, which is preserved via the
+   documented DynamicallyAccessedMembers pattern from docs/TRIMMING.md. *@
+<section id="combo-section">
+    <IgbCombo T="SmokeDataItem" Data="_items" ValueKey="Id" DisplayKey="Name" Label="Smoke combo"></IgbCombo>
+</section>
+
+@* Event payload path: Change materializes IgbDateRangeValue from the event detail. *@
+<section id="daterange-section">
+    <IgbDateRangePicker Change="OnRangeChanged"></IgbDateRangePicker>
+    <p id="range-result">@_rangeResult</p>
+</section>
+
+@code {
+    private string _rangeResult = "no range selected";
+
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+    public class SmokeDataItem
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private readonly List<SmokeDataItem> _items = new()
+    {
+        new SmokeDataItem { Id = 1, Name = "Alpha" },
+        new SmokeDataItem { Id = 2, Name = "Beta" },
+        new SmokeDataItem { Id = 3, Name = "Gamma" },
+    };
+
+    private void OnRangeChanged(IgbDateRangeValueEventArgs args)
+    {
+        var value = args.Detail;
+        _rangeResult = value == null ? "no range selected" : $"{value.Start:d} - {value.End:d}";
+    }
+}

--- a/tests/IgniteUI.Blazor.Lite.PublishSmoke/IgniteUI.Blazor.Lite.PublishSmoke.csproj
+++ b/tests/IgniteUI.Blazor.Lite.PublishSmoke/IgniteUI.Blazor.Lite.PublishSmoke.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <!-- Publish-compatibility smoke app: publishes the library under assembly trimming
+       (and, as future work, AOT compilation) and exercises the reflection-adjacent
+       features in the browser. See docs/TRIMMING.md. -->
+  <PropertyGroup>
+    <!-- Match the library's TFMs so each gets a real ILLink pass (e.g. the net8-only reflection paths). -->
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Trim analyzer for the app's own code (errors via the repo .editorconfig);
+         linker-level issues still only surface at publish. -->
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <!-- Fail the publish on any ILLink warning, reported individually. Linker *analysis*
+         warnings stay suppressed (Blazor default) — the framework's own assemblies emit them;
+         the library's analysis cleanliness is enforced at build time via the repo .editorconfig. -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\IgniteUI.Blazor.Lite.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/IgniteUI.Blazor.Lite.PublishSmoke/Program.cs
+++ b/tests/IgniteUI.Blazor.Lite.PublishSmoke/Program.cs
@@ -1,0 +1,20 @@
+using System.Collections.ObjectModel;
+using IgniteUI.Blazor.Controls;
+using IgniteUI.Blazor.Lite.PublishSmoke;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+
+// Type-based module preload under trimming (settings-carried + params, merged). IgbChat is never
+// statically used by this app, so its preload only survives via [IgbModule<IgbChatModule>].
+var settings = new IgniteUIBlazorSettings()
+    .WithModulesToLoad(new ReadOnlyCollection<Type>([typeof(IgbChatModule)]));
+
+builder.Services.AddIgniteUIBlazor(settings,
+    typeof(IgbButtonModule),
+    typeof(IgbAvatarModule),
+    typeof(IgbComboModule),
+    typeof(IgbDateRangePickerModule));
+
+await builder.Build().RunAsync();

--- a/tests/IgniteUI.Blazor.Lite.PublishSmoke/Properties/launchSettings.json
+++ b/tests/IgniteUI.Blazor.Lite.PublishSmoke/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "IgniteUI.Blazor.Lite.PublishSmoke": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:57044;http://localhost:57045"
+    }
+  }
+}

--- a/tests/IgniteUI.Blazor.Lite.PublishSmoke/README.md
+++ b/tests/IgniteUI.Blazor.Lite.PublishSmoke/README.md
@@ -1,0 +1,51 @@
+# PublishSmoke — trimmed-publish verification app
+
+A minimal Blazor WebAssembly app that publishes `IgniteUI.Blazor.Lite` **with assembly trimming** and exercises the reflection-adjacent features in a real browser. The trim analyzer cannot validate `[UnconditionalSuppressMessage]` justifications or retention-based mechanisms like `[IgbModule<TSelf>]` — this app is the end-to-end check for those.
+
+## Why publish? Can't I just `dotnet run -c Release`?
+
+No — the trimmer (ILLink) only runs during **publish**. `dotnet run`/`dotnet build` always use the full, untrimmed assemblies regardless of configuration, so nothing trim-related can be observed that way. Verification is always: publish, then serve the publish output as static files.
+
+## Run it
+
+```bash
+# 1. Publish trimmed (from the repo root). The app multi-targets the library's TFMs;
+#    publish requires picking one — check all three after linker-sensitive changes.
+dotnet publish tests/IgniteUI.Blazor.Lite.PublishSmoke -c Release -f net10.0
+
+# 2. Serve the publish output (any static file server works; npx needs no install — Node is a repo prerequisite):
+npx http-server tests/IgniteUI.Blazor.Lite.PublishSmoke/bin/Release/net10.0/publish/wwwroot -p 5620
+
+# 3. Open http://localhost:5620/ and check the page against the table below.
+```
+
+Three gates, in order of what they can see:
+
+1. **Build** — the trim analyzer runs over this app's own source (`EnableTrimAnalyzer`, findings are errors via the repo `.editorconfig`); the library's source is analyzed the same way at its own build. Build-time analysis cannot see linker behavior or referenced-assembly IL.
+2. **Publish** — ILLink runs; fails on any linker warning (`ILLinkTreatWarningsAsErrors`, single-warn off) such as unresolved `DynamicDependency` assemblies (IL2035 class). Linker *analysis* warnings stay muzzled — Blazor default — because the framework's own assemblies emit them.
+3. **Browser** — the only gate that catches *silent* trims: a publish can succeed while a suppression's justification or a retention mechanism quietly stopped holding. That's the checklist below.
+
+## What to check in the browser
+
+| Page section | Expected | A failure means |
+|---|---|---|
+| `ChatModule preloaded:` | `True` | `[IgbModule<TSelf>]` preservation broke — the Type-based module preload silently lost `Register` (IgbChat's component is deliberately never referenced by this app, so nothing else can keep it alive) |
+| Outlined button + avatar render styled | camelCase enum attributes (`variant="outlined"`, `shape="circle"` in dev tools) | enum fields were trimmed — the enum-preservation justification in `TryGetWCEnumName`/`GetWCEnumTransform` no longer holds |
+| Button group | `selection` is `single-required` in dev tools | enum **field attributes** were trimmed — the `[WCEnumName]` mapping path degraded to camelCase (`singleRequired`) |
+| Combo shows 3 items | `Alpha`, `Beta`, `Gamma` | data-source reflection over the (preserved) POCO broke — the documented `DynamicallyAccessedMembers` consumer pattern in docs/TRIMMING.md no longer suffices |
+| Date range picker present; selecting a range updates the result line | date text below the picker | the event payload path (`IgbDateRangeValue` materialization) broke |
+| Browser console | no errors (a stray `favicon` 404 is fine) | anything else: investigate |
+
+The checklist is automated as `TrimmedPublishSmokeTest` in `IgniteUI.Blazor.Lite.IntegrationTests` (`Category=TrimmedPublish`, runs in CI after the publish step). It serves the net10.0 publish output — publishing it on demand if missing — so locally it's just:
+
+```bash
+dotnet test tests/IgniteUI.Blazor.Lite.IntegrationTests --filter Category=TrimmedPublish --settings .runsettings
+```
+
+The manual browser pass above remains useful for the other TFMs and for linker experiments.
+
+## When to run
+
+- After any change to reflection, serialization, `[DynamicallyAccessedMembers]` annotations, or suppressions in `src/` (see the `igniteui-blazor-lite-trimming` skill in `.agents/skills/` and docs/TRIMMING.md).
+- After SDK updates — linker behavior should be re-validated.
+- For linker experiments, run a control (publish *without* the change) first. Beware: any constrained static-abstract call (e.g. `IIgbModule.Register` through a generic) roots the implementations on all kept module types, contaminating controls.

--- a/tests/IgniteUI.Blazor.Lite.PublishSmoke/_Imports.razor
+++ b/tests/IgniteUI.Blazor.Lite.PublishSmoke/_Imports.razor
@@ -1,0 +1,3 @@
+@using System.Diagnostics.CodeAnalysis
+@using Microsoft.AspNetCore.Components.Web
+@using IgniteUI.Blazor.Controls

--- a/tests/IgniteUI.Blazor.Lite.PublishSmoke/wwwroot/index.html
+++ b/tests/IgniteUI.Blazor.Lite.PublishSmoke/wwwroot/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>IgniteUI.Blazor.Lite publish smoke</title>
+    <base href="/" />
+    <link href="_content/IgniteUI.Blazor/themes/light/material.css" rel="stylesheet" />
+  </head>
+
+  <body>
+    <div id="app">Loading...</div>
+
+    <div id="blazor-error-ui" style="display: none">
+      An unhandled error has occurred.
+      <a href="." class="reload">Reload</a>
+    </div>
+    <script src="_content/IgniteUI.Blazor/app.bundle.js"></script>
+    <script src="_framework/blazor.webassembly.js"></script>
+  </body>
+</html>

--- a/tests/IgniteUI.Blazor.Tests/ServiceRegistrationTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ServiceRegistrationTests.cs
@@ -198,4 +198,29 @@ public class ServiceRegistrationTests
 
         Assert.Equal(2, FirstModule.Registrations.Count);
     }
+
+    /// <summary>
+    /// Type-based preload is trim-safe only because every module carries a self-referencing
+    /// <c>[IgbModule&lt;TSelf&gt;]</c>. A missing attribute — or one pasted from another
+    /// module — silently breaks that module's preload in trimmed apps; this guards both.
+    /// </summary>
+    [Fact]
+    public void EveryLibraryModule_CarriesSelfReferencingIgbModuleAttribute()
+    {
+        var moduleTypes = typeof(IgbAvatarModule).Assembly.GetTypes()
+            .Where(t => t.IsClass && typeof(IIgbModule).IsAssignableFrom(t))
+            .ToList();
+        Assert.NotEmpty(moduleTypes);
+
+        foreach (var type in moduleTypes)
+        {
+            var attributeType = type.GetCustomAttributes(inherit: false)
+                .Select(a => a.GetType())
+                .SingleOrDefault(a => a.IsGenericType && a.GetGenericTypeDefinition() == typeof(IgbModuleAttribute<>));
+
+            Assert.True(attributeType != null, $"{type.Name} is missing [IgbModule<{type.Name}>].");
+            Assert.True(attributeType!.GenericTypeArguments[0] == type,
+                $"{type.Name} carries [IgbModule<{attributeType.GenericTypeArguments[0].Name}>] — the attribute must reference its own type.");
+        }
+    }
 }


### PR DESCRIPTION
Closes #348 

## What & why

Enabling [`<IsTrimmable>true</IsTrimmable>`](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming) surfaced 48 unique trim-analysis warnings per TFM (net8/net9/net10), concentrated in the JSON interop layer and the reflective data-source/module plumbing. This PR resolves all of them — real fixes where possible, narrowly-justified suppressions only where the reflected members are provably preserved (framework/library reflection) or belong to app-supplied data types with a documented preservation requirement — so the library is safe to consume from apps published with [trimming](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/configure-trimmer) (the Blazor WebAssembly publish default).

Based on `dpetev/event-callback-compare-fix`: its `EventCallbackExtensions.EqualsCompat` replaces the old reflective `CompareEventCallbacks` and is already trim-clean under the new analyzer gate with no annotations (`typeof(EventCallback<TValue>).GetField` is statically analyzable).

## Changes

### Real fixes

- **JSON source generation** ([docs](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation)): new `IgbJsonContext` (`src/componentsBase/IgbJsonContext.cs`) covers the closed set of wire shapes (`Dictionary<string,object>`, its array, `object`, `object[]`, `string`, `string[]`, `int[]`, `double[]`); all ~25 `JsonSerializer` call sites in `BaseRendererControl` now use typed `JsonTypeInfo` overloads — the IL2026s are gone for real, not suppressed. Deserialized `object` values still surface as `JsonElement`, identical to the reflection-based behavior.
- **`DateRangePicker` Change handler**: the `Serialize(args.Detail) → Deserialize<IgbDateRangeValue>` round-trip (with a per-event `JsonSerializerOptions` allocation) is replaced by a direct `Start`/`End` copy — the two types share the exact shape.
- **Trim-safe module registration, zero API changes to registration itself**: new `IIgbModule` interface (`static abstract Register`) implemented by all 75 `*Module` classes, each also carrying a self-referencing `[IgbModule<TSelf>]` whose `[DynamicallyAccessedMembers(PublicMethods)]` generic parameter makes the trimmer preserve the module's `Register` **whenever the type itself is kept** — custom attributes live and die with their type, so this works for `typeof` args, arrays, and runtime-computed `Type`s alike, while unreferenced modules still trim fully (verified empirically: preloading an otherwise-unreferenced module through the untouched `params Type[]` overload silently no-ops without the attribute, works with it; a drift-guard test asserts every module's attribute references itself). Alternative designs were built and verified, then dropped: an `IgbModuleRef` implicit-conversion wrapper and `[OverloadResolutionPriority]` dual overloads (call-site tracing can't cover arrays/computed `Type`s; the wrapper broke `Type[]` array call sites) and a fluent `Add<T>()` collection builder (reflection-free but API shape not wanted — kept as a possible future addition).

### Annotations ([DynamicallyAccessedMembers](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings))

- `BaseRendererControl` class: `PublicProperties` — inherited by every component, satisfies the `BuildSequenceInfo` property walk; costs nothing real since rendered components already get `All` via `OpenComponent<T>`.
- `Utils.TryGetWCEnumName` / `ObjectToParam(…, Type, …)` chain: deliberately **unannotated** — DAM on method parameters of component base classes surfaces IL2111 in every consuming app (see suppression table); enum origins are `typeof` literals or boxed library enum fields at every call site.
- `IgbComponentRendererContainer.ComponentType` (property only; the backing field is deliberately unannotated — field DAM surfaces IL2110, see suppression table) and `DynamicContentInfo.ControlType` / `TypedDynamicContent(Type)`: `All`, as required by `RenderTreeBuilder.OpenComponent(Type)`.
- `UnmarshalledDataSource.GetIListTypeArg`/`GetIEnumerableTypeArg`: `Interfaces`.

### Suppression inventory (each `[UnconditionalSuppressMessage]`, with justification)

| Site | Code | Why it is safe |
|---|---|---|
| `BaseRendererControl.SendJsonSync` | IL2026 | Arguments are strings, `DotNetObjectReference<WebCallback>` (a library type; only its id is serialized), `ElementReference[]`; the return is consumed as `JsonElement` and re-parsed only via the source-generated `IgbJsonContext` — no user types cross the JS interop boundary. |
| `BaseRendererControl.GetWCEnumTransform` (helper extracted from `BuildSequenceInfo`) | IL2070 | ILLink preserves all fields of kept enum types; enum parameter property types are kept with their declaring component. Validated in the trimmed browser smoke (enum values render as camelCase strings, not numbers). |
| `Utils.TryGetWCEnumName` | IL2070 | Same enum-field preservation. Deliberately suppressed instead of annotated: DAM-annotated *method parameters* on component base classes trigger IL2111 in every consuming app, because `OpenComponent<T>` roots component members "via reflection". |
| `IgniteUIBlazor` ctor (module `Register` loop) | IL2075 | Library module types carry `[IgbModule<TSelf>]`, preserving `Register` whenever the type is kept, so the lookup succeeds however the `Type` flowed here; third-party module types must be preserved by the app — documented in docs/TRIMMING.md. |
| `IgniteUIBlazor.IsRuntimeValid` | IL2075 | Probes optional `RemoteJSRuntime.IsInitialized`; in supported trim scenarios (WASM, MAUI BlazorWebView) the type doesn't exist and the probe correctly finds nothing. A string `DynamicDependency` can't be used (IL2035 when the Server assembly is absent). |
| `RuntimeHelper` ctor | IL2075, IL2060, IL2026 | net8-only `InvokeUnmarshalled` probe (API removed from the framework in net9+, binary-verified), preserved via the existing `DynamicDependency`; absence degrades to the raw-pointer `InvokeVoid` path that is the only path on net9+. IL2026: the `DynamicDependency` marks the runtime's RUC members (net10 `GetValue`/`SetValue`/…), which the probe filters out by name and never invokes. |
| `IgbComponentRendererContainer.ComponentType` | IL2078 | The backing field is only assigned through the annotated property; annotating the field itself would expose IL2110 to consuming apps. |
| `JSDataSourceSchema.GetPropertiesFromType`/`GetFieldsFromType` | IL2067 | Data-source boundary: item types are supplied by the app at runtime — documented requirement in docs/TRIMMING.md. |
| `JSDataSourceSchema.CreateFromDictionary` | IL2075 | Reflects only the `Dictionary<string, object>` indexer (both call sites guard on that type), which the library also uses statically — always preserved alongside this code. |
| `UnmarshalledDataSource.ExtractSchema` / `ExtractSchemaFromType` | IL2072 / IL2067 | Same boundary. |

### Guards & docs

- Trim regression guard: `dotnet_analyzer_diagnostic.category-Trimming.severity = error` (plus `category-SingleFile`) in the repo `.editorconfig` — category bulk-config covers current *and future* IL2xxx codes, inert where the trim analyzer is off. Verified: removing a suppression fails the build with `error IL2070`. Suppression policy: docs/TRIMMING.md contributor section.
- New **`docs/TRIMMING.md`** (linked from README): consumer guidance — preserving data item types (including nested complex types), module preloading, AOT status.
- New **`tests/IgniteUI.Blazor.Lite.PublishSmoke`**: Blazor WASM app publishing the library trimmed (`ILLinkTreatWarningsAsErrors`, single-warn off, own trim analyzer on) with a browser checklist in its README; in the solution and published by CI after the library build. Named publish-scoped so the future AOT pass reuses it.
- ci.yml gains the `npm run copythemes` step the release workflow already had — CI builds had no component themes in `src/wwwroot` (gitignored, npm-produced), which `TrimmedPublishSmokeTest`'s clean-load fact caught as a theme-CSS 404 on its first CI run.
- New **`TrimmedPublishSmokeTest`** (IntegrationTests, `Category=TrimmedPublish`): the browser checklist as Playwright facts over the trimmed net10.0 publish output — module preload survival, camelCase enum tokens, reflected data source, `igcChange` payload round-trip, clean load (no console errors/failed requests). Served by a minimal static-file host on a dynamic port (`Infrastructure/TrimmedPublishServer.cs`) that publishes the smoke app on demand; CI runs it via the existing unfiltered integration-test step, hitting the already-published fast path. Silent trims now fail CI instead of waiting for a manual check.

## Verification

- `dotnet build` (all 3 TFMs, rebuild): **0 IL diagnostics** with the `.editorconfig` error gate active.
- `dotnet test`: 959 passed / 0 failed on each of net8.0, net9.0, net10.0.
- `dotnet publish` of PublishSmoke: **0 ILLink warnings** (linker analysis warnings stay suppressed per the Blazor default — the framework's own assemblies emit them).
- Headless-browser smoke against the trimmed publish output: enum attributes render as web-component tokens — camelCase by convention (`variant="outlined"`, `shape="circle"` — enum fields survive trimming) and attribute-mapped (`selection="single-required"` — `[WCEnumName]` field attributes survive too), the combo binds a 3-item reflected POCO list preserved per the docs/TRIMMING.md pattern, and a dispatched `igcChange` round-trips through the new date-range copy path into rendered output. These checks now run automatically as `TrimmedPublishSmokeTest`; the full integration suite (77 tests including the 5 new facts) passes.
- Module registration verified with isolated trimmed publishes preloading a module whose component the app never references (`IgbChatModule`), through the `Type`-based path with no other rooting: without `[IgbModule<TSelf>]` the preload silently loses `Register`; with it, preserved. Plain type-level `[DynamicallyAccessedMembers]` (on the interface or the module class) was also tested and does *not* work: class-level DAM only activates for *instantiated* types (that's why it works on app data-item classes and on `BaseRendererControl`) or annotated `GetType()` flows — module classes are never instantiated, only `typeof`-referenced, hence the generic-attribute form whose DAM rides the attribute's type argument instead. The smoke app exercises the attribute-protected `Type` path permanently.

## Behavioral notes

- `GatherSimpleAttributes` previously deserialized with no options (default `MaxDepth` 64); it now honors `Settings.JsonSerializerOptions.MaxDepth` (library default 32) like its sibling call sites.
- The `AddIgniteUIBlazor` overloads are **unchanged** — no source or binary breaking changes to module registration; `IIgbModule` and `[IgbModule<TSelf>]` are purely additive.
- Object-initializing `IgbDateRangeValue` in the Change handler triggers two BL0005 analyzer warnings (parameter set outside component) — same class of pre-existing warnings as `Chat.cs`/`Tabs.cs`.
- ⚠️ **Known size limitation** (not a trim-safety issue): `MarshalByValueFactory.CreateInstance`'s static switch constructs every marshal-by-value type, so all event-args types survive trimming and pull in thin shells of their component types (e.g. `IgbTab` keeps `Type` + 4 property accessors in an app that never uses tabs). Bounded — unused components don't survive in full — and reclaiming it needs pay-for-play event-args registration, deferred to the interop rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)