### PR TITLE
Fix the intermittent Interop unit test failures

### DIFF
--- a/src/componentsBase/BaseRendererControl.cs
+++ b/src/componentsBase/BaseRendererControl.cs
@@ -155,6 +155,14 @@ namespace IgniteUI.Blazor.Controls
         }
         private LinkedList<RendererMessage> _messageQueue = new LinkedList<RendererMessage>();
 
+        /// <summary>
+        /// Guards <see cref="_messageQueue"/> and the <c>_updateQueued</c> flag that decides when it
+        /// is flushed. Two paths flush it - <c>SendMessageImmediate</c> on the caller's thread,
+        /// <c>QueueUpdate</c> on the renderer's - and a component driven from off the Blazor
+        /// dispatcher (a timer, a bound collection filled in the background) hits both at once.
+        /// </summary>
+        private readonly object _messageQueueLock = new object();
+
         private string _containerId = Guid.NewGuid().ToString();
 
         internal string ContainerId
@@ -852,7 +860,7 @@ namespace IgniteUI.Blazor.Controls
             }
             RendererMessage m = new RendererMessage();
             m.Type = ("description");
-            _messageQueue.AddLast(m);
+            Enqueue(m);
             QueueUpdate();
         }
 
@@ -954,6 +962,13 @@ namespace IgniteUI.Blazor.Controls
         private Dictionary<long, Object> _methodReturns = new Dictionary<long, Object>();
         private Object _semLock = new Object();
 
+        /// <summary>
+        /// Shared by every instance because the WebView callback paths return only the invoke ID,
+        /// without a container ID to identify the originating component.
+        /// </summary>
+        /// <remarks>
+        /// Only use <see cref="Interlocked.Increment" /> as this is incremented from any thread.
+        /// </remarks>
         static long _invokeId = 0;
         protected async Task<object> InvokeMethod(string methodName, object[] arguments, string[] types, ElementReference[] nativeElements = null)
         {
@@ -995,7 +1010,7 @@ namespace IgniteUI.Blazor.Controls
             m.Type = ("invokeMethod");
             string[] args = new string[arguments.Length];
             string[] typeStrings = new string[arguments.Length];
-            long invokeId = _invokeId++;
+            long invokeId = Interlocked.Increment(ref _invokeId);
             for (int i = 0; i < arguments.Length; i++)
             {
                 args[i] = GetStringArg(arguments[i], types[i]);
@@ -1045,7 +1060,7 @@ namespace IgniteUI.Blazor.Controls
             m.Type = ("invokeMethod");
             string[] args = new string[arguments.Length];
             string[] typeStrings = new string[arguments.Length];
-            long invokeId = _invokeId++;
+            long invokeId = Interlocked.Increment(ref _invokeId);
             for (int i = 0; i < arguments.Length; i++)
             {
                 args[i] = GetStringArg(arguments[i], types[i]);
@@ -1574,7 +1589,7 @@ namespace IgniteUI.Blazor.Controls
                 return;
             }
             //Console.WriteLine("sending message");
-            _messageQueue.AddLast(m);
+            Enqueue(m);
             QueueUpdate();
         }
 
@@ -1585,8 +1600,14 @@ namespace IgniteUI.Blazor.Controls
                 return null;
             }
 
-            Update();
-            return await SendJsonImmediate(m);
+            // The send must start under this lock.
+            Task<object> sent;
+            lock (_messageQueueLock)
+            {
+                Update();
+                sent = SendJsonImmediate(m);
+            }
+            return await sent;
         }
 
         private object SendMessageSyncImmediate(RendererMessage m)
@@ -1595,51 +1616,79 @@ namespace IgniteUI.Blazor.Controls
             {
                 return null;
             }
-            UpdateSync();
-            return SendJsonImmediateSync(m);
+            lock (_messageQueueLock)
+            {
+                UpdateSync();
+                return SendJsonImmediateSync(m);
+            }
+        }
+
+        private void Enqueue(RendererMessage m)
+        {
+            lock (_messageQueueLock)
+            {
+                _messageQueue.AddLast(m);
+            }
         }
 
         private void QueueUpdate()
         {
-            if (!_updateQueued && _ready)
+            bool schedule = false;
+            lock (_messageQueueLock)
             {
-                _updateQueued = true;
+                if (!_updateQueued && _ready)
+                {
+                    _updateQueued = true;
+                    schedule = true;
+                }
+            }
+
+            if (schedule)
+            {
                 Task.Delay(0).ContinueWith((t) => InvokeAsync(Update));
             }
         }
 
         private void Update()
         {
-            this._updateQueued = false;
-
-            if (!_ready)
+            // Spans the whole drain, not just the dequeue, so two flushes cannot interleave their
+            // sends. A thread already holding it can take it again, so nesting is fine.
+            lock (_messageQueueLock)
             {
-                return;
-            }
+                this._updateQueued = false;
 
-            //Console.WriteLine("updateing: " + this.GetType().Name + " " + _messageQueue.Count);
-            while (_messageQueue.Count > 0)
-            {
-                RendererMessage m = _messageQueue.First.Value;
-                _messageQueue.RemoveFirst();
-                ProcessMessage(m);
+                if (!_ready)
+                {
+                    return;
+                }
+
+                //Console.WriteLine("updateing: " + this.GetType().Name + " " + _messageQueue.Count);
+                while (_messageQueue.Count > 0)
+                {
+                    RendererMessage m = _messageQueue.First.Value;
+                    _messageQueue.RemoveFirst();
+                    ProcessMessage(m);
+                }
             }
         }
 
         private void UpdateSync()
         {
-            this._updateQueued = false;
-
-            if (!_ready)
+            lock (_messageQueueLock)
             {
-                return;
-            }
+                this._updateQueued = false;
 
-            while (_messageQueue.Count > 0)
-            {
-                RendererMessage m = _messageQueue.First.Value;
-                _messageQueue.RemoveFirst();
-                ProcessMessageSync(m);
+                if (!_ready)
+                {
+                    return;
+                }
+
+                while (_messageQueue.Count > 0)
+                {
+                    RendererMessage m = _messageQueue.First.Value;
+                    _messageQueue.RemoveFirst();
+                    ProcessMessageSync(m);
+                }
             }
         }
 
