### PR TITLE
fix: two behavioral changes/regressions from nullable annotation pass

### DIFF
--- a/src/componentsBase/RuntimeHelper.cs
+++ b/src/componentsBase/RuntimeHelper.cs
@@ -10,7 +10,7 @@ namespace IgniteUI.Blazor.Controls
 #if NET5_0
         private IJSUnmarshalledRuntime? _unmarshalledRuntime;
 #else
-        private Func<IJSInProcessRuntime, string, string, int, UnmarshalledColumn?[]?, string>? _callSendUnmarshalledColumnMessage;
+        private Func<IJSInProcessRuntime, string, string, int, UnmarshalledColumn[]?, string>? _callSendUnmarshalledColumnMessage;
         private Func<IJSInProcessRuntime, string, string, string, string>? _callSendUnmarshalledColumnDataIntentMessage;
 #endif
         private IJSInProcessRuntime? _inprocRuntime;
@@ -57,7 +57,7 @@ namespace IgniteUI.Blazor.Controls
                         var meth = target.MakeGenericMethod(new Type[] {
                             typeof(string),
                             typeof(int),
-                            typeof(UnmarshalledColumn?[]),
+                            typeof(UnmarshalledColumn[]),
                             typeof(string)
                             });
 
@@ -65,14 +65,14 @@ namespace IgniteUI.Blazor.Controls
                         var methodNameParam = Expression.Parameter(typeof(string), "methodName");
                         var refNameParam = Expression.Parameter(typeof(string), "refName");
                         var indexParam = Expression.Parameter(typeof(int), "index");
-                        var columnsParam = Expression.Parameter(typeof(UnmarshalledColumn?[]), "columns");
+                        var columnsParam = Expression.Parameter(typeof(UnmarshalledColumn[]), "columns");
 
                         var wsRuntime = Expression.Convert(jsRuntimeParam, inprocRuntime.GetType());
                         var call = Expression.Call(wsRuntime, meth, methodNameParam, refNameParam,
                         indexParam, columnsParam);
 
                         _callSendUnmarshalledColumnMessage =
-                        (Func<IJSInProcessRuntime, string, string, int, UnmarshalledColumn?[]?, string>)Expression.Lambda(
+                        (Func<IJSInProcessRuntime, string, string, int, UnmarshalledColumn[]?, string>)Expression.Lambda(
                             call, jsRuntimeParam, methodNameParam, refNameParam, indexParam, columnsParam).Compile();
                     }
 
@@ -105,12 +105,12 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        public unsafe string? SendUnmarshalledColumnMessage(string methodName, string refName, int index, UnmarshalledColumn?[]? columns)
+        public unsafe string? SendUnmarshalledColumnMessage(string methodName, string refName, int index, UnmarshalledColumn[]? columns)
         {
 #if NET5_0
             if (_unmarshalledRuntime != null)
             {
-                return _unmarshalledRuntime.InvokeUnmarshalled<string, int, UnmarshalledColumn?[]?, string>(methodName, refName, index, columns);
+                return _unmarshalledRuntime.InvokeUnmarshalled<string, int, UnmarshalledColumn[]?, string>(methodName, refName, index, columns);
             }
 #else
             if (_callSendUnmarshalledColumnMessage != null)

--- a/src/componentsBase/UnmarshalledDataSource.cs
+++ b/src/componentsBase/UnmarshalledDataSource.cs
@@ -26,7 +26,7 @@ namespace IgniteUI.Blazor.Controls
         public string?[]? StringValues { get; set; }
         public bool[]? NullValues { get; set; }
         public Guid[]? IDValues { get; set; }
-        public UnmarshalledColumn?[]?[]? SubDataSourceValues;
+        public UnmarshalledColumn[]?[]? SubDataSourceValues;
 
         public UnmarshalledColumn Column { get; set; }
 
@@ -66,7 +66,7 @@ namespace IgniteUI.Blazor.Controls
         [FieldOffset(40)]
         public string[] StringValues;
         [FieldOffset(40)]
-        public UnmarshalledColumn?[][]? SubDataSourceValues;
+        public UnmarshalledColumn[]?[]? SubDataSourceValues;
         [FieldOffset(48)]
         public bool[] NullValues;
     }
