### PR TITLE
fix: unmarshalled nested-field error

### DIFF
--- a/src/componentsBase/JsonDataSourceSchema.cs
+++ b/src/componentsBase/JsonDataSourceSchema.cs
@@ -903,7 +903,7 @@ namespace IgniteUI.Blazor.Controls
             FieldTypes = _buildingFieldsTypes.ToArray();
             FieldDataIntents = _buildingFieldsDataIntents.ToArray();
             FieldGetters = new Func<object, object>[_buildingFields.Count];
-            TypedFieldGetters = new Func<object, object>[_buildingFields.Count];
+            TypedFieldGetters = new Delegate[_buildingFields.Count];
             for (int i = 0; i < _buildingFields.Count; i++)
             {
                 FieldNames[i] = _buildingFields[i].Name;

--- a/tests/IgniteUI.Blazor.Tests/UnmarshalledDataChannelTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/UnmarshalledDataChannelTests.cs
@@ -83,9 +83,7 @@ public class UnmarshalledDataChannelTests : BunitContext
         Assert.Equal(["alpha", "beta", "gamma"], values.StringValues.Take(3));
     }
 
-    [Fact(Skip = "Item types with public primitive-typed fields crash schema creation: JsonDataSourceSchema.Commit " +
-        "stores the typed field getters in a Func<object, object>[] and throws ArrayTypeMismatchException " +
-        "(TypedPropertyGetters uses Delegate[]). Enable once the field getter array type is fixed.")]
+    [Fact]
     public void NestedPublicFields_TransferAsColumns()
     {
         var create = RenderScenario("nested-field-shipments");


### PR DESCRIPTION
## Description
~Additional fix awaiting on #373 to be merged and synced into the target branch to enable skipped tests;~

Items whose nested type has public primitive-typed fields crash schema creation (`JsonDataSourceSchema.Commit` stores typed field getters in a `Func<object, object>[]` → `ArrayTypeMismatchException`; the property arrays already use `Delegate[]`). 

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:
Combo


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**:
 - **Hosting model**: <!-- Blazor Server / WebAssembly / Hybrid / United -->
 - **Browser(s)**:
 - **OS**:

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified

Closes #