@@ -3177,7 +3226,10 @@ namespace IgniteUI.Blazor.Controls
                 RendererMessage m = new RendererMessage();
                 m.Type = ("cleanup");
 
-                _messageQueue.Clear();
+                lock (_messageQueueLock)
+                {
+                    _messageQueue.Clear();
+                }
                 await SendMessageImmediate(m).ConfigureAwait(false);
             }
             catch (JSDisconnectedException ex)

--- a/tests/IgniteUI.Blazor.Tests/BlazorComponentTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/BlazorComponentTestBase.cs
@@ -19,12 +19,12 @@ public abstract class BlazorComponentTestBase : BunitContext
     /// <summary>The interop harness for components on the default (current) interop stack.</summary>
     protected InteropHarness Interop { get; }
 
-    private Dictionary<Func<BunitJSInterop, InteropHarness>, InteropHarness>? _overrideHarnesses;
+    private Dictionary<InteropHarnessRegistry.HarnessFactory, InteropHarness>? _overrideHarnesses;
 
     protected BlazorComponentTestBase()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        Interop = InteropHarnessRegistry.CreateDefault(JSInterop);
+        Interop = InteropHarnessRegistry.CreateDefault(JSInterop, () => Renderer.Dispatcher);
         Interop.ConfigureServices(Services);
         IgniteUIBlazor = Interop.Service;
     }
@@ -50,7 +50,7 @@ public abstract class BlazorComponentTestBase : BunitContext
         _overrideHarnesses ??= new();
         if (!_overrideHarnesses.TryGetValue(factory, out var harness))
         {
-            harness = factory(JSInterop);
+            harness = factory(JSInterop, () => Renderer.Dispatcher);
             harness.ConfigureServices(Services);
             _overrideHarnesses[factory] = harness;
         }

--- a/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
@@ -367,7 +367,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
                 var registration = harness.FindPropertyUpdate(containerId, WireMemberName(bind.DrivingEvent))
                     ?? throw new XunitException(
                         $"binding transmitted no \"{bind.DrivingEvent}\" event registration — without it the " +
-                        "client never reports changes, so the binding can never fire");
+                        $"client never reports changes, so the binding can never fire ({harness.DescribeTraffic(containerId)})");
                 Assert.Equal(bind.DrivingEvent, registration.GetString());
 
                 harness.RaiseEvent(containerId, bind.DrivingEvent, bind.ArgsJson.Get(harness, cut));
@@ -487,7 +487,8 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
                 Assert.Equal(bound, evt.Get(cut.Instance));
                 var wireName = WireMemberName(evt.EventName);
                 var registration = harness.FindPropertyUpdate(containerId, wireName)
-                    ?? throw new XunitException("no event-handler registration transmission was observed");
+                    ?? throw new XunitException(
+                        "no event-handler registration transmission was observed — " + harness.DescribeTraffic(containerId));
                 Assert.Equal(evt.EventName, registration.GetString());
 
                 var argsJson = evt.ArgsJson.Get(harness, cut);
@@ -557,7 +558,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
                     {
                         throw new XunitException(
                             $"re-binding \"{evt.EventName}\" transmitted {rebound?.ToString() ?? "no registration"} — " +
-                            "the client would never resubscribe");
+                            $"the client would never resubscribe ({harness.DescribeTraffic(containerId)})");
                     }
                 }
             }

--- a/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
+++ b/tests/IgniteUI.Blazor.Tests/ComponentWithContractTestBase.cs
@@ -174,7 +174,9 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
             ? $"no new current-state read was issued for \"{method.ReadsProperty}\""
             : $"\"{method.JsName}\" sent no new invocation";
 
-        var (call, result) = await InvokeExpectingNewCall(matching, () => method.Invoke(cut.Instance), noNewCall);
+        // On the dispatcher, as application code calling a component API is - see OnDispatcher.
+        var (call, result) = await InvokeExpectingNewCall(
+            matching, () => harness.OnDispatcher(() => method.Invoke(cut.Instance)), noNewCall);
         AssertObserved(harness, cut, scope, method, call, result);
 
         if (method.SyncInvoke is not null)
@@ -183,7 +185,7 @@ public abstract class ComponentWithContractTestBase<TComponent> : BlazorComponen
             // (the stub persists) to the same result.
             var (syncCall, syncResult) = await InvokeExpectingNewCall(
                 matching,
-                () => Task.FromResult(method.SyncInvoke(cut.Instance)),
+                () => Task.FromResult(harness.OnDispatcher(() => method.SyncInvoke(cut.Instance))),
                 "sync twin: " + noNewCall);
             AssertObserved(harness, cut, scope, method, syncCall, syncResult);
         }

--- a/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
@@ -203,6 +203,14 @@ public abstract class InteropHarness
     /// </summary>
     public abstract IReadOnlyList<int> DataItemInsertions(string containerId, int expected);
 
