### PR TITLE
chore: Bypass cleanup send guard in BaseRendererControl

### DIFF
--- a/src/componentsBase/BaseRendererControl.cs
+++ b/src/componentsBase/BaseRendererControl.cs
@@ -3142,8 +3142,8 @@ namespace IgniteUI.Blazor.Controls
                 return;
             }
 
-            disposedValue = true;
             _shouldReevaluateRuntime = true;
+
             try
             {
                 await TrySendCleanupAsync().ConfigureAwait(false);
@@ -3151,6 +3151,7 @@ namespace IgniteUI.Blazor.Controls
             finally
             {
                 _shouldReevaluateRuntime = false;
+                disposedValue = true;
                 _objRef?.Dispose();
             }
 

--- a/src/componentsBase/BaseRendererControl.cs
+++ b/src/componentsBase/BaseRendererControl.cs
@@ -3142,6 +3142,7 @@ namespace IgniteUI.Blazor.Controls
                 return;
             }
 
+            disposedValue = true;
             _shouldReevaluateRuntime = true;
 
             try
@@ -3151,7 +3152,6 @@ namespace IgniteUI.Blazor.Controls
             finally
             {
                 _shouldReevaluateRuntime = false;
-                disposedValue = true;
                 _objRef?.Dispose();
             }
 
@@ -3179,7 +3179,8 @@ namespace IgniteUI.Blazor.Controls
                 m.Type = ("cleanup");
 
                 _messageQueue.Clear();
-                await SendMessageImmediate(m).ConfigureAwait(false);
+                // Normal sends are already closed by disposal; cleanup intentionally bypasses the disposed guard.
+                await SendJsonImmediate(m).ConfigureAwait(false);
             }
             catch (JSDisconnectedException ex)
             {

--- a/tests/IgniteUI.Blazor.Tests/BaseRendererControlDisposalTests.cs
+++ b/tests/IgniteUI.Blazor.Tests/BaseRendererControlDisposalTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using IgniteUI.Blazor.Controls;
 using Microsoft.JSInterop;
+using System.Text.Json;
 
 namespace IgniteUI.Blazor.Tests;
 
@@ -96,14 +97,38 @@ public class BaseRendererControlDisposalTests : BlazorComponentTestBase
     }
 
     [Fact]
+    public async Task DisposeAsync_SendsCleanupMessage()
+    {
+        Interop.PrimeReady();
+        var cut = Render<IgbButton>();
+        var invocationCount = JSInterop.Invocations.Count;
+
+        await cut.Instance.DisposeAsync();
+
+        AssertCleanupSentOnce(invocationCount);
+    }
+
+    [Fact]
     public async Task DisposeAsync_CalledTwice_IsIdempotent()
     {
+        Interop.PrimeReady();
         var cut = Render<IgbButton>();
         var instance = (IAsyncDisposable)cut.Instance;
+        var invocationCount = JSInterop.Invocations.Count;
 
         await instance.DisposeAsync();
 
         var ex = await Record.ExceptionAsync(async () => await instance.DisposeAsync());
         Assert.Null(ex);
+        AssertCleanupSentOnce(invocationCount);
+    }
+
+    private void AssertCleanupSentOnce(int invocationCount)
+    {
+        var cleanup = Assert.Single(JSInterop.Invocations
+            .Skip(invocationCount)
+            .Where(invocation => invocation.Identifier == "igSendMessage"));
+        using var message = JsonDocument.Parse((string)cleanup.Arguments[1]!);
+        Assert.Equal("cleanup", message.RootElement.GetProperty("type").GetString());
     }
 }


### PR DESCRIPTION
## Description
Fix regression where the tag was set before the last cleanup message was sent.
~There are tests for the disposal here: https://github.com/IgniteUI/igniteui-blazor/pull/394~


## Motivation / Context
<!-- Why is this change needed? Link to the related issue(s) or discussion. -->


### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog

### Component(s) / Area(s) Affected:
<!-- List the component(s) or area(s) this PR touches, e.g. Grid, Combo, Theming -->


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **.NET version**:
 - **Hosting model**: <!-- Blazor Server / WebAssembly / Hybrid / United -->
 - **Browser(s)**:
 - **OS**:

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified

Closes #
