### PR TITLE
docs: Publish the performance targets and measurements document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Published a [performance targets and measurements](docs/performance.md) document recording the enforced bundle size budgets, the runtime targets, and how to reseed a budget. Every release publishes its measured sizes against those budgets in the workflow run summary.
+
 ## 0.1.0 - 2026-07-14
 
 This release updates the Ignite UI for Blazor to the latest [igniteui-webcomponents@7.2.4 release](https://github.com/IgniteUI/igniteui-webcomponents/releases/tag/7.2.4) and matching related changes from `IgniteUI.Blazor` [25.2.77 (March 2026)](https://www.infragistics.com/products/ignite-ui-blazor/blazor/components/general-changelog-dv-blazor#25277-march-2026), [25.2.102 (May 2026)](https://www.infragistics.com/products/ignite-ui-blazor/blazor/components/general-changelog-dv-blazor#252102-may-2026) and [26.1.51 (June 2026)](https://www.infragistics.com/products/ignite-ui-blazor/blazor/components/general-changelog-dv-blazor#26151-june-2026) with highlights noted below:

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ After the above steps, open the solution in Visual Studio or run the stories pro
 dotnet run --project stories/IgniteUI.Blazor.Stories.csproj
 ```
 
+## Performance
+
+- [Performance targets and measurements](docs/performance.md) — the enforced bundle size budgets and the runtime targets.
+
 [Dock Manager]: https://www.infragistics.com/products/ignite-ui-blazor/blazor/components/layouts/dock-manager
 [Commercial]: https://www.infragistics.com/legal/license
 [MIT]: https://github.com/IgniteUI/igniteui-blazor/blob/master/LICENSE

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,67 @@
+# Performance targets and measurements
+
+This document is the published performance budget for `IgniteUI.Blazor.Lite`. It exists so that a size or latency regression is a decision somebody makes on the record, rather than something a consumer discovers after upgrading.
+
+Budgets are enforced, not aspirational: [`eng/bundle-budgets.json`](../eng/bundle-budgets.json) holds the numbers and [`eng/Check-BundleBudget.ps1`](../eng/Check-BundleBudget.ps1) fails the release when an asset exceeds one. The `evidence` job of the release workflow runs that check against the assets that were actually built and attaches `performance-report.md` and `performance-report.json` to the GitHub release.
+
+Every release also publishes its budget in the workflow run summary: the same measured-versus-budget tables, plus any breaches, are written to the job summary of the run that produced the package. The numbers for a given release are therefore readable directly from its run, without downloading an artefact or trusting the table below to still be current.
+
+## Scope
+
+These budgets cover the static web assets the package ships under `_content/IgniteUI.Blazor`. They do not cover the consuming application's own bundle, the Blazor framework payload, or the .NET runtime download in a WebAssembly host — those are outside anything this package controls.
+
+## Asset size budgets
+
+Measured on 2026-08-27 from a production webpack build (`npm run build` followed by `npm run copythemes`) on Node 22, against `igniteui-webcomponents` 7.2.4.
+
+| Group | Measured raw KiB | Raw budget | Measured gzip KiB | Gzip budget |
+| --- | ---: | ---: | ---: | ---: |
+| `loader` | 2.5 | 8 | 1.0 | 4 |
+| `app` | 408.8 | 460 | 103.8 | 118 |
+| `web-components-core` | 272.2 | 310 | 34.5 | 40 |
+| `web-components` | 1912.4 | 2100 | 255.6 | 285 |
+| `lazy-chunks` | 88.2 | 120 | 27.8 | 40 |
+| `license-notices` | 0.7 | 8 | n/a | n/a |
+| `source-maps` | 6119.1 | 6900 | n/a | n/a |
+| `themes` | 312.8 | 345 | 30.9 | 36 |
+
+| Total | Measured raw KiB | Raw budget | Measured gzip KiB | Gzip budget |
+| --- | ---: | ---: | ---: | ---: |
+| `served-javascript` | 2684.2 | 2950 | 422.6 | 470 |
+| `served-assets` | 2997.0 | 3300 | 453.5 | 510 |
+| `package-static-web-assets` | 9116.8 | 10240 | n/a | n/a |
+
+Bundle filenames are content-hashed, so budgets are expressed as patterns rather than filenames, and a file's group is whichever pattern matches it first. `eng/bundle-budgets.json` lists specific patterns before catch-alls for exactly this reason — for example `app.*.bundle.js` is listed ahead of the generic `*.bundle.js`, so an app bundle is budgeted as `app`, not folded into `lazy-chunks`. An asset that matches no pattern at all fails the check, so a new bundle cannot enter the package without someone budgeting for it.
+
+Two things worth knowing about these numbers:
+
+- Source maps are two thirds of the package on disk but are never requested unless a developer opens devtools, so they carry a raw budget and no gzip budget. `served-assets` is the number that describes what a user actually downloads.
+- Themes ship as eight prebuilt stylesheets and a consumer references one of them, so the `themes` figure is the whole set, not the per-page cost.
+
+## Runtime targets
+
+The following targets apply to the reference scenario — the Interactive Server test bed in [`tests/IgniteUI.Blazor.Lite.TestBed`](../tests/IgniteUI.Blazor.Lite.TestBed) rendering a single component on a warm server over a local connection, measured on the CI runner class.
+
+| Metric | Target |
+| --- | --- |
+| Time from `blazor.web.js` start to the package's JS initializer resolving | < 250 ms |
+| First component upgrade (custom element defined and rendered) after initializer | < 150 ms |
+| Property write from .NET to reflected DOM state | < 50 ms |
+| User interaction to `EventCallback` invocation on the server | < 100 ms plus circuit round-trip |
+
+**These runtime targets are published but not yet measured per release.** The bundle-size half of this budget is enforced today; the timing harness that produces the runtime half is tracked separately and lands with the accessibility automation. Until it does, treat the table above as the committed target and the absence of a recorded measurement as a known gap rather than a passing result.
+
+## Changing a budget
+
+Raising a budget is allowed and sometimes correct — a new component or an upstream `igniteui-webcomponents` release legitimately adds bytes. What is not allowed is raising it silently. Update the number in `eng/bundle-budgets.json`, update the measured column in this table, and say why in the changelog entry for the release that carries the increase.
+
+## Reproducing locally
+
+```pwsh
+npm ci
+npm run build
+npm run copythemes
+./eng/Check-BundleBudget.ps1
+```
+
+The report is written to `artifacts/perf/`. Pass `-ReportOnly` to measure without failing, which is what you want when reseeding budgets after an intentional increase.


### PR DESCRIPTION
## Description

Publishes `docs/performance.md` — the performance budget for `IgniteUI.Blazor.Lite` — and links it from the README and the changelog.

The document exists so that a size or latency regression is a decision somebody makes on the record, rather than something a consumer discovers after upgrading. It covers:

- **Scope** — the static web assets shipped under `_content/IgniteUI.Blazor`. Explicitly *not* the consuming app's own bundle, the Blazor framework payload, or the WebAssembly runtime download, none of which this package controls.
- **Asset size budgets** — measured raw and gzip figures per group and per total, taken from a production webpack build on Node 22 against `igniteui-webcomponents` 7.2.4, each alongside the budget it is checked against.
- **Two things the numbers need context for** — source maps are two thirds of the package on disk but are never fetched unless devtools is open, so they carry a raw budget and no gzip budget; and the `themes` figure is all eight prebuilt stylesheets, not the per-page cost of the one a consumer references.
- **Runtime targets** — four latency targets against the Interactive Server test bed, published as a commitment and marked plainly as **not yet measured per release**, since the timing harness lands with the accessibility automation.
- **Changing a budget** — raising one is allowed and sometimes correct; raising it silently is not. The rule is: update `eng/bundle-budgets.json`, update the measured column, and say why in the changelog.

### The one substantive change from the version in #371

The document now records that **every release publishes its budget in the workflow run summary**, not only as an attached artefact. `eng/Check-BundleBudget.ps1` already appends the measured-versus-budget tables and any breaches to `$GITHUB_STEP_SUMMARY`; the doc previously mentioned only `performance-report.md`/`.json` on the release. The practical difference for a reviewer is that the numbers for a given release are readable straight from its run — no artefact download, and no need to trust that the table in this document is still current.

## Motivation / Context

This is the PERF-09/10 gap from the package readiness assessment: the package had no published size or latency budget, so there was no threshold a regression could be measured against and no record of what "acceptable" meant.

Split out of #371 so the budget can be reviewed on its own terms rather than as a footnote to a release-workflow refactor.

> [!IMPORTANT]
> **This document describes enforcement that lives in #371.** `eng/bundle-budgets.json`, `eng/Check-BundleBudget.ps1` and the `evidence` job are not on `master` yet, so until #371 merges the two relative links in the opening paragraph will 404 and the "enforced, not aspirational" claim describes machinery that is one PR away. If that is not acceptable, this PR should merge after #371 rather than before it — or the enforcement files should be pulled in here. Flagging rather than deciding.

### Type of Change (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [x] Changelog

### Component(s) / Area(s) Affected:

Documentation only. No product code, build, or workflow changes.

## How Has This Been Tested?

 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

The run-summary claim was verified against the script rather than assumed: `eng/Check-BundleBudget.ps1` builds the totals and groups tables plus a "Budget breaches" section, writes them to `performance-report.md`, and appends the same lines to `$GITHUB_STEP_SUMMARY` when it is set. Relative link targets were checked against `master` — see the note above for the two that do not resolve yet.

### Test Configuration:
 - **.NET version**: n/a
 - **Hosting model**: n/a
 - **Browser(s)**: n/a
 - **OS**: n/a

## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [x] This PR includes general feature table updates in the root `README.MD`
 - [x] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