+    /// <summary>
+    /// A short account of what the instance has transmitted, to report alongside an expected
+    /// transmission that never showed up. Absence on its own is ambiguous: a message that was never
+    /// queued reads exactly like one that was queued and never flushed, and only the second is a
+    /// timing problem. "Sent nothing at all" separates them.
+    /// </summary>
+    public abstract string DescribeTraffic(string containerId);
+
     public IEnumerable<InteropMethodCall> CallsOf(string methodName, string? containerId = null) =>
         MethodCalls.Where(c => c.MethodName == methodName && (containerId is null || c.ContainerId == containerId));
 

--- a/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
@@ -98,6 +98,34 @@ public sealed class InteropReturn
 /// </summary>
 public abstract class InteropHarness
 {
+    private readonly Func<Dispatcher> _dispatcher;
+
+    /// <param name="dispatcher">
+    /// Resolves the renderer's dispatcher. Taken as a required argument rather than set afterwards
+    /// so a harness cannot exist without one, and resolved on use rather than up front because the
+    /// harness is built while the test's services are still being configured - asking for the
+    /// renderer that early settles the container.
+    /// </param>
+    protected InteropHarness(Func<Dispatcher> dispatcher) =>
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+
+    /// <summary>
+    /// Runs <paramref name="work"/> on the renderer's dispatcher, where Blazor delivers real
+    /// JS-to-.NET calls and application code invokes component APIs. Anything that makes a component
+    /// transmit belongs here: off the dispatcher the send races the renderer's own flush, and bUnit
+    /// records both on one unsynchronized list, so a raced message can be lost outright.
+    /// </summary>
+    public void OnDispatcher(Action work) =>
+        _dispatcher().InvokeAsync(work).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// <inheritdoc cref="OnDispatcher(Action)" path="/summary"/>
+    /// Hands back a still-running task instead of awaiting it on the dispatcher, which would hold
+    /// the dispatcher until it completes and deadlock a deferred return needing it to get there.
+    /// An interop call transmits before it yields, so the send still happens here.
+    /// </summary>
+    public T OnDispatcher<T>(Func<T> work) => _dispatcher().InvokeAsync(work).GetAwaiter().GetResult();
+
     /// <summary>The service instance components resolve via DI.</summary>
     public abstract IIgniteUIBlazor Service { get; }
 

--- a/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/InteropHarness.cs
@@ -193,6 +193,16 @@ public abstract class InteropHarness
     /// </summary>
     public abstract void ClearObserved();
 
+    /// <summary>
+    /// The positions of the item insertions transmitted for the instance's bound data, in the order
+    /// the client received them. Transmission is asynchronous and nothing observable says it has
+    /// finished, so <paramref name="expected"/> - what the caller is waiting for - is what the wait
+    /// is pinned to. Everything transmitted comes back, so both a shortfall and an overshoot are
+    /// returned to be asserted on rather than hidden. How an insertion is spelled on the wire is
+    /// implementation-specific; that every one arrives exactly once, in order, is not.
+    /// </summary>
+    public abstract IReadOnlyList<int> DataItemInsertions(string containerId, int expected);
+
     public IEnumerable<InteropMethodCall> CallsOf(string methodName, string? containerId = null) =>
         MethodCalls.Where(c => c.MethodName == methodName && (containerId is null || c.ContainerId == containerId));
 

--- a/tests/IgniteUI.Blazor.Tests/Interop/InteropHarnessRegistry.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/InteropHarnessRegistry.cs
@@ -12,15 +12,18 @@ namespace IgniteUI.Blazor.Tests.Interop;
 /// </summary>
 public static class InteropHarnessRegistry
 {
-    private static readonly Dictionary<Type, Func<BunitJSInterop, InteropHarness>> Overrides = [];
+    private static readonly Dictionary<Type, HarnessFactory> Overrides = [];
 
-    public static void Register<TComponent>(Func<BunitJSInterop, InteropHarness> factory)
+    /// <summary>Builds a harness from the test's JS interop and its renderer's dispatcher.</summary>
+    public delegate InteropHarness HarnessFactory(BunitJSInterop jsInterop, Func<Dispatcher> dispatcher);
+
+    public static void Register<TComponent>(HarnessFactory factory)
         where TComponent : IComponent
         => Overrides[typeof(TComponent)] = factory;
 
-    public static InteropHarness CreateDefault(BunitJSInterop jsInterop) =>
-        new RendererMessageInteropHarness(jsInterop);
+    public static InteropHarness CreateDefault(BunitJSInterop jsInterop, Func<Dispatcher> dispatcher) =>
+        new RendererMessageInteropHarness(jsInterop, dispatcher);
 
-    internal static Func<BunitJSInterop, InteropHarness>? OverrideFor(Type componentType) =>
+    internal static HarnessFactory? OverrideFor(Type componentType) =>
         Overrides.TryGetValue(componentType, out var factory) ? factory : null;
 }

--- a/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
@@ -367,6 +367,30 @@ public sealed class RendererMessageInteropHarness : InteropHarness
                 && m.Message.GetProperty("type").GetString() == "refNotifyInsertItem")
             .Select(m => m.Message.GetProperty("index").GetInt32())];
 