@@ -145,9 +145,9 @@ namespace IgniteUI.Blazor.Controls
         {
             //Console.WriteLine("adjusting capacity, oldValue: " + oldValue + ", newValue: " + newValue);
             DateTime start = DateTime.Now;
-            if (columns == null || schema == null)
+            if (schema == null)
             {
-                return null;
+                return columns;
             }
             if (schema.IsDataSource)
             {
@@ -728,7 +728,7 @@ namespace IgniteUI.Blazor.Controls
 
                         if (column.IsSubDataSource)
                         {
-                            UnmarshalledColumn?[]? cols = null;
+                            UnmarshalledColumn[]? cols = null;
                             if (objVal != null)
                             {
                                 var id = _idGetter!(item!);
@@ -814,15 +814,15 @@ namespace IgniteUI.Blazor.Controls
 
                         if (column.IsSubDataSource)
                         {
-                            UnmarshalledColumn?[]? cols = null;
+                            UnmarshalledColumn[]? cols = null;
                             if (objVal != null)
                             {
                                 var sub = (UnmarshalledDataSource)UnmarshalledDataSource.CreateWithSchema(objVal, column.SubSchema, _manager, _helper)!;
                                 var subcols = sub!.GetColumns("");
 
                                 UnmarshalledColumn primcol = new UnmarshalledColumn();
-                                primcol.ActualCount = subcols![0].GetValueOrDefault().ActualCount;
-                                primcol.DataSourceID = subcols[0].GetValueOrDefault().DataSourceID;
+                                primcol.ActualCount = subcols[0].ActualCount;
+                                primcol.DataSourceID = subcols[0].DataSourceID;
                                 primcol.PropertyPath = "___primitiveVal";
                                 primcol.Type = GetArrayType(newColumn.Type);
                                 int i = 0;
@@ -876,7 +876,7 @@ namespace IgniteUI.Blazor.Controls
                                         break;
                                 }
 
-                                cols = new UnmarshalledColumn?[subcols.Length + 1];
+                                cols = new UnmarshalledColumn[subcols.Length + 1];
                                 for (i = 0; i < subcols.Length; i++)
                                 {
                                     cols[i] = subcols[i];
@@ -1073,7 +1073,7 @@ namespace IgniteUI.Blazor.Controls
 
                         if (column.IsSubDataSource)
                         {
-                            UnmarshalledColumn?[]? cols = null;
+                            UnmarshalledColumn[]? cols = null;
                             if (objVal != null)
                             {
                                 var sub = (UnmarshalledDataSource)UnmarshalledDataSource.CreateWithSchema(objVal, column.SubSchema, _manager, _helper)!;
@@ -1121,15 +1121,15 @@ namespace IgniteUI.Blazor.Controls
 
                         if (column.IsSubDataSource)
                         {
-                            UnmarshalledColumn?[]? cols = null;
+                            UnmarshalledColumn[]? cols = null;
                             if (objVal != null)
                             {
                                 var sub = (UnmarshalledDataSource?)UnmarshalledDataSource.CreateWithSchema(objVal, column.SubSchema, _manager, _helper);
                                 var subcols = sub!.GetColumns("");
 
                                 UnmarshalledColumn primcol = new UnmarshalledColumn();
-                                primcol.ActualCount = subcols![0].GetValueOrDefault().ActualCount;
-                                primcol.DataSourceID = subcols[0].GetValueOrDefault().DataSourceID;
+                                primcol.ActualCount = subcols[0].ActualCount;
+                                primcol.DataSourceID = subcols[0].DataSourceID;
                                 primcol.PropertyPath = "___primitiveVal";
                                 primcol.Type = GetArrayType(newColumn.Type);
                                 int i = 0;
@@ -1183,7 +1183,7 @@ namespace IgniteUI.Blazor.Controls
                                         break;
                                 }
 
-                                cols = new UnmarshalledColumn?[subcols.Length + 1];
+                                cols = new UnmarshalledColumn[subcols.Length + 1];
                                 for (i = 0; i < subcols.Length; i++)
                                 {
                                     cols[i] = subcols[i];
@@ -1555,7 +1555,7 @@ namespace IgniteUI.Blazor.Controls
             return JSDataSourceSchemaType.ObjectValue;
         }
 
-        private void GetColumns(string refName, UnmarshalledColumnData?[]? columns, List<UnmarshalledColumn?>? l)
+        private void GetColumns(string refName, UnmarshalledColumnData?[]? columns, List<UnmarshalledColumn> l)
         {
             List<UnmarshalledColumnData?[]> toDrill = new List<UnmarshalledColumnData?[]>();
 
@@ -1582,7 +1582,7 @@ namespace IgniteUI.Blazor.Controls
                         col.DataSourceID = refName;
                         col.ActualCount = _size;
 
-                        l!.Add(col);
+                        l.Add(col);
                     }
                 }
             }
@@ -1592,9 +1592,9 @@ namespace IgniteUI.Blazor.Controls
             }
         }
 
-        internal UnmarshalledColumn?[]? GetColumns(string refName)
+        internal UnmarshalledColumn[] GetColumns(string refName)
         {
-            var l = new List<UnmarshalledColumn?>();
+            var l = new List<UnmarshalledColumn>();
             GetColumns(refName, _columns, l);
             return l.ToArray();
         }
@@ -1664,7 +1664,7 @@ namespace IgniteUI.Blazor.Controls
                     var existingColumn = column.SubDataSourceValues;
                     if (existingColumn == null || existingColumn.Length != newValue)
                     {
-                        var subColumn = new UnmarshalledColumn?[newValue][];
+                        var subColumn = new UnmarshalledColumn[newValue][];
                         if (existingColumn != null)
                         {
                             Array.Copy(existingColumn, subColumn, _size);


### PR DESCRIPTION
Two changes in the nullable pass weren't annotation-only and broke the unmarshalled (WASM) data path. Neither shows up in the test suite — bUnit never exercises `IJSInProcessRuntime`, so the interop send path is inert there.

## `AdjustCapacity` never allocated columns

The null guard changed from `columns == null && schema == null` to `columns == null || schema == null`. `_columns` starts null and is only ever assigned from this method's return value, so the `||` guard returned null on every call and the allocation branches below it became dead code: no columns were ever built and every `Send*` message shipped an empty set. The early-returns added to the item insert/update/remove helpers masked this silently instead of crashing.

**Fix:** guard only what's dereferenced — `if (schema == null) return columns;`. Identical to pre-nullable behavior in every reachable state; the one divergent case (non-null `columns`, null `schema`) previously threw NRE and is now a no-op.

## `UnmarshalledColumn?[]` changed memory layout, not just annotations

`UnmarshalledColumn` is a struct, so `UnmarshalledColumn?` means `Nullable<UnmarshalledColumn>` — a different runtime type, unlike the annotation-only `?` on reference types. The struct is `[StructLayout(LayoutKind.Explicit, Size = 56)]` and JS reads its arrays from raw WASM memory at fixed offsets; the `Nullable<T>` wrapper adds a per-element header, changing the array stride and shifting every field, so JS would read garbage.

**Fix:** reverted all element types to `UnmarshalledColumn`, moving the `?` onto the array dimensions where nullability was actually intended (inner `SubDataSourceValues` arrays may be null; struct elements can't be, so no warnings return). Applied consistently across `UnmarshalledDataSource.cs` and the matching `RuntimeHelper` signatures and `typeof`s. This also reverts `subcols[0].GetValueOrDefault()` to plain field access, which would otherwise silently substitute a default column.

## Verification

- Build: 0 errors, no compiler warnings in the touched files (no suppressed nullable warnings resurfaced).
- Tests: 964 passed / 0 failed on net8.0, net9.0 and net10.0.

## Follow-ups (not addressed here)

- `AdjustCapacity`'s new `Math.Min` / `?? Array.Empty()` clamping silently skips columns on schema-array length mismatch and would shift field columns into property slots; the old code threw. The field-loop bound also quietly changed from `_schema` to the local `schema` — likely a real fix, but worth its own callout/test.
- The method-wide `#pragma warning disable CS8604` blocks around `CreateColumn` and `AdjustColumnCapacity` can be dropped by making the `Update` delegate take `object?` items (as `Insert` already does) and `CreateColumn`'s `propertyName` a `string?`.
- `ExtractSchemaFromType(Type? itemType)` accepts null but immediately does `itemType!.IsArray`; either make the parameter non-nullable again or add `ArgumentNullException.ThrowIfNull`.