+    public override string DescribeTraffic(string containerId)
+    {
+        var messages = SettledMessagesFor(containerId);
+        if (messages.Count == 0)
+        {
+            return "the instance sent nothing at all";
+        }
+        // Oldest first reads better in a failure, and a cap keeps a data-heavy instance from
+        // burying the message it is attached to.
+        var kinds = messages.AsEnumerable().Reverse().Take(12).Select(m => m.Message.GetProperty("type").GetString() switch
+        {
+            "refChanged" => "refChanged " + Named(m.Message, "refName"),
+            "invokeMethod" => "invokeMethod " + Named(m.Message, "methodName"),
+            var type => type ?? "?",
+        });
+        var listed = string.Join(", ", kinds);
+        return messages.Count > 12
+            ? $"it sent {messages.Count} messages: {listed}, ..."
+            : $"it sent {messages.Count} messages: {listed}";
+    }
+
+    private static string Named(JsonElement message, string property) =>
+        message.TryGetProperty(property, out var name) ? name.GetString() ?? "?" : "?";
+
     private int SendCountFor(string containerId) =>
         SnapshotInvocations().Count(i =>
             i.Identifier == SendMessage && i.Arguments.Count > 0 && i.Arguments[0] as string == containerId);

--- a/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
@@ -29,8 +29,8 @@ public sealed class RendererMessageInteropHarness : InteropHarness
     /// Default: forces the JSON data-source channel (as on Blazor Server), keeping data
     /// transfers observable as refChanged messages.
     /// </summary>
-    public RendererMessageInteropHarness(BunitJSInterop js)
-        : this(js, forceJsonDataMarshalling: true)
+    public RendererMessageInteropHarness(BunitJSInterop js, Func<Dispatcher> dispatcher)
+        : this(js, dispatcher, forceJsonDataMarshalling: true)
     {
     }
 
@@ -41,7 +41,8 @@ public sealed class RendererMessageInteropHarness : InteropHarness
     /// DataSourceManager picks UnmarshalledDataSource and the column messages are
     /// recorded in <see cref="UnmarshalledColumnMessages"/> instead of crossing to JS.
     /// </summary>
-    public RendererMessageInteropHarness(BunitJSInterop js, bool forceJsonDataMarshalling)
+    public RendererMessageInteropHarness(BunitJSInterop js, Func<Dispatcher> dispatcher, bool forceJsonDataMarshalling)
+        : base(dispatcher)
     {
         _js = js;
         var runtime = forceJsonDataMarshalling
@@ -150,7 +151,8 @@ public sealed class RendererMessageInteropHarness : InteropHarness
         _js.SetupVoid("igWaitForLoaded", _ => true).SetVoidResult();
     }
 
-    public override void MakeReady() => _service.WebCallback.OnReady();
+    // The JS-to-.NET entries below run on the dispatcher, where Blazor delivers the real ones.
+    public override void MakeReady() => OnDispatcher(_service.WebCallback.OnReady);
 
     public override string ContainerIdOf(IRenderedComponent<IComponent> cut) =>
         cut.Find("[data-ig-id]").GetAttribute("data-ig-id")
@@ -232,11 +234,11 @@ public sealed class RendererMessageInteropHarness : InteropHarness
     public override void RaiseEvent(string containerId, string eventName, string argsJson = "{}", string targetName = "mainControl")
     {
         var payload = $$"""{"sender": {"refType": "name", "id": "{{targetName}}"}, "args": {{argsJson}}}""";
-        _service.WebCallback.OnRaiseEvent(containerId, targetName, eventName, payload);
+        OnDispatcher(() => _service.WebCallback.OnRaiseEvent(containerId, targetName, eventName, payload));
     }
 
     public override void CompleteDeferred(InteropMethodCall call, InteropReturn result) =>
-        _service.WebCallback.OnInvokeReturn(call.ContainerId, call.InvokeId, ToResultPayload(result));
+        OnDispatcher(() => _service.WebCallback.OnInvokeReturn(call.ContainerId, call.InvokeId, ToResultPayload(result)));
 
     public override JsonElement? FindPropertyUpdate(string containerId, string wireName)
     {

--- a/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
+++ b/tests/IgniteUI.Blazor.Tests/Interop/RendererMessageInteropHarness.cs
@@ -252,8 +252,9 @@ public sealed class RendererMessageInteropHarness : InteropHarness
         // can starve the queue-flush continuations well past their usual few milliseconds.
         for (var attempt = 0; attempt < 80; attempt++)
         {
-            // One snapshot+parse per attempt, scanned newest-first.
-            var messages = Messages().Where(m => m.ContainerId == containerId).Reverse().ToList();
+            // One snapshot+parse per attempt, newest-first, taken once the instance stops
+            // transmitting: mid-flush the newest update recorded is not yet the newest one sent.
+            var messages = SettledMessagesFor(containerId);
 
             string? dataRefId = null;
             foreach (var (_, message, _) in messages)
@@ -291,6 +292,84 @@ public sealed class RendererMessageInteropHarness : InteropHarness
         }
         return null;
     }
+
+    /// <summary>
+    /// This instance's traffic, newest first, taken once it stops transmitting. A flush hands its
+    /// messages to JS one at a time, so a snapshot can land between two and show an update the next
+    /// one supersedes - how a script ref read back as the event registration sharing its ref name.
+    /// Only this instance's traffic can supersede it, so other components never hold it up.
+    /// </summary>
+    private List<(string ContainerId, JsonElement Message, IReadOnlyList<ElementReference> Elements)> SettledMessagesFor(string containerId)
+    {
+        // Bounded, so a component that never stops transmitting cannot hang the test; the caller
+        // has its own budget for concluding absence.
+        for (var attempt = 0; attempt < 40; attempt++)
+        {
+            // Barrier first, and it is what actually settles a flush already sending: it queues
+            // behind that flush's own dispatcher work item, so the flush has finished by the time
+            // this returns - however long it was preempted between two sends, which is the part no
+            // lull can promise. Going first also means the counts below read a record nothing is
+            // appending to. A flush still waiting on the thread-pool hop that posts it is visible
+            // to neither, so a caller that knows what it is waiting for should say so instead - see
+            // DataItemInsertions.
+            OnDispatcher(() => { });
+            var sends = SendCountFor(containerId);
+            Thread.Sleep(1);
+            if (SendCountFor(containerId) == sends)
+            {
+                break;
+            }
+        }
+        return Messages().Where(m => m.ContainerId == containerId).Reverse().ToList();
+    }
+
+    /// <summary>On this stack an insertion is a refNotifyInsertItem message carrying its index.</summary>
+    public override IReadOnlyList<int> DataItemInsertions(string containerId, int expected)
+    {
+        // Reaching the count asked for is what establishes that transmission happened at all: a
+        // lull cannot, because a flush still waiting for its thread-pool hop looks exactly like one
+        // with nothing left to send. Past that point the wait inverts - hold on until the count
+        // stops moving and the dispatcher is drained - so traffic that *overshoots*, a duplicated
+        // notification say, is returned to be asserted on rather than cut off at the expected count
+        // and silently passing. Bounded either way, and answering short is the point: a shortfall is
+        // the failure worth reporting, not something to hide behind a timeout. Reparsed only when
+        // the traffic moved, so stopping short costs one parse rather than one per attempt.
+        var counted = -1;
+        var steady = 0;
+        List<int> seen = [];
+        for (var attempt = 0; attempt < 400; attempt++)
+        {
+            var sends = SendCountFor(containerId);
+            if (sends != counted)
+            {
+                counted = sends;
+                seen = InsertionsFor(containerId);
+                steady = 0;
+            }
+            else if (seen.Count >= expected && ++steady >= 3)
+            {
+                // Whatever was already sending has landed by now, so a count still unmoved is done.
+                OnDispatcher(() => { });
+                if (SendCountFor(containerId) == counted)
+                {
+                    break;
+                }
+                steady = 0;
+            }
+            Thread.Sleep(1);
+        }
+        return seen;
+    }
+
+    private List<int> InsertionsFor(string containerId) =>
+        [.. Messages()
+            .Where(m => m.ContainerId == containerId
+                && m.Message.GetProperty("type").GetString() == "refNotifyInsertItem")
+            .Select(m => m.Message.GetProperty("index").GetInt32())];
+
+    private int SendCountFor(string containerId) =>
+        SnapshotInvocations().Count(i =>
+            i.Identifier == SendMessage && i.Arguments.Count > 0 && i.Arguments[0] as string == containerId);
 
     /// <summary>
     /// refChanged values embed their payload as prefixed strings
@@ -377,8 +456,10 @@ public sealed class RendererMessageInteropHarness : InteropHarness
     }
 
     /// <summary>
-    /// Components flush queued messages from background continuations, so bUnit's
-    /// append-only invocation record can grow while we read it. Snapshot with retry.
+    /// Components flush queued messages from background continuations, so bUnit's append-only
+    /// invocation record can grow while we read it - and the longer the record, the longer each
+    /// attempt is exposed, so a component mid-flush can beat several in a row. Yielding is enough
+    /// once the flush ends; a real pause is what gets us there.
     /// </summary>
     private IReadOnlyList<JSRuntimeInvocation> SnapshotInvocations()
     {
@@ -388,9 +469,16 @@ public sealed class RendererMessageInteropHarness : InteropHarness
             {
                 return [.. _js.Invocations];
             }
-            catch (InvalidOperationException) when (attempt < 10)
+            catch (InvalidOperationException) when (attempt < 200)
             {
-                Thread.Yield();
+                if (attempt < 10)
+                {
+                    Thread.Yield();
+                }
+                else
+                {
+                    Thread.Sleep(1);
+                }
             }
         }
     }

--- a/tests/IgniteUI.Blazor.Tests/InteropReadinessTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropReadinessTests.cs
@@ -15,7 +15,7 @@ public class InteropReadinessTests : BlazorComponentTestBase
     {
         var cut = Render<IgbBanner>();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => cut.Instance.ShowAsync());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Interop.OnDispatcher(cut.Instance.ShowAsync));
         Assert.Null(Interop.FindCall("show"));
     }
 
@@ -26,7 +26,7 @@ public class InteropReadinessTests : BlazorComponentTestBase
         Interop.SetupMethodResult("show", InteropReturn.Bool(true));
         var cut = Render<IgbBanner>();
 
-        var shown = await cut.Instance.ShowAsync();
+        var shown = await Interop.OnDispatcher(cut.Instance.ShowAsync);
 
         Assert.True(shown);
         Assert.NotNull(Interop.FindCall("show", Interop.ContainerIdOf(cut)));
@@ -39,7 +39,7 @@ public class InteropReadinessTests : BlazorComponentTestBase
         Interop.SetupMethodResult("hide", InteropReturn.Bool(false));
 
         Interop.MakeReady();
-        var hidden = await cut.Instance.HideAsync();
+        var hidden = await Interop.OnDispatcher(cut.Instance.HideAsync);
 
         Assert.False(hidden);
         Assert.NotNull(Interop.FindCall("hide", Interop.ContainerIdOf(cut)));

--- a/tests/IgniteUI.Blazor.Tests/InteropThreadingTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropThreadingTests.cs
@@ -13,24 +13,30 @@ public class InteropThreadingTests : BlazorComponentTestBase
 {
     private sealed record Row(string Name);
 
+    private const int Rows = 20000;
+
     [Fact]
     public async Task BoundCollection_FilledFromABackgroundTask_DoesNotTearTheMessageQueue()
     {
         Interop.PrimeReady();
         var data = new ObservableCollection<Row>();
-        Render<IgbCombo<Row>>(ps => ps.Add(c => c.Data, data));
+        var cut = Render<IgbCombo<Row>>(ps => ps.Add(c => c.Data, data));
 
         // One writer, so the collection itself is never used concurrently: only the component's
         // queue sees two threads - these change notifications and the renderer's flush. Filling
         // bound data from a background load is ordinary, and it used to throw out of the queue.
         await Task.Run(() =>
         {
-            for (var i = 0; i < 20000; i++)
+            for (var i = 0; i < Rows; i++)
             {
                 data.Add(new Row($"row-{i}"));
             }
         });
 
-        Assert.Equal(20000, data.Count);
+        // Asserted on what the client received, not on the collection we just filled: tearing the
+        // queue drops and duplicates notifications as readily as it throws, and the producer's own
+        // count shows neither. Only the renderer drains here, so this says nothing about two
+        // drains interleaving - that is what holding the lock across the whole drain is for.
+        Assert.Equal(Enumerable.Range(0, Rows), Interop.DataItemInsertions(Interop.ContainerIdOf(cut), Rows));
     }
 }

--- a/tests/IgniteUI.Blazor.Tests/InteropThreadingTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/InteropThreadingTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.ObjectModel;
+using Bunit;
+using IgniteUI.Blazor.Controls;
+
+namespace IgniteUI.Blazor.Tests;
+
+/// <summary>
+/// Thread-safety of the queue a component sends its interop through. A component reaches that
+/// queue from wherever it is driven from, and two paths collide without any misuse: change
+/// notifications from bound data run on whichever thread mutated it, while the renderer flushes.
+/// </summary>
+public class InteropThreadingTests : BlazorComponentTestBase
+{
+    private sealed record Row(string Name);
+
+    [Fact]
+    public async Task BoundCollection_FilledFromABackgroundTask_DoesNotTearTheMessageQueue()
+    {
+        Interop.PrimeReady();
+        var data = new ObservableCollection<Row>();
+        Render<IgbCombo<Row>>(ps => ps.Add(c => c.Data, data));
+
+        // One writer, so the collection itself is never used concurrently: only the component's
+        // queue sees two threads - these change notifications and the renderer's flush. Filling
+        // bound data from a background load is ordinary, and it used to throw out of the queue.
+        await Task.Run(() =>
+        {
+            for (var i = 0; i < 20000; i++)
+            {
+                data.Add(new Row($"row-{i}"));
+            }
+        });
+
+        Assert.Equal(20000, data.Count);
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/MethodInteropTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/MethodInteropTests.cs
@@ -20,7 +20,7 @@ public class MethodInteropTests : BlazorComponentTestBase
         Interop.SetupMethodResult("toggle", InteropReturn.Deferred);
         var cut = Render<IgbBanner>();
 
-        var pending = cut.Instance.ToggleAsync();
+        var pending = Interop.OnDispatcher(cut.Instance.ToggleAsync);
         Assert.False(pending.IsCompleted);
 
         Interop.CompleteDeferred(Interop.RequireCall("toggle"), InteropReturn.Bool(true));

--- a/tests/IgniteUI.Blazor.Tests/ScriptPropTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ScriptPropTests.cs
@@ -86,7 +86,7 @@ public class ScriptPropTests : BlazorComponentTestBase
 
             // Clear:
             interop.ClearObserved();
-            prop.SetValue(cut.Instance, null);
+            interop.OnDispatcher(() => prop.SetValue(cut.Instance, null));
             var cleared = interop.FindPropertyUpdate(interop.ContainerIdOf(cut), wireName);
             if (cleared is null)
             {

--- a/tests/IgniteUI.Blazor.Tests/ScriptPropTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/ScriptPropTests.cs
@@ -80,7 +80,8 @@ public class ScriptPropTests : BlazorComponentTestBase
             if (actual is null)
             {
                 throw new Xunit.Sdk.XunitException(
-                    $"{componentType.Name}.{prop.Name}: no script-ref transmission observed for \"{wireName}\"");
+                    $"{componentType.Name}.{prop.Name}: no script-ref transmission observed for \"{wireName}\" — " +
+                    interop.DescribeTraffic(interop.ContainerIdOf(cut)));
             }
             Assert.Equal(scriptName, actual.Value.GetString());
 

--- a/tests/IgniteUI.Blazor.Tests/ThreadPoolSetup.cs
+++ b/tests/IgniteUI.Blazor.Tests/ThreadPoolSetup.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace IgniteUI.Blazor.Tests;
+
+internal static class ThreadPoolSetup
+{
+    /// <summary>
+    /// Components flush their interop queue from a thread-pool work item, while the tests observing
+    /// that traffic block a thread-pool thread waiting for it - xUnit runs test cases on the pool.
+    /// With the default floor of one thread per core, the collections running at once can hold every
+    /// readily available thread, leaving the flush waiting on the pool's slow injection of new ones,
+    /// and CI compounds it by running one process per target framework at the same time. Raising the
+    /// floor keeps threads available for the flush, so a wait resolves in milliseconds instead of
+    /// running out its budget and reporting traffic that was queued but never sent.
+    /// </summary>
+    [ModuleInitializer]
+    [SuppressMessage("Usage", "CA2255:The 'ModuleInitializer' attribute should not be used in libraries",
+        Justification = "Not a library: this is the test assembly configuring its own run, and the " +
+            "floor has to be raised before the first test takes a pool thread.")]
+    internal static void RaiseMinimumThreads()
+    {
+        ThreadPool.GetMinThreads(out var workers, out var completionPorts);
+        ThreadPool.SetMinThreads(Math.Max(workers, Environment.ProcessorCount * 8), completionPorts);
+    }
+}

--- a/tests/IgniteUI.Blazor.Tests/UnmarshalledDataChannelTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/UnmarshalledDataChannelTests.cs
@@ -21,7 +21,7 @@ public class UnmarshalledDataChannelTests : BunitContext
     public UnmarshalledDataChannelTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        _interop = new RendererMessageInteropHarness(JSInterop, forceJsonDataMarshalling: false);
+        _interop = new RendererMessageInteropHarness(JSInterop, () => Renderer.Dispatcher, forceJsonDataMarshalling: false);
         _interop.ConfigureServices(Services);
     }
 


### PR DESCRIPTION
Closes #329

Four intermittent failures in `IgniteUI.Blazor.Tests`, four different causes: three about interop messages crossing threads they should not, one about the flush never getting a thread at all. Each cause is fixed in its own commit. The first is a genuine product bug that reproduces from ordinary application code, with no test involvement at all.

## The failures

| Failure | Symptom |
|---|---|
| `SnackbarTests.Methods_FollowContract` ([run](https://github.com/IgniteUI/igniteui-blazor/actions/runs/32128811526/job/95712257701#step:12:2950)) | `InvalidOperationException: The LinkedList is empty` out of `BaseRendererControl.Update()` |
| `ScriptPropTests.ScriptProps_TransmitScriptRefs(IgbTabs)` ([run](https://github.com/IgniteUI/igniteui-blazor/actions/runs/32281478640/job/96161043566?pr=351#step:12:1524), [run](https://github.com/IgniteUI/igniteui-blazor/actions/runs/30985554644/job/92239357902?pr=288#step:12:427)) | `Expected: "handleChangeScript"` / `Actual: "Change"` |
| `CheckboxTests.Binds_FollowContract` ([#329](https://github.com/IgniteUI/igniteui-blazor/issues/329)) | `binding transmitted no "Change" event registration` |
| `InputTests` and `RadioTests` `Events_FollowContract` ([run](https://github.com/IgniteUI/igniteui-blazor/actions/runs/33516078612/job/100157469244#step:12:180)) | `no event-handler registration transmission was observed` |

All intermittent, all green on re-run.

## How component messaging works

Every `BaseRendererControl` owns a `LinkedList<RendererMessage> _messageQueue` and reaches it through two different paths.

**The deferred path.** A property setter marks state dirty, which appends a message and asks for a flush:

```
setter → MarkPropDirty → MarkContentDirty → SendDescriptionMessage → _messageQueue.AddLast + QueueUpdate
OnRefChanged                              → SendMessage            → _messageQueue.AddLast + QueueUpdate
```

`QueueUpdate` deliberately does not flush inline:

```csharp
if (!_updateQueued && _ready)
{
    _updateQueued = true;
    Task.Delay(0).ContinueWith((t) => InvokeAsync(Update));
}
```

The deferral is load-bearing: `Update` serialises the component, and doing that inline from a setter would serialise a half-applied component and emit one description per dirty property instead of one per batch. So the flush hops onto the thread pool, then posts back to the renderer's dispatcher, where it drains FIFO.

**The immediate path.** An API call cannot be deferred — the caller is awaiting a return value — so it flushes *synchronously, on the calling thread*, to stay ordered behind the queue:

```csharp
private async Task<object> SendMessageImmediate(RendererMessage m)
{
    Update();                       // ← drains the queue on the caller's thread
    return await SendJsonImmediate(m);
}
```

Both paths are correct alone. Together, the queue is drained from two places and `Update` is reachable from any thread a component is driven from. On the dispatcher that is serialised; off it two flushes run at once on an unsynchronised `LinkedList`:

- `Count > 0` then `RemoveFirst()` on an emptied list → `InvalidOperationException: The LinkedList is empty`.
- `AddLast` interleaved with `RemoveFirst` → torn nodes: `NullReferenceException`, or a message silently dropped.
- Both drains dequeue, then race to `igSendMessage` → the client receives two messages in the wrong order. Ref updates apply last-write-wins, so an inverted pair silently keeps the *older* value.

### The four causes

**1. The queue is not thread-safe** *(product)*. Reachable from application code — see below. This killed `SnackbarTests`: the contract test called `ShowAsync()` from the xUnit thread, so the inline drain ran concurrently with the renderer's.

**2. The harness read a partially flushed queue** *(test)*. `IgbTabs.ChangeScript` and the `Change` event registration ride the *same* ref name (`<containerId>/Change`), because `IgbTabs`' constructor installs its own handler via `EnsureChangeHandled()` before the parameter is applied, so `FindPropertyUpdate` relies on "newest wins". But a flush hands its messages to JS one at a time, and the recorded traffic showed the wire order was always *correct* — the scan landed between the two sends, saw only the event registration, and returned it without retrying, because it had found *something*.

**3. bUnit's invocation recorder is not thread-safe** *(test)*. This explains `CheckboxTests`, where the message was never observed even after ~2s of retrying. Two threads calling `InvokeAsync` on bUnit's JSInterop — the number a single off-dispatcher API call creates — fail 4 runs out of 4 with `An item with the same key has already been added` and `Operations that change non-concurrent collections must have exclusive access`, an unsynchronised `List<T>.Add`. So a raced send is not merely late; it can be **lost permanently**, which no retry budget recovers.

**4. The flush needs a thread-pool thread, and the tests waiting for it hold those threads** *(test)*. This explains the `Events_FollowContract` pair — two failures in [one run](https://github.com/IgniteUI/igniteui-blazor/actions/runs/33516078612/job/100157469244#step:12:180), in two different per-framework processes, both after exactly the two seconds a read spends before concluding absence. `QueueUpdate` hands the flush to the pool, and a test waiting for that traffic blocks a pool thread while it waits, because xUnit runs test cases on pool threads. The pool's floor is one thread per core and xUnit's parallelism is also one collection per core, so on a four-core runner four waiting reads can hold every thread the pool gives out without throttling, leaving the flush on its injection of new ones — a thread or two per second. The floor is per process, so the three per-framework processes widen the window by competing for cores rather than for each other's threads. Nothing races here: the messages are queued and never sent inside the budget.

## The product bug reproduces without tests

The library has exactly one off-dispatcher hop, and it immediately re-enters the dispatcher. But a component reaches its queue from wherever it is *driven* from, and `JsonDataSource.OnCollectionChanged` runs synchronously on whichever thread mutated the bound collection, straight into `SendMessage` → `AddLast`, with no dispatcher hop.

So this is enough — bind a collection, fill it from a background load:

```csharp
var data = new ObservableCollection<Row>();
Render<IgbCombo<Row>>(ps => ps.Add(c => c.Data, data));
await Task.Run(() => { for (var i = 0; i < 20000; i++) data.Add(new Row($"row-{i}")); });
```

A single writer, so the `ObservableCollection` is never used concurrently; no component API called off the dispatcher; no test-only threading. The only thing seeing two threads is the component's own queue: this task's change notifications, and the renderer's flush.

**Without the fix this crashes 6 times out of 6** (`NullReferenceException` inside `LinkedList.AddLast`); with it, clean. Kept as the regression test, asserting the *transmitted* insertions rather than the collection it just filled — tearing the queue drops notifications as readily as it throws, and the producer's own count shows neither.

## The fixes

**1. `fix: guard the renderer message queue against concurrent access`**

One reentrant lock over `_messageQueue` and the `_updateQueued` flag that decides when it is flushed, covering the *whole* drain rather than just the dequeue, and the start of an immediate send — so nothing the component sends can interleave with a flush. `_invokeId` also goes `Interlocked`: a plain `++` can hand two calls the same id, which collides in `_methodTasks`.

**2. `test: drive components through the renderer's dispatcher`**

Adds `InteropHarness.OnDispatcher`, makes the dispatcher required, and routes everything that makes a component transmit through it: contract invocations, because application code calls component APIs from event handlers, and the harness's JS-to-.NET entries (`RaiseEvent`, `MakeReady`, `CompleteDeferred`), because that is where Blazor delivers the real ones. The generic overload hands back a still-running task instead of awaiting on the dispatcher, which would hold it until the task completes and deadlock a deferred return needing it to get there.

**3. `test: read interop traffic only once it has settled`**

`FindPropertyUpdate` no longer reads a queue that is still flushing. Nothing observable says a flush has finished: a gap in the traffic looks the same whether the renderer was descheduled mid-flush or has nothing left to send, and the thread-pool hop that posts a flush cannot be seen from outside. So rather than trying to detect completion, the harness waits for what it expects to arrive — it drains the dispatcher before reading, and `DataItemInsertions(containerId, expected)` waits for the count the caller asked for, then until that count stops moving, so both a shortfall and an overshoot come back to be asserted on. Bounded throughout, so a component that never stops transmitting cannot hang a test.

**4. `test: keep the thread pool from starving interop flushes`**

Raises the pool's minimum thread count for the test assembly, so a blocking wait cannot hold the thread that the flush it waits for needs. At identical pressure — 128 pool threads blocked — a registration the default floor never delivers within two seconds arrives in 47ms. Absence is also ambiguous on its own, a message never queued reading exactly like one queued and never flushed, so the failures reporting one now say what the instance did transmit; "the instance sent nothing at all" is the giveaway for this cause.

## Moving to a separate PR

Review of the queue lock turned up two more product races of the same class, in the invocation bookkeeping and at teardown. Both are reachable only from off the dispatcher and neither can produce a test flake, so they are separated in #394 instead.

## Verification

- Repeated clean full-suite runs, plus runs under `DOTNET_PROCESSOR_COUNT=1` with 24 CPU hogs to approximate CI's three concurrent per-TFM processes. Only net10.0 ran locally, so that concurrency is approximated rather than reproduced.
- Each commit builds and passes on its own, so the history bisects. Suite runtime better than halved.

## Notes for review

- **The lock spans `ProcessMessage`** and the start of an immediate send, so `Serialize()` and a JS interop call. Should be safe — per-component, reentrant, and nothing inside waits on another thread (`SendJson` fires `InvokeAsync` without awaiting; the sync path blocks on its own thread) — but it is the most reviewable claim here. The narrower alternative locks only the enqueue/dequeue, which stops the crash and leaves send ordering unguarded.
- `IgbTabs.ChangeScript` sharing a ref name with the internal `Change` registration looks like a real product wrinkle, not a test artifact: whether a user's `ChangeScript` wins depends on ordering against the handler the constructor installs. Out of scope, but worth its own look.
- One residual in `FindPropertyUpdate`: if a flush has not been posted yet the barrier finds nothing to drain, quiet reads as settled, and an update already in the window is returned. No caller reaches it — every read is either against a fresh render, whose candidate messages all leave in one flush, or preceded by `ClearObserved`, so there is no earlier update to go stale. It would also read as a hard failure rather than a flake. Left alone deliberately; closing it would mean waiting on an expected value rather than on quiet.